### PR TITLE
chore: add link to the roadmap in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 [Read the Documentation](docs/README.md)
 
+## Roadmap
+
+We use GitHub issues and project to track our roadmap. Please see our roadmap [here](https://github.com/orgs/knative/projects/49).
+
 ## Contributing
 
 We are always looking for contributions from the Function Developer community.  For more information on how to participate, see the [Contribuiting Guide](docs/CONTRIBUTING.md)


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thanks for sending a pull request! -->

Based on our discussion on TOC adding link to the Roadmap to project's Readme for better visibility.


- :broom: add link to the roadmap in the Readme

