### PR TITLE
Set seccomp of auxiliary pods on k8s 1.24+

### DIFF
--- a/k8s/dialer.go
+++ b/k8s/dialer.go
@@ -148,7 +148,7 @@ func (c *contextDialer) startDialerPod(ctx context.Context) (err error) {
 					Stdin:           true,
 					StdinOnce:       true,
 					Command:         []string{"socat", "-u", "-", "OPEN:/dev/null"},
-					SecurityContext: defaultSecurityContext(),
+					SecurityContext: defaultSecurityContext(client),
 				},
 			},
 			DNSPolicy:     coreV1.DNSClusterFirst,

--- a/k8s/persistent_volumes.go
+++ b/k8s/persistent_volumes.go
@@ -128,7 +128,7 @@ func runWithVolumeMounted(ctx context.Context, podImage string, podCommand []str
 							MountPath: volumeMntPoint,
 						},
 					},
-					SecurityContext: defaultSecurityContext(),
+					SecurityContext: defaultSecurityContext(client),
 				},
 			},
 			Volumes: []corev1.Volume{{

--- a/k8s/security_context.go
+++ b/k8s/security_context.go
@@ -1,16 +1,28 @@
 package k8s
 
 import (
+	"github.com/Masterminds/semver"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
-func defaultSecurityContext() *corev1.SecurityContext {
+var oneTwentyFour = semver.MustParse("1.24")
+
+func defaultSecurityContext(client *kubernetes.Clientset) *corev1.SecurityContext {
 	runAsNonRoot := true
-	return &corev1.SecurityContext{
+	sc := &corev1.SecurityContext{
 		Privileged:               new(bool),
 		AllowPrivilegeEscalation: new(bool),
 		RunAsNonRoot:             &runAsNonRoot,
 		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 		SeccompProfile:           nil,
 	}
+	if info, err := client.ServerVersion(); err == nil {
+		var v *semver.Version
+		v, err = semver.NewVersion(info.String())
+		if err == nil && v.Compare(oneTwentyFour) >= 0 {
+			sc.SeccompProfile = &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}
+		}
+	}
+	return sc
 }


### PR DESCRIPTION
# Changes

- :bug:  Set `seccomp` of auxiliary pods on k8s 1.24+
  This is for OpenShift 4.11+

/kind bug
