### PR TITLE
Adds ability to pull from private repos for git builds

### DIFF
--- a/function_git.go
+++ b/function_git.go
@@ -8,9 +8,11 @@ import (
 )
 
 type Git struct {
-	URL        *string `yaml:"url,omitempty"`
-	Revision   *string `yaml:"revision,omitempty"`
-	ContextDir *string `yaml:"contextDir,omitempty"`
+	URL             *string `yaml:"url,omitempty"`
+	Revision        *string `yaml:"revision,omitempty"`
+	ContextDir      *string `yaml:"contextDir,omitempty"`
+	SSHSecret       *string `yaml:"sshSecret,omitempty"`
+	BasicAuthSecret *string `yaml:"basicAuthSecret,omitempty"`
 }
 
 // validateGit validates input Git option from function config

--- a/pipelines/tekton/tasks.go
+++ b/pipelines/tekton/tasks.go
@@ -18,10 +18,20 @@ func taskFetchSources() pplnv1beta1.PipelineTask {
 		TaskRef: &pplnv1beta1.TaskRef{
 			Name: "git-clone",
 		},
-		Workspaces: []pplnv1beta1.WorkspacePipelineTaskBinding{{
-			Name:      "output",
-			Workspace: "source-workspace",
-		}},
+		Workspaces: []pplnv1beta1.WorkspacePipelineTaskBinding{
+			{
+				Name:      "output",
+				Workspace: "source-workspace",
+			},
+			{
+				Name:      "ssh-directory",
+				Workspace: "ssh-workspace",
+			},
+			{
+				Name:      "basic-auth",
+				Workspace: "basic-auth-workspace",
+			},
+		},
 		Params: []pplnv1beta1.Param{
 			{Name: "url", Value: *pplnv1beta1.NewArrayOrString("$(params.gitRepository)")},
 			{Name: "revision", Value: *pplnv1beta1.NewArrayOrString("$(params.gitRevision)")},

--- a/schema/func_yaml-schema.json
+++ b/schema/func_yaml-schema.json
@@ -160,6 +160,12 @@
 				},
 				"contextDir": {
 					"type": "string"
+				},
+				"sshSecret": {
+					"type": "string"
+				},
+				"basicAuthSecret": {
+					"type": "string"
 				}
 			},
 			"additionalProperties": false,


### PR DESCRIPTION
# Changes

- 🎁 Wires auth workspaces in plugins in order to pull from private repos

/kind enhancement

Fixes #849 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

```release-note
Private repositories can be used with git based on-cluster builds
```

/hold for UX and doc changes

The current UX:
- User creates an appropriate secret with either ssh  or basic-auth credentials as outlined [here](https://hub.tekton.dev/tekton/task/git-clone). Secret must be in the same namespace as the function.
- User adds the secret name under `sshSecret` or `basicAuthSecret` in `func.yaml`
- `func deploy`

There's likely a better UX that doesn't require the user to create the Secrets manually but I'd like more guidance on that. Maybe something under `func config` 
