### PR TITLE
chore: fix ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,8 +54,8 @@ jobs:
           files: ./coverage.txt
           flags: integration-tests
 
-  build-and-publish:
-    needs: test
+  build:
+    needs: [check, test-unit, test-integration]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -94,8 +94,9 @@ jobs:
         with:
           name: Windows Binary
           path: func_windows_amd64.exe
+
   publish-image:
-    needs: test
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The `needs` contexts were pointing to old job steps.

```
Invalid workflow file: .github/workflows/ci.yaml#L58](https://github.com/knative/func/actions/runs/3237468662/workflow)
The workflow is not valid. .github/workflows/ci.yaml (Line: 58, Col: 12): Job 'build-and-publish' depends on unknown job 'test'. .github/workflows/ci.yaml (Line: 98, Col: 12): Job 'publish-image' depends on unknown job 'test'.
```

/kind bug