### PR TITLE
fix: improve error message when invalid function name is used

### DIFF
--- a/utils/names.go
+++ b/utils/names.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -23,11 +24,11 @@ func ValidateFunctionName(name string) error {
 
 	if errs := validation.IsDNS1123Label(name); len(errs) > 0 {
 		// In case of invalid name the error is this:
-		//	"a DNS-1123 label must consist of lower case alphanumeric characters or '-',
+		//	"a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',
 		//   and must start and end with an alphanumeric character (e.g. 'my-name',
 		//   or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')"
-		// Let's reuse it for our purposes, ie. replace "DNS-1123 label" substring with "function name"
-		return ErrInvalidFunctionName(errors.New(strings.Replace(strings.Join(errs, ""), "a DNS-1123 label", "Function name", 1)))
+		// Let's reuse it for our purposes, ie. replace "a lowercase RFC 1123 label" substring with "Function name" and the actual function name
+		return ErrInvalidFunctionName(errors.New(strings.Replace(strings.Join(errs, ""), "a lowercase RFC 1123 label", fmt.Sprintf("Function name '%v'", name), 1)))
 	}
 
 	return nil

--- a/utils/names_test.go
+++ b/utils/names_test.go
@@ -1,8 +1,11 @@
+//go:build !integration
 // +build !integration
 
 package utils
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -32,6 +35,20 @@ func TestValidateFunctionName(t *testing.T) {
 		if err == nil && !c.Valid {
 			t.Fatalf("Expected error for invalid entry: %v", c.In)
 		}
+	}
+}
+
+func TestValidateFunctionNameErrMsg(t *testing.T) {
+	invalidFnName := "EXAMPLE"
+	errMsgPrefix := fmt.Sprintf("Function name '%v'", invalidFnName)
+
+	err := ValidateFunctionName(invalidFnName)
+	if err != nil {
+		if !strings.HasPrefix(err.Error(), errMsgPrefix) {
+			t.Fatalf("Unexpected error message: %v, the message should start with '%v' string", err.Error(), errMsgPrefix)
+		}
+	} else {
+		t.Fatalf("Expected error for invalid entry: %v", invalidFnName)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

We are using validation function from `k8s.io/apimachinery` and the error message has been changed upstream. Fixing this and improving the message with the acutal fn name.

Test has been added so we can capture any change in the future.

Fixes: #565 