### PR TITLE
chore: add coverage for integration tests

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   test:
-    name: Integration Test 
+    name: Integration Test
     strategy:
       matrix:
         go: [1.18.x]
@@ -23,3 +23,7 @@ jobs:
         run: ./hack/registry.sh
       - name: Integration Test
         run: make test-integration
+      - uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.txt
+          flags: integration-tests

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   test:
-    name: Unit Test 
+    name: Unit Test
     strategy:
       matrix:
         go: [1.18.x]
@@ -35,3 +35,7 @@ jobs:
         run: make test
       - name: Template Unit Tests
         run: make test-templates
+      - uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.txt
+          flags: unit-tests-${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /templates/typescript/cloudevents/build
 /templates/typescript/http/build
 /coverage.out
+/coverage.txt
 /bin
 /target
 

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ $(BIN): $(CODE)
 	env CGO_ENABLED=0 go build -ldflags $(LDFLAGS) ./cmd/$(BIN)
 
 test: $(CODE) ## Run core unit tests
-	go test -race -cover -coverprofile=coverage.out ./...
+	go test -race -cover -coverprofile=coverage.txt ./...
 
 check: bin/golangci-lint ## Check code quality (lint)
 	./bin/golangci-lint run --timeout 300s
@@ -94,7 +94,7 @@ zz_filesystem_generated.go: clean_templates
 clean: clean_templates ## Remove generated artifacts such as binaries and schemas
 	rm -f $(BIN) $(BIN_WINDOWS) $(BIN_LINUX) $(BIN_DARWIN_AMD64) $(BIN_DARWIN_ARM64)
 	rm -f schema/func_yaml-schema.json
-	rm -f coverage.out
+	rm -f coverage.txt
 
 docs:
 	# Generating command reference doc
@@ -140,7 +140,7 @@ test-typescript: ## Test Typescript templates
 ###################
 
 test-integration: ## Run integration tests using an available cluster.
-	go test -tags integration ./... -v
+	go test -tags integration --coverprofile=coverage.txt ./... -v
 
 test-e2e: ## Run end-to-end tests using an available cluster.
 	./test/e2e_lifecycle_tests.sh node


### PR DESCRIPTION
Added coverage output for integration test, and added codecov uploads for both integration and unit tests.

This commit changes the output file to coverage.txt as well, in order to be consistent with knative test infrastructure.

/kind chore

Signed-off-by: Lance Ball <lball@redhat.com>

