### PR TITLE
chore: update CI to run unit+integration on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,21 @@ on:
     branches:
       - "main"
 jobs:
-  test:
+  check:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.18"
+      - name: Lint
+        run: make check
+      - name: Check that 'func.yaml schema' is up-to-date
+        run: make schema-check
+      - name: Check embedded templates content
+        run: go test -run "^\QTestFileSystems\E$/^\Qembedded\E$"
+
+  test-unit:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
@@ -15,16 +29,33 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '11'
-      - name: Check embedded templates content
-        run: go test -run "^\QTestFileSystems\E$/^\Qembedded\E$"
+      - name: Unit Test
+        run:  make test
+      - uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.txt
+          flags: unit-tests
+
+  test-integration:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.18"
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11'
       - name: Unit Test
         run:  make test
       - name: Template Unit Tests
         run:  make test-templates
-      - name: Lint
-        run: make check
-      - name: Check that 'func.yaml schema' is up-to-date
-        run: make schema-check
+      - name: Integration Tests
+        run: make test-integration
+      - uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.txt
+          flags: integration-tests
 
   build-and-publish:
     needs: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,6 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.18"
-      - uses: actions/setup-java@v1
-        with:
-          java-version: '11'
       - name: Unit Test
         run:  make test
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
# Changes

This commit modifies the Ci jobs that run when commits land on `main`, splitting the one job into three: check, test-unit and test-integration. Code coverage stats are included for both test runs.

- 🧹 ensure integration tests run in CI on the `main` branch
- 🧹 add code coverage steps to both unit and integration test runs on `main`

/kind chore

Signed-off-by: Lance Ball <lball@redhat.com>
