### PR TITLE
feat: namespace globally configurable

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -43,8 +43,9 @@ No local files are deleted.
 		fmt.Fprintf(cmd.OutOrStdout(), "error loading config at '%v'. %v\n", config.File(), err)
 	}
 
-	// Flag
+	// Flags
 	cmd.Flags().BoolP("confirm", "c", cfg.Confirm, "Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)")
+	cmd.Flags().StringP("namespace", "n", cfg.Namespace, "The namespace in which to delete. (Env: $FUNC_NAMESPACE)")
 	cmd.Flags().StringP("all", "a", "true", "Delete all resources created for a function, eg. Pipelines, Secrets, etc. (Env: $FUNC_ALL) (allowed values: \"true\", \"false\")")
 	setPathFlag(cmd)
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -45,7 +45,7 @@ No local files are deleted.
 
 	// Flags
 	cmd.Flags().BoolP("confirm", "c", cfg.Confirm, "Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)")
-	cmd.Flags().StringP("namespace", "n", cfg.Namespace, "The namespace in which to delete. (Env: $FUNC_NAMESPACE)")
+	cmd.Flags().StringP("namespace", "n", "", "The namespace in which to delete. (Env: $FUNC_NAMESPACE)")
 	cmd.Flags().StringP("all", "a", "true", "Delete all resources created for a function, eg. Pipelines, Secrets, etc. (Env: $FUNC_ALL) (allowed values: \"true\", \"false\")")
 	setPathFlag(cmd)
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -729,9 +729,13 @@ func namespace(cfg deployConfig, f fn.Function, stderr io.Writer) (namespace str
 	} else if f.Deploy.Namespace != "" {
 		namespace = f.Deploy.Namespace // value from previous deployment (func.yaml) 2nd priority
 	} else {
-		// Try to derive a default from the current k8s context, if any.
-		if namespace, err = k8s.GetNamespace(""); err != nil {
-			fmt.Fprintln(stderr, "Warning: no namespace provided, and none currently active. Continuing to attempt deployment")
+		// If global config setting exists, use that, followed by the active
+		// k8s namesapce if not set.
+		gc, err := config.NewDefault()
+		if err != nil {
+			fmt.Fprintf(stderr, "Warning: error reading global config.%v", err)
+		} else {
+			namespace = gc.Namespace
 		}
 	}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -733,7 +733,7 @@ func namespace(cfg deployConfig, f fn.Function, stderr io.Writer) (namespace str
 		// k8s namesapce if not set.
 		gc, err := config.NewDefault()
 		if err != nil {
-			fmt.Fprintf(stderr, "Warning: error reading global config.%v", err)
+			fmt.Fprintf(stderr, "warning: error reading global config.%v", err)
 		} else {
 			namespace = gc.Namespace
 		}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	fn "knative.dev/func"
+	"knative.dev/func/config"
 )
 
 func NewInfoCmd(newClient ClientFactory) *cobra.Command {
@@ -35,7 +36,15 @@ the current directory or from the directory specified with --path.
 		PreRunE:           bindEnv("output", "path"),
 	}
 
+	// Config
+	cfg, err := config.NewDefault()
+	if err != nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "error loading config at '%v'. %v\n", config.File(), err)
+	}
+
+	// Flags
 	cmd.Flags().StringP("output", "o", "human", "Output format (human|plain|json|xml|yaml|url) (Env: $FUNC_OUTPUT)")
+	cmd.Flags().StringP("namespace", "n", cfg.Namespace, "The namespace in which to look for the named function. (Env: $FUNC_NAMESPACE)")
 	setPathFlag(cmd)
 
 	if err := cmd.RegisterFlagCompletionFunc("output", CompleteOutputFormatList); err != nil {

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -12,7 +12,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	fn "knative.dev/func"
-	"knative.dev/func/config"
 )
 
 func NewInfoCmd(newClient ClientFactory) *cobra.Command {
@@ -36,15 +35,9 @@ the current directory or from the directory specified with --path.
 		PreRunE:           bindEnv("output", "path"),
 	}
 
-	// Config
-	cfg, err := config.NewDefault()
-	if err != nil {
-		fmt.Fprintf(cmd.OutOrStdout(), "error loading config at '%v'. %v\n", config.File(), err)
-	}
-
 	// Flags
 	cmd.Flags().StringP("output", "o", "human", "Output format (human|plain|json|xml|yaml|url) (Env: $FUNC_OUTPUT)")
