### PR TITLE
chore: add unit test cases for instances

### DIFF
--- a/instances.go
+++ b/instances.go
@@ -16,6 +16,7 @@ var (
 	ErrNotRunning          = errors.New("function not running")
 	ErrRootRequired        = errors.New("function root path is required")
 	ErrEnvironmentNotFound = errors.New("environment not found")
+	ErrMismatchedName      = errors.New("name passed does not match name of the function at root")
 )
 
 // Instances manager
@@ -100,9 +101,7 @@ func (s *Instances) Remote(ctx context.Context, name, root string) (Instance, er
 			return Instance{}, err
 		}
 		if name != f.Name {
-			return Instance{}, errors.New(
-				"name passed does not match name of the function at root. " +
-					"Try passing either name or root rather than both.")
+			return Instance{}, errors.New("name passed does not match name of the function at root")
 		}
 	}
 

--- a/instances_test.go
+++ b/instances_test.go
@@ -5,6 +5,7 @@ package function
 
 import (
 	"context"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -74,6 +75,11 @@ func TestInstance_RemoteErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var badRoot = "func.yaml: no such file or directory"
+	if runtime.GOOS == "windows" {
+		badRoot = "The system cannot find the path specified"
+	}
+
 	tests := []struct {
 		name string
 		root string
@@ -82,7 +88,7 @@ func TestInstance_RemoteErrors(t *testing.T) {
 		{
 			name: "foo",
 			root: "foo", // bad root
-			want: "func.yaml: no such file or directory",
+			want: badRoot,
 		},
 		{
 			name: "foo", // name and root are mismatched

--- a/instances_test.go
+++ b/instances_test.go
@@ -1,0 +1,99 @@
+//go:build !integration
+// +build !integration
+
+package function
+
+import (
+	"context"
+	"testing"
+
+	. "knative.dev/kn-plugin-func/testing"
+)
+
+// TestInstances_LocalErrors tests the three possible error states for a function
+// when attempting to access a local instance.
+func TestInstances_LocalErrors(t *testing.T) {
+	root, rm := Mktemp(t)
+	defer rm()
+
+	// Create a function that will not be running
+	if err := New().Create(Function{Runtime: "go", Root: root}); err != nil {
+		t.Fatal(err)
+	}
+	// Load the function
+	f, err := NewFunction(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		f    Function
+		want error
+	}{
+		{
+			name: "Not running", // Function exists but is not running
+			f:    f,
+			want: ErrNotRunning,
+		},
+		{
+			name: "Not initialized", // A function directory is provided, but no function exists
+			f:    Function{Root: "testdata/not-initialized"},
+			want: ErrNotInitialized,
+		},
+		{
+			name: "Root required", // No root directory is provided
+			f:    Function{},
+			want: ErrRootRequired,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := Instances{}
+			if _, err := i.Local(context.TODO(), tt.f); err != tt.want {
+				t.Errorf("Local() error = %v, wantErr %v", err, tt.want)
+			}
+		})
+	}
+}
+
+// TestInstance_RemoteErrors tests the possible error states for a function when
+// attempting to access a remote instance.
+func TestInstance_RemoteErrors(t *testing.T) {
+	root, rm := Mktemp(t)
+	defer rm()
+
+	// Create a function that will not be running
+	if err := New().Create(Function{Runtime: "go", Root: root}); err != nil {
+		t.Fatal(err)
+	}
+	// Load the function
+	_, err := NewFunction(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		root string
+		want string
+	}{
+		{
+			name: "foo",
+			root: "foo", // bad root
+			want: "stat foo/func.yaml: no such file or directory",
+		},
+		{
+			name: "foo", // name and root are mismatched
+			root: root,
+			want: "name passed does not match name of the function at root",
+		},
+	}
+	for _, tt := range tests {
+		i := Instances{}
+		if _, err := i.Remote(context.TODO(), tt.name, tt.root); err.Error() != tt.want {
+			t.Errorf("Remote() %v error = %v, wantErr %v", "Mismatched name and root", err.Error(), tt.want)
+		}
+	}
+
+}

--- a/instances_test.go
+++ b/instances_test.go
@@ -5,6 +5,7 @@ package function
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	. "knative.dev/kn-plugin-func/testing"
@@ -81,7 +82,7 @@ func TestInstance_RemoteErrors(t *testing.T) {
 		{
 			name: "foo",
 			root: "foo", // bad root
-			want: "stat foo/func.yaml: no such file or directory",
+			want: "func.yaml: no such file or directory",
 		},
 		{
 			name: "foo", // name and root are mismatched
@@ -91,7 +92,7 @@ func TestInstance_RemoteErrors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		i := Instances{}
-		if _, err := i.Remote(context.TODO(), tt.name, tt.root); err.Error() != tt.want {
+		if _, err := i.Remote(context.TODO(), tt.name, tt.root); !strings.Contains(err.Error(), tt.want) {
 			t.Errorf("Remote() %v error = %v, wantErr %v", "Mismatched name and root", err.Error(), tt.want)
 		}
 	}


### PR DESCRIPTION
# Changes

- 🧹 adds some tests checking expected error states for function instances, local and remote

/kind chore

Related: https://github.com/knative/func/issues/1275