### PR TITLE
chore: update image tag in tekton pipeline

### DIFF
--- a/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+++ b/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
@@ -24,7 +24,7 @@ spec:
       description: The workspace containing the function project
   steps:
   - name: func-deploy
-    image: "ghcr.io/knative-sandbox/kn-plugin-func/func:latest"
+    image: "ghcr.io/knative/func/func:latest"
     script: |
       export FUNC_IMAGE="$(params.image)"
       func deploy --verbose --build=false --push=false --path=$(params.path)


### PR DESCRIPTION
# Changes

- 🧹 reference the `func` image at `ghcr.io/knative/func:latest` in tekton pipelines

We are now producing `func` images in the knative org.

Signed-off-by: Lance Ball <lball@redhat.com>

/kind chore

**Release Note**
```release-note
Uses `func` image from `ghcr.io/knative/func:latest` in tekton on-cluster build pipeline
```