-	cmd.Flags().StringP("namespace", "n", cfg.Namespace, "The namespace in which to look for the named function. (Env: $FUNC_NAMESPACE)")
+	cmd.Flags().StringP("namespace", "n", "", "The namespace in which to look for the named function. (Env: $FUNC_NAMESPACE)")
 	setPathFlag(cmd)
 
 	if err := cmd.RegisterFlagCompletionFunc("output", CompleteOutputFormatList); err != nil {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	fn "knative.dev/func"
+	"knative.dev/func/config"
 )
 
 func NewListCmd(newClient ClientFactory) *cobra.Command {
@@ -38,7 +39,15 @@ Lists all deployed functions in a given namespace.
 		PreRunE:    bindEnv("all-namespaces", "output"),
 	}
 
+	// Config
+	cfg, err := config.NewDefault()
+	if err != nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "error loading config at '%v'. %v\n", config.File(), err)
+	}
+
+	// Flags
 	cmd.Flags().BoolP("all-namespaces", "A", false, "List functions in all namespaces. If set, the --namespace flag is ignored.")
+	cmd.Flags().StringP("namespace", "n", cfg.Namespace, "The namespace for which to list functions. (Env: $FUNC_NAMESPACE)")
 	cmd.Flags().StringP("output", "o", "human", "Output format (human|plain|json|xml|yaml) (Env: $FUNC_OUTPUT)")
 
 	if err := cmd.RegisterFlagCompletionFunc("output", CompleteOutputFormatList); err != nil {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -14,7 +14,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	fn "knative.dev/func"
-	"knative.dev/func/config"
 )
 
 func NewListCmd(newClient ClientFactory) *cobra.Command {
@@ -39,15 +38,9 @@ Lists all deployed functions in a given namespace.
 		PreRunE:    bindEnv("all-namespaces", "output"),
 	}
 
-	// Config
-	cfg, err := config.NewDefault()
-	if err != nil {
-		fmt.Fprintf(cmd.OutOrStdout(), "error loading config at '%v'. %v\n", config.File(), err)
-	}
-
 	// Flags
 	cmd.Flags().BoolP("all-namespaces", "A", false, "List functions in all namespaces. If set, the --namespace flag is ignored.")
