### PR TITLE
test: adding oncluster builds e2e tests for s2i supported runtimes

### DIFF
--- a/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+++ b/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
@@ -63,7 +63,9 @@ spec:
         echo "" > /env-vars/env-file
         for var in "$@"
         do
-            echo "$var" >> /env-vars/env-file
+            if [[ "$var" != "=" ]]; then
+                echo "$var" >> /env-vars/env-file
+            fi
         done
 
         echo "Generated Build Env Var file"


### PR DESCRIPTION
# Changes

- :gift: Oncluster builds tests for s2i supported runtimes
- :bug: Fix s2i task when build env array is empty for node functions (#1363)

/kind cleanup
