### PR TITLE
fix: correct error in OpenShift registry credential provider

### DIFF
--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -135,7 +135,7 @@ func GetDockerCredentialLoaders() []creds.CredentialsCallback {
 			if registry == registryHostPort {
 				return credentials, nil
 			}
-			return docker.Credentials{}, nil
+			return docker.Credentials{}, creds.ErrCredentialsNotFound
 		},
 	}
 


### PR DESCRIPTION
# Changes

- :bug: Return correct error in OpenShift registry credential provider

/kind bug

```release-note
fix: empty credentials issue for docker.io
```