-	cmd.Flags().StringP("namespace", "n", cfg.Namespace, "The namespace for which to list functions. (Env: $FUNC_NAMESPACE)")
+	cmd.Flags().StringP("namespace", "n", "", "The namespace for which to list functions. (Env: $FUNC_NAMESPACE)")
 	cmd.Flags().StringP("output", "o", "human", "Output format (human|plain|json|xml|yaml) (Env: $FUNC_OUTPUT)")
 
 	if err := cmd.RegisterFlagCompletionFunc("output", CompleteOutputFormatList); err != nil {

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -339,7 +339,6 @@ func runRepositoryAdd(_ *cobra.Command, args []string, newClient ClientFactory) 
 	// be created in XDG_CONFIG_HOME/func even if the repo path environment
 	// was set to some other location on disk.
 	client, done := newClient(ClientConfig{Verbose: cfg.Verbose})
-
 	defer done()
 
 	// Preconditions

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,10 +74,6 @@ EXAMPLES
 	if err := viper.BindPFlag("verbose", cmd.PersistentFlags().Lookup("verbose")); err != nil {
 		fmt.Fprintf(os.Stderr, "error binding flag: %v\n", err)
 	}
-	cmd.PersistentFlags().StringP("namespace", "n", "", "The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)")
-	if err := viper.BindPFlag("namespace", cmd.PersistentFlags().Lookup("namespace")); err != nil {
-		fmt.Fprintf(os.Stderr, "error binding flag: %v\n", err)
-	}
 
 	// Version
 	cmd.Version = config.Version.String()

--- a/config/config.go
+++ b/config/config.go
@@ -118,7 +118,7 @@ func File() string {
 	return path
 }
 
-// RepositoriesPath returns the full at which to look for repositories.
+// RepositoriesPath returns the full path at which to look for repositories.
 // Use FUNC_REPOSITORIES_PATH to override default.
 func RepositoriesPath() string {
 	path := filepath.Join(Dir(), Repositories)

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 	"knative.dev/func/builders"
+	"knative.dev/func/k8s"
 )
 
 const (
@@ -23,19 +24,31 @@ const (
 	DefaultBuilder = builders.Default
 )
 
+// DefaultNamespace for remote operations is the currently active
+// context namespace (if available) or the fallback "default".
+func DefaultNamespace() (namespace string) {
+	var err error
+	if namespace, err = k8s.GetNamespace(""); err != nil {
+		return "default"
+	}
+	return
+}
+
 // Global configuration settings.
 type Config struct {
-	Builder  string `yaml:"builder,omitempty"`
-	Confirm  bool   `yaml:"confirm,omitempty"`
-	Language string `yaml:"language,omitempty"`
+	Builder   string `yaml:"builder,omitempty"`
+	Confirm   bool   `yaml:"confirm,omitempty"`
+	Language  string `yaml:"language,omitempty"`
+	Namespace string `yaml:"namespace,omitempty"`
 }
 
 // New Config struct with all members set to static defaults.  See NewDefaults
 // for one which further takes into account the optional config file.
 func New() Config {
 	return Config{
-		Language: DefaultLanguage,
-		Builder:  DefaultBuilder,
+		Builder:   DefaultBuilder,
+		Language:  DefaultLanguage,
+		Namespace: DefaultNamespace(),
 		// ...
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -39,8 +39,8 @@ func TestLoad(t *testing.T) {
 	}
 }
 
-// TestSave ensures that saving an update config persists.
-func TestSave(t *testing.T) {
+// TestWrite ensures that writing a config persists.
+func TestWrite(t *testing.T) {
 	// mktmp
 	root, rm := Mktemp(t)
 	defer rm()

--- a/config/testdata/TestDefaultNamespace/kubeconfig
+++ b/config/testdata/TestDefaultNamespace/kubeconfig
@@ -1,0 +1,25 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://cluster.example.com:6443
+  name: cluster.example.com:6443
+contexts:
+- context:
+    cluster: cluster.example.com:6443
+    namespace: default
+    user: kube:admin/cluster.example.com:6443
+  name: default/cluster.example.com:6443/kube:admin
+- context:
+    cluster: cluster.example.com:6443
+    namespace: func
+    user: kube:admin/cluster.example.com:6443
+  name: func/cluster.example.com:6443/kube:admin
+current-context: func/cluster.example.com:6443/kube:admin
+kind: Config
+preferences: {}
+users:
+- name: kubeadmin
+  user:
+    token: sha256~XXXXexample-test-hash
+

--- a/config/testdata/TestLoad/func/config.yaml
+++ b/config/testdata/TestLoad/func/config.yaml
@@ -1,0 +1,1 @@
+language: custom

--- a/docs/reference/func.md
+++ b/docs/reference/func.md
@@ -30,9 +30,8 @@ EXAMPLES
 ### Options
 
 ```
-  -h, --help               help for func
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -h, --help      help for func
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_build.md
+++ b/docs/reference/func_build.md
@@ -58,8 +58,7 @@ func build --builder=pack --builder-image cnbs/sample-builder:bionic
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_completion.md
+++ b/docs/reference/func_completion.md
@@ -31,8 +31,7 @@ func completion <bash|zsh|fish>
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_config.md
+++ b/docs/reference/func_config.md
@@ -25,8 +25,7 @@ func config
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_config_envs.md
+++ b/docs/reference/func_config_envs.md
@@ -25,8 +25,7 @@ func config envs
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_config_envs_add.md
+++ b/docs/reference/func_config_envs_add.md
@@ -50,8 +50,7 @@ func config envs add --value='{{ configMap:confMapName }}'
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_config_envs_remove.md
+++ b/docs/reference/func_config_envs_remove.md
@@ -24,8 +24,7 @@ func config envs remove
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_config_labels.md
+++ b/docs/reference/func_config_labels.md
@@ -24,8 +24,7 @@ func config labels
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_config_labels_add.md
+++ b/docs/reference/func_config_labels_add.md
@@ -27,8 +27,7 @@ func config labels add
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_config_labels_remove.md
+++ b/docs/reference/func_config_labels_remove.md
@@ -24,8 +24,7 @@ func config labels remove
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_config_volumes.md
+++ b/docs/reference/func_config_volumes.md
@@ -24,8 +24,7 @@ func config volumes
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_config_volumes_add.md
+++ b/docs/reference/func_config_volumes_add.md
@@ -24,8 +24,7 @@ func config volumes add
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_config_volumes_remove.md
+++ b/docs/reference/func_config_volumes_remove.md
@@ -24,8 +24,7 @@ func config volumes remove
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_create.md
+++ b/docs/reference/func_create.md
@@ -78,8 +78,7 @@ func create
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_delete.md
+++ b/docs/reference/func_delete.md
@@ -32,17 +32,17 @@ func delete -n apps myfunc
 ### Options
 
 ```
-  -a, --all string    Delete all resources created for a function, eg. Pipelines, Secrets, etc. (Env: $FUNC_ALL) (allowed values: "true", "false") (default "true")
-  -c, --confirm       Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)
-  -h, --help          help for delete
-  -p, --path string   Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -a, --all string         Delete all resources created for a function, eg. Pipelines, Secrets, etc. (Env: $FUNC_ALL) (allowed values: "true", "false") (default "true")
+  -c, --confirm            Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)
+  -h, --help               help for delete
+  -n, --namespace string   The namespace in which to delete. (Env: $FUNC_NAMESPACE)
+  -p, --path string        Path to the project directory (Env: $FUNC_PATH) (default ".")
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_info.md
+++ b/docs/reference/func_info.md
@@ -29,16 +29,16 @@ func info --output yaml --path myotherfunc
 ### Options
 
 ```
-  -h, --help            help for info
-  -o, --output string   Output format (human|plain|json|xml|yaml|url) (Env: $FUNC_OUTPUT) (default "human")
-  -p, --path string     Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -h, --help               help for info
+  -n, --namespace string   The namespace in which to look for the named function. (Env: $FUNC_NAMESPACE)
+  -o, --output string      Output format (human|plain|json|xml|yaml|url) (Env: $FUNC_OUTPUT) (default "human")
+  -p, --path string        Path to the project directory (Env: $FUNC_PATH) (default ".")
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_invoke.md
+++ b/docs/reference/func_invoke.md
@@ -111,8 +111,7 @@ func invoke
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_languages.md
+++ b/docs/reference/func_languages.md
@@ -53,8 +53,7 @@ func languages
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_list.md
+++ b/docs/reference/func_list.md
@@ -31,16 +31,16 @@ func list --all-namespaces --output json
 ### Options
 
 ```
-  -A, --all-namespaces   List functions in all namespaces. If set, the --namespace flag is ignored.
-  -h, --help             help for list
-  -o, --output string    Output format (human|plain|json|xml|yaml) (Env: $FUNC_OUTPUT) (default "human")
+  -A, --all-namespaces     List functions in all namespaces. If set, the --namespace flag is ignored.
+  -h, --help               help for list
+  -n, --namespace string   The namespace for which to list functions. (Env: $FUNC_NAMESPACE)
+  -o, --output string      Output format (human|plain|json|xml|yaml) (Env: $FUNC_OUTPUT) (default "human")
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_repository.md
+++ b/docs/reference/func_repository.md
@@ -135,8 +135,7 @@ func repository
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_repository_add.md
+++ b/docs/reference/func_repository_add.md
@@ -16,8 +16,7 @@ func repository add <name> <url>
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_repository_list.md
+++ b/docs/reference/func_repository_list.md
@@ -15,8 +15,7 @@ func repository list
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_repository_remove.md
+++ b/docs/reference/func_repository_remove.md
@@ -16,8 +16,7 @@ func repository remove <name>
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_repository_rename.md
+++ b/docs/reference/func_repository_rename.md
@@ -16,8 +16,7 @@ func repository rename <old> <new>
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_run.md
+++ b/docs/reference/func_run.md
@@ -52,8 +52,7 @@ func run --build=false
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_templates.md
+++ b/docs/reference/func_templates.md
@@ -54,8 +54,7 @@ func templates
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_version.md
+++ b/docs/reference/func_version.md
@@ -36,8 +36,7 @@ func version
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
:gift: default namespace globally configurable
:gift:  namespace flag help more contetually relavant
:broom:  removes namespace from commands where it is not applicable

Moves namespace derivation logic to global config and prepares commands for integration by defining namespace directly on each.

Related: #901 

/kind enhancement

```release-notes
* default namespace is now globally configurable
* namespace flag help is more contextually relevant
* removes the namespace flag from commands where it is not applicable
```