### PR TITLE
chore: use t.Cleanup() more

### DIFF
--- a/docker/docker_client_pm_test.go
+++ b/docker/docker_client_pm_test.go
@@ -23,15 +23,14 @@ import (
 )
 
 func TestNewDockerClientWithPodmanMachine(t *testing.T) {
-	defer withCleanHome(t)()
+	withCleanHome(t)
 
 	publicKey, privateKeyPath := prepareKeys(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*1)
 	defer cancel()
 
-	sshConf, stopSSH := startSSH(t, publicKey)
-	defer stopSSH()
+	sshConf := startSSH(t, publicKey)
 	_ = sshConf
 
 	uri := fmt.Sprintf("ssh://user@%s%s", sshConf.address, sshDockerSocket)

--- a/docker/docker_client_windows_test.go
+++ b/docker/docker_client_windows_test.go
@@ -15,7 +15,7 @@ func TestNewClientWinPipe(t *testing.T) {
 
 	const testNPipe = "test-npipe"
 
-	defer startMockDaemonWinPipe(t, testNPipe)()
+	startMockDaemonWinPipe(t, testNPipe)
 	t.Setenv("DOCKER_HOST", fmt.Sprintf("npipe:////./pipe/%s", testNPipe))
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*1)
@@ -37,10 +37,10 @@ func TestNewClientWinPipe(t *testing.T) {
 	}
 }
 
-func startMockDaemonWinPipe(t *testing.T, pipeName string) func() {
+func startMockDaemonWinPipe(t *testing.T, pipeName string) {
 	p, err := winio.ListenPipe(`\\.\pipe\`+pipeName, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return startMockDaemon(t, p)
+	startMockDaemon(t, p)
 }


### PR DESCRIPTION
# Changes

- :broom: Use `t.Cleanup()` more.

/kind cleanup
