### PR TITLE
fix: use proper temp dir for funs in e2e tests

### DIFF
--- a/test/_e2e/e2e_functions_test.go
+++ b/test/_e2e/e2e_functions_test.go
@@ -14,7 +14,7 @@ import (
 // for a function that responds to HTTP
 func TestHttpFunction(t *testing.T) {
 
-	project := NewFunctionTestProject(GetRuntime(), "http")
+	project := NewFunctionTestProject(t, GetRuntime(), "http")
 	knFunc := NewKnFuncShellCli(t)
 
 	Create(t, knFunc, project)
@@ -33,7 +33,7 @@ func TestHttpFunction(t *testing.T) {
 // for a function that responds to CloudEvents
 func TestCloudEventsFunction(t *testing.T) {
 
-	project := NewFunctionTestProject(GetRuntime(), "cloudevents")
+	project := NewFunctionTestProject(t, GetRuntime(), "cloudevents")
 	knFunc := NewKnFuncShellCli(t)
 
 	Create(t, knFunc, project)

--- a/test/_e2e/func_test_proj.go
+++ b/test/_e2e/func_test_proj.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"testing"
 )
 
 // FunctionTestProject
@@ -35,13 +36,13 @@ type FunctionTestProject struct {
 }
 
 // NewFunctionTestProject initiates a project with derived function name an project path
-func NewFunctionTestProject(runtime string, template string) FunctionTestProject {
+func NewFunctionTestProject(t *testing.T, runtime string, template string) FunctionTestProject {
 	project := FunctionTestProject{
 		Runtime:  runtime,
 		Template: template,
 	}
 	project.FunctionName = "func-" + runtime + "-" + template
-	project.ProjectPath = filepath.Join(os.TempDir(), project.FunctionName)
+	project.ProjectPath = filepath.Join(t.TempDir(), project.FunctionName)
 	return project
 }
 

--- a/test/_e2e/update_test.go
+++ b/test/_e2e/update_test.go
@@ -26,7 +26,7 @@ func Update(t *testing.T, knFunc *TestShellCmdRunner, project *FunctionTestProje
 
 	// Template folder exists for given runtime / template.
 	// Let's update the project and redeploy
-	err := projectUpdaterFor(project).UpdateFolderContent(templatePath, project)
+	err := projectUpdaterFor(project).UpdateFolderContent(t, templatePath, project)
 	if err != nil {
 		t.Fatal("an error has occurred while updating project folder with new sources.", err.Error())
 	}
@@ -64,9 +64,9 @@ func projectUpdaterFor(project *FunctionTestProject) projectUpdater {
 	return updater
 }
 
-func (p projectUpdater) UpdateFolderContent(templatePath string, project *FunctionTestProject) error {
+func (p projectUpdater) UpdateFolderContent(t *testing.T, templatePath string, project *FunctionTestProject) error {
 	// Create temp project folder (reuse func.yaml)
-	projectTmp := NewFunctionTestProject(project.Runtime, project.Template)
+	projectTmp := NewFunctionTestProject(t, project.Runtime, project.Template)
 	projectTmp.ProjectPath = projectTmp.ProjectPath + "-tmp"
 	err := projectTmp.CreateProjectFolder()
 	if err != nil {


### PR DESCRIPTION
# Changes

- :broom: Use proper temporary directory for function instances in end to end testing.

/kind cleanup
