### PR TITLE
feat: function context - build builder

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -51,35 +51,6 @@ func TestClient_New(t *testing.T) {
 	}
 }
 
-// TestClient_InstantiationCreatesRepositoriesPath ensures that instantiating the
-// client has the side-effect of ensuring that the repositories path exists
-// on-disk, and also confirms that the XDG_CONFIG_HOME environment variable is
-// respected when calculating this home path.
-func TestClient_InstantiationCreatesRepositoriesPath(t *testing.T) {
-	root := "testdata/example.com/testNewCreatesRepositoriesPath"
-	defer Using(t, root)()
-
-	rootAbs, err := filepath.Abs(root) // absolute path to root
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Instruct the system to use the above test root directory as the home dir.
-	t.Setenv("XDG_CONFIG_HOME", rootAbs)
-
-	// The expected full path to the repositories should be:
-	expected := filepath.Join(rootAbs, "func", "repositories")
-
-	// Create a new client, which should perform initialization checks such as
-	// ensuring the full path to repositories exists.
-	_ = fn.New(fn.WithRegistry(TestRegistry))
-
-	// Confirm that the repositories path exists.
-	if _, err := os.Stat(expected); err != nil {
-		t.Fatal(err)
-	}
-}
-
 // TestClient_New_RuntimeRequired ensures that the the runtime is an expected value.
 func TestClient_New_RuntimeRequired(t *testing.T) {
 	// Create a root for the new function

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -7,6 +7,7 @@ import (
 
 	fn "knative.dev/func"
 	"knative.dev/func/buildpacks"
+	"knative.dev/func/config"
 	"knative.dev/func/docker"
 	"knative.dev/func/docker/creds"
 	fnhttp "knative.dev/func/http"
@@ -65,15 +66,16 @@ func NewClientFactory(n func() *fn.Client) ClientFactory {
 //	defer done()
 func NewClient(cfg ClientConfig, options ...fn.Option) (*fn.Client, func()) {
 	var (
-		p  = progress.New(cfg.Verbose)            // updates the CLI
-		t  = newTransport(cfg.InsecureSkipVerify) // may provide a custom impl which proxies
-		c  = newCredentialsProvider(t)            // for accessing registries
+		p  = progress.New(cfg.Verbose)                // updates the CLI
+		t  = newTransport(cfg.InsecureSkipVerify)     // may provide a custom impl which proxies
+		c  = newCredentialsProvider(config.Path(), t) // for accessing registries
 		d  = newKnativeDeployer(cfg.Namespace, cfg.Verbose)
 		pp = newTektonPipelinesProvider(cfg.Namespace, p, c, cfg.Verbose)
 		o  = []fn.Option{ // standard (shared) options for all commands
 			fn.WithVerbose(cfg.Verbose),
 			fn.WithProgressListener(p),
 			fn.WithTransport(t),
+			fn.WithRepositoriesPath(config.RepositoriesPath()),
 			fn.WithBuilder(buildpacks.NewBuilder(buildpacks.WithVerbose(cfg.Verbose))),
 			fn.WithRemover(knative.NewRemover(cfg.Namespace, cfg.Verbose)),
 			fn.WithDescriber(knative.NewDescriber(cfg.Namespace, cfg.Verbose)),
@@ -119,7 +121,7 @@ func newTransport(insecureSkipVerify bool) fnhttp.RoundTripCloser {
 // newCredentialsProvider returns a credentials provider which possibly
 // has cluster-flavor specific additional credential loaders to take advantage
 // of features or configuration nuances of cluster variants.
-func newCredentialsProvider(t http.RoundTripper) docker.CredentialsProvider {
+func newCredentialsProvider(configPath string, t http.RoundTripper) docker.CredentialsProvider {
 	options := []creds.Opt{
 		creds.WithPromptForCredentials(newPromptForCredentials(os.Stdin, os.Stdout, os.Stderr)),
 		creds.WithPromptForCredentialStore(newPromptForCredentialStore()),
@@ -131,7 +133,7 @@ func newCredentialsProvider(t http.RoundTripper) docker.CredentialsProvider {
 			creds.WithAdditionalCredentialLoaders(openshift.GetDockerCredentialLoaders()...))
 	}
 	// Other cluster variants can be supported here
-	return creds.NewCredentialsProvider(options...)
+	return creds.NewCredentialsProvider(configPath, options...)
 }
 
 func newTektonPipelinesProvider(namespace string, progress *progress.Bar, creds docker.CredentialsProvider, verbose bool) *tekton.PipelinesProvider {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -237,9 +237,10 @@ func newCreateConfig(cmd *cobra.Command, args []string, newClient ClientFactory)
 	// Not exposed as a flag due to potential confusion with the more likely
 	// "repository override" flag, and due to its unlikliness of being needed, but
 	// it is still available as an environment variable.
-	repositoriesPath = os.Getenv("FUNC_REPOSITORIES_PATH")
 	if repositoriesPath == "" { // if no env var provided
-		repositoriesPath = fn.New().RepositoriesPath() // use ~/.config/func/repositories
+		client, done := newClient(ClientConfig{})
+		defer done()
+		repositoriesPath = client.RepositoriesPath() // use ~/.config/func/repositories
 	}
 
 	// Config is the final default values based off the execution context.

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -328,6 +328,17 @@ func runRepositoryAdd(_ *cobra.Command, args []string, newClient ClientFactory) 
 		return
 	}
 
+	// Adding a repository requires there be a config path structure on disk
+	if err = config.CreatePaths(); err != nil {
+		return
+	}
+
+	// Create a client instance which utilizes the given repositories path.
+	// Note that this MAY not be in the config structure if the environment
+	// variable to override said path was provided explicitly.
+	// TODO: rectify this inconsitency:  the config default path structure will
+	// be created in XDG_CONFIG_HOME/func even if the repo path environment
+	// was set to some other location on disk.
 	client, done := newClient(ClientConfig{Verbose: cfg.Verbose},
 		fn.WithRepositoriesPath(cfg.RepositoriesPath))
 	defer done()
@@ -604,10 +615,7 @@ func newRepositoryConfig(args []string) (cfg repositoryConfig, err error) {
 
 	// Repositories Path
 	// Use env var to alter the default of ~/.config/func/repositories
-	cfg.RepositoriesPath = os.Getenv("FUNC_REPOSITORIES_PATH")
-	if cfg.RepositoriesPath == "" {
-		cfg.RepositoriesPath = fn.New().RepositoriesPath()
-	}
+	cfg.RepositoriesPath = config.RepositoriesPath()
 
 	// If not in confirm (interactive prompting) mode,
 	// this struct is complete.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -437,4 +438,32 @@ func defaultTemplatedHelp(cmd *cobra.Command, args []string) {
 	if err := tpl.Execute(cmd.OutOrStdout(), data); err != nil {
 		fmt.Fprintf(cmd.ErrOrStderr(), "unable to display help text: %v", err)
 	}
+}
+
+// effectivePath for this invocation.  Default: "."
+// Directly parses the os.Args for the value of the optional --path|-p flag
+// such that this function can be used during init.
+func effectivePath() string {
+	var (
+		path  = "."
+		env   = os.Getenv("FUNC_PATH")
+		fs    = flag.NewFlagSet("", flag.ContinueOnError)
+		long  = fs.String("path", "", "")
+		short = fs.String("p", "", "")
+		err   = fs.Parse(os.Args)
+	)
+	fs.Parse(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: error parsing arguments: %v", err)
+	}
+	if env != "" {
+		path = env
+	}
+	if *short != "" {
+		path = *short
+	}
+	if *long != "" {
+		path = *long
+	}
+	return path
 }

--- a/config/config.go
+++ b/config/config.go
@@ -7,52 +7,77 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 	"gopkg.in/yaml.v2"
+	"knative.dev/func/builders"
+	"knative.dev/func/k8s"
+	"knative.dev/func/openshift"
 )
 
 const (
 	// Filename into which Config is serialized
 	Filename = "config.yaml"
 
-	// DefaultConfigPath is used in the unlikely event that
-	// the user has no home directory (no ~), there is no
-	// XDG_CONFIG_HOME set
-	DefaultConfigPath = ".config/func"
+	// Repositories is the default directory for repositoires.
+	Repositories = "repositories"
 
 	// DefaultLanguage is intentionaly undefined.
 	DefaultLanguage = ""
+
+	// DefaultBuilder defined by builders
+	DefaultBuilder = builders.Default
 )
 
-type Config struct {
-	// Language Runtime
-	Language string `yaml:"language"`
+func DefaultRegistry() string {
+	switch {
+	case openshift.IsOpenShift():
+		return openshift.GetDefaultRegistry()
+	default:
+		return ""
+	}
+}
 
-	// Confirm Prompts
-	Confirm bool `yaml:"confirm"`
+// DefaultNamespace for remote operations is the currently active
+// context namespace (if available) or the fallbacl "default".
+func DefaultNamespace() (namespace string) {
+	var err error
+	if namespace, err = k8s.GetNamespace(""); err != nil {
+		return "default"
+	}
+	return
+}
+
+// Global configuration settings.
+type Config struct {
+	Builder   string `yaml:"builder,omitempty"`
+	Confirm   bool   `yaml:"confirm,omitempty"`
+	Language  string `yaml:"language,omitempty"`
+	Namespace string `yaml:"namespace,omitempty"`
+	Registry  string `yaml:"registry,omitempty"`
+	Verbose   bool   `yaml:"verbose,omitempty"`
 }
 
 // New Config struct with all members set to static defaults.  See NewDefaults
 // for one which further takes into account the optional config file.
 func New() Config {
 	return Config{
-		Language: DefaultLanguage,
-		// ...
+		Builder:   DefaultBuilder,
+		Language:  DefaultLanguage,
+		Namespace: DefaultNamespace(),
+		Registry:  DefaultRegistry(),
 	}
 }
 
-// Creates a new config populated by global defaults as defined by the
+// NewDefault returns a config populated by global defaults as defined by the
 // config file located in .Path() (the global func settings path, which is
-//  usually ~/.config/func)
+//  usually ~/.config/func).
+// The config path is not required to be present.
 func NewDefault() (cfg Config, err error) {
-	cfg = New()       // cfg now populated by static defaults
-	p := ConfigPath() // applies ~/.config/func/config.yaml if it exists
-	if _, err = os.Stat(p); err != nil {
+	cfg = New()
+	cp := ConfigPath()
+	bb, err := os.ReadFile(cp)
+	if err != nil {
 		if os.IsNotExist(err) {
 			err = nil // config file is not required
 		}
-		return
-	}
-	bb, err := os.ReadFile(p)
-	if err != nil {
 		return
 	}
 	err = yaml.Unmarshal(bb, &cfg) // cfg now has applied config.yaml
@@ -61,23 +86,17 @@ func NewDefault() (cfg Config, err error) {
 
 // Load the config exactly as it exists at path (no static defaults)
 func Load(path string) (c Config, err error) {
-	if _, err = os.Stat(path); err != nil {
-		return
-	}
 	bb, err := os.ReadFile(path)
 	if err != nil {
-		return
+		return c, fmt.Errorf("error reading global config: %v", err)
 	}
 	err = yaml.Unmarshal(bb, &c)
 	return
 }
 
-// Save the config to the given path
-func (c Config) Save(path string) (err error) {
-	var bb []byte
-	if bb, err = yaml.Marshal(&c); err != nil {
-		return
-	}
+// Write the config to the given path
+func (c Config) Write(path string) (err error) {
+	bb, _ := yaml.Marshal(&c) // Marshaling no longer errors; this is back compat
 	return os.WriteFile(path, bb, os.ModePerm)
 }
 
@@ -88,7 +107,10 @@ func (c Config) Save(path string) (err error) {
 // 3.  The value of $XDG_CONFIG_PATH/func if the environment variable exists.
 // The path is created if it does not already exist.
 func Path() (path string) {
-	path = DefaultConfigPath
+	// default path is a relative path used in the unlikely event that
+	// the user has no home directory (no ~), there is no
+	// XDG_CONFIG_HOME set
+	path = filepath.Join(".config", "func")
 
 	// ~/.config/func is the default if ~ can be expanded
 	if home, err := homedir.Expand("~"); err == nil {
@@ -100,21 +122,43 @@ func Path() (path string) {
 		path = filepath.Join(xdg, "func")
 	}
 
-	mkdir(path)
 	return
 }
 
 // ConfigPath returns the full path at which to look for a config file.
+// Use FUNC_CONFIG_FILE to override default.
 func ConfigPath() string {
-	// TODO: It might be nice to include consideration of a FUNC_CONFIG_FILE
-	// which would allow explicitly setting a config file.
-
-	// usually ~/.config/func/config.yaml
-	return filepath.Join(Path(), Filename)
+	path := filepath.Join(Path(), Filename)
+	if e := os.Getenv("FUNC_CONFIG_FILE"); e != "" {
+		path = e
+	}
+	return path
 }
 
-func mkdir(path string) {
-	if err := os.MkdirAll(path, os.ModePerm); err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating '%v': %v", path, err)
+// RepositoriesPath returns the full at which to look for repositories.
+// Use FUNC_REPOSITORIES_PATH to override default.
+func RepositoriesPath() string {
+	path := filepath.Join(Path(), Repositories)
+	if e := os.Getenv("FUNC_REPOSITORIES_PATH"); e != "" {
+		path = e
 	}
+	return path
+}
+
+// CreatePaths is a convenience function for creating the on-disk func config
+// structure.  All operations should be tolerant of nonexistant disk
+// footprint where possible (for example listing repositories should not
+// require an extant path, but _adding_ a repository does require that the func
+// config structure exist.
+// Current structure is:
+// ~/.config/func
+// ~/.config/func/repositories
+func CreatePaths() (err error) {
+	if err = os.MkdirAll(Path(), os.ModePerm); err != nil {
+		return fmt.Errorf("error creating global config path: %v", err)
+	}
+	if err = os.MkdirAll(RepositoriesPath(), os.ModePerm); err != nil {
+		return fmt.Errorf("error creating global config repositories path: %v", err)
+	}
+	return
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -20,7 +21,8 @@ func TestNewDefaults(t *testing.T) {
 }
 
 // TestLoad ensures that loading a config reads values
-// in from a config file at path.
+// in from a config file at path, and in this case (unlike NewDefault) the
+// file must exist at path or error.
 func TestLoad(t *testing.T) {
 	cfg, err := config.Load("testdata/func/config.yaml")
 	if err != nil {
@@ -28,6 +30,12 @@ func TestLoad(t *testing.T) {
 	}
 	if cfg.Language != "custom" {
 		t.Fatalf("loaded config did not contain values from config file.  Expected \"custom\" got \"%v\"", cfg.Language)
+	}
+
+	// and ensure error
+	cfg, err = config.Load("invalid/path")
+	if err == nil {
+		t.Fatal("did not receive expected error loading nonexistent config path")
 	}
 }
 
@@ -45,7 +53,7 @@ func TestSave(t *testing.T) {
 	cfg.Language = "testSave"
 
 	// save
-	if err := cfg.Save(filename); err != nil {
+	if err := cfg.Write(filename); err != nil {
 		t.Fatal(err)
 	}
 
@@ -91,4 +99,108 @@ func TestNewDefault(t *testing.T) {
 	if cfg.Language != "custom" {
 		t.Fatalf("config file not loaded")
 	}
+}
+
+// TestCreatePaths ensures that the paths are created when requested.
+func TestCreatePaths(t *testing.T) {
+	home, cleanup := Mktemp(t)
+	t.Cleanup(cleanup)
+
+	t.Setenv("XDG_CONFIG_HOME", home)
+
+	if err := config.CreatePaths(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(config.Path()); err != nil {
+		if os.IsNotExist(err) {
+			t.Fatalf("config path '%v' not created", config.Path())
+		}
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(config.Path(), "repositories")); err != nil {
+		if os.IsNotExist(err) {
+			t.Fatalf("config path '%v' not created", config.Path())
+		}
+		t.Fatal(err)
+	}
+
+	// Trying to create when repositories path is invalid should error
+	t.Setenv("FUNC_REPOSITORIES_PATH", "/../../invalid")
+	if err := config.CreatePaths(); err == nil {
+		t.Fatal("did not receive error when creating paths with an invalid FUNC_REPOSITORIES_PATH")
+	}
+
+	// Trying to Create config path should bubble errors, for example when HOME is
+	// set to a nonexistent path.
+	t.Setenv("XDG_CONFIG_HOME", "/invalid")
+	if err := config.CreatePaths(); err == nil {
+		t.Fatal("did not receive error when creating paths in an invalid home")
+	}
+
+}
+
+// TestNewDefault_ConfigNotRequired ensures that when creating a new
+// config which would load a global config, its nonexistence causes no error.
+func TestNewDefault_ConfigNotRequired(t *testing.T) {
+	// Custom config home results in a config file default path of
+	// ./testdata/func/config.yaml
+	home, cleanup := Mktemp(t)
+	t.Cleanup(cleanup)
+	t.Setenv("XDG_CONFIG_HOME", home)
+
+	_, err := config.NewDefault() // Should not error despite no config.
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRepositoriesPath returns the path expected
+// (XDG_CONFIG_HOME/func/repositories by default)
+func TestRepositoriesPath(t *testing.T) {
+	home, cleanup := Mktemp(t)
+	t.Cleanup(cleanup)
+	t.Setenv("XDG_CONFIG_HOME", home)
+
+	expected := filepath.Join(home, "func", config.Repositories)
+	if config.RepositoriesPath() != expected {
+		t.Fatalf("unexpected reposiories path: %v", config.RepositoriesPath())
+	}
+}
+
+// TestWrite ensures that a config is written to the given path and errors
+// are returned correctly when the path does not exist.
+func TestWrite(t *testing.T) {
+	home, cleanup := Mktemp(t)
+	t.Cleanup(cleanup)
+	t.Setenv("XDG_CONFIG_HOME", home)
+
+	cfg := config.New()
+	cfg.Language = "example"
+
+	// First try writing to a nonexistent path
+	if err := cfg.Write(config.ConfigPath()); err == nil {
+		t.Fatal("did not receive error writing to a nonexistent path")
+	}
+
+	// Create the path and try again
+	if err := config.CreatePaths(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.Write(config.ConfigPath()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDefaultNamespace ensures that, when thre is a problem determining the
+// active namespace, the static DefaultNamespace ("default") is used.
+func TestDefaultNamespace(t *testing.T) {
+	home, cleanup := Mktemp(t)
+	t.Cleanup(cleanup)
+	t.Setenv("XDG_CONFIG_HOME", home)
+	if config.DefaultNamespace() != "default" {
+		t.Fatalf("did not receive expecetd default namespace 'default', got '%v'", config.DefaultNamespace())
+	}
+
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -127,14 +127,16 @@ func TestCreatePaths(t *testing.T) {
 	}
 
 	// Trying to create when repositories path is invalid should error
-	t.Setenv("FUNC_REPOSITORIES_PATH", "/../../invalid")
+	_ = os.WriteFile("./invalidRepositoriesPath.txt", []byte{}, os.ModePerm)
+	t.Setenv("FUNC_REPOSITORIES_PATH", "./invalidRepositoriesPath.txt")
 	if err := config.CreatePaths(); err == nil {
 		t.Fatal("did not receive error when creating paths with an invalid FUNC_REPOSITORIES_PATH")
 	}
 
 	// Trying to Create config path should bubble errors, for example when HOME is
 	// set to a nonexistent path.
-	t.Setenv("XDG_CONFIG_HOME", "/invalid")
+	_ = os.WriteFile("./invalidConfigHome.txt", []byte{}, os.ModePerm)
+	t.Setenv("XDG_CONFIG_HOME", "./invalidConfigHome.txt")
 	if err := config.CreatePaths(); err == nil {
 		t.Fatal("did not receive error when creating paths in an invalid home")
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,7 +24,7 @@ func TestNewDefaults(t *testing.T) {
 // in from a config file at path, and in this case (unlike NewDefault) the
 // file must exist at path or error.
 func TestLoad(t *testing.T) {
-	cfg, err := config.Load("testdata/func/config.yaml")
+	cfg, err := config.Load(filepath.Join("testdata", "TestLoad", "func", "config.yaml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/config/testdata/TestDefaultNamespace/kubeconfig
+++ b/config/testdata/TestDefaultNamespace/kubeconfig
@@ -1,0 +1,25 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://cluster.example.com:6443
+  name: cluster.example.com:6443
+contexts:
+- context:
+    cluster: cluster.example.com:6443
+    namespace: default
+    user: kube:admin/cluster.example.com:6443
+  name: default/cluster.example.com:6443/kube:admin
+- context:
+    cluster: cluster.example.com:6443
+    namespace: func
+    user: kube:admin/cluster.example.com:6443
+  name: func/cluster.example.com:6443/kube:admin
+current-context: func/cluster.example.com:6443/kube:admin
+kind: Config
+preferences: {}
+users:
+- name: kubeadmin
+  user:
+    token: sha256~XXXXexample-test-hash
+

--- a/config/testdata/TestLoad/func/config.yaml
+++ b/config/testdata/TestLoad/func/config.yaml
@@ -1,0 +1,1 @@
+language: custom

--- a/docker/creds/credentials.go
+++ b/docker/creds/credentials.go
@@ -13,7 +13,6 @@ import (
 	"runtime"
 	"strings"
 
-	"knative.dev/func/config"
 	"knative.dev/func/docker"
 
 	dockerConfig "github.com/containers/image/v5/pkg/docker/config"
@@ -143,7 +142,7 @@ func WithAdditionalCredentialLoaders(loaders ...CredentialsCallback) Opt {
 // The picked value will be saved in the func config.
 //
 // To verify that credentials are correct custom callback can be used (see WithVerifyCredentials).
-func NewCredentialsProvider(opts ...Opt) docker.CredentialsProvider {
+func NewCredentialsProvider(configPath string, opts ...Opt) docker.CredentialsProvider {
 	var c credentialsProvider
 
 	for _, o := range opts {
@@ -166,7 +165,7 @@ func NewCredentialsProvider(opts ...Opt) docker.CredentialsProvider {
 		}
 	}
 
-	c.authFilePath = filepath.Join(config.Path(), "auth.json")
+	c.authFilePath = filepath.Join(configPath, "auth.json")
 	sys := &containersTypes.SystemContext{
 		AuthFilePath: c.authFilePath,
 	}

--- a/docker/creds/credentials_test.go
+++ b/docker/creds/credentials_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"knative.dev/func/config"
 	"knative.dev/func/docker"
 	"knative.dev/func/docker/creds"
 	. "knative.dev/func/testing"
@@ -416,6 +415,7 @@ func TestNewCredentialsProvider(t *testing.T) {
 			}
 
 			credentialsProvider := creds.NewCredentialsProvider(
+				testConfigPath(t),
 				creds.WithPromptForCredentials(tt.args.promptUser),
 				creds.WithVerifyCredentials(tt.args.verifyCredentials),
 				creds.WithAdditionalCredentialLoaders(tt.args.additionalLoaders...))
@@ -432,7 +432,7 @@ func TestNewCredentialsProvider(t *testing.T) {
 }
 
 func TestNewCredentialsProviderEmptyCreds(t *testing.T) {
-	credentialsProvider := creds.NewCredentialsProvider(creds.WithVerifyCredentials(func(ctx context.Context, image string, credentials docker.Credentials) error {
+	credentialsProvider := creds.NewCredentialsProvider(testConfigPath(t), creds.WithVerifyCredentials(func(ctx context.Context, image string, credentials docker.Credentials) error {
 		if image == "localhost:5555/someorg/someimage:sometag" && credentials == (docker.Credentials{}) {
 			return nil
 		}
@@ -478,6 +478,7 @@ func TestCredentialsProviderSavingFromUserInput(t *testing.T) {
 	}
 
 	credentialsProvider := creds.NewCredentialsProvider(
+		testConfigPath(t),
 		creds.WithPromptForCredentials(pwdCbk),
 		creds.WithVerifyCredentials(correctVerifyCbk),
 		creds.WithPromptForCredentialStore(chooseNoStore))
@@ -497,6 +498,7 @@ func TestCredentialsProviderSavingFromUserInput(t *testing.T) {
 		t.Errorf("expected to have zero credentials in store, but has: %d", credsInStore)
 	}
 	credentialsProvider = creds.NewCredentialsProvider(
+		testConfigPath(t),
 		creds.WithPromptForCredentials(pwdCbk),
 		creds.WithVerifyCredentials(correctVerifyCbk),
 		creds.WithPromptForCredentialStore(chooseMockStore))
@@ -519,6 +521,7 @@ func TestCredentialsProviderSavingFromUserInput(t *testing.T) {
 		t.Errorf("expected to have exactly one credentials in store, but has: %d", credsInStore)
 	}
 	credentialsProvider = creds.NewCredentialsProvider(
+		testConfigPath(t),
 		creds.WithPromptForCredentials(pwdCbkThatShallNotBeCalled(t)),
 		creds.WithVerifyCredentials(correctVerifyCbk),
 		creds.WithPromptForCredentialStore(shallNotBeInvoked))
@@ -534,8 +537,6 @@ func cleanUpConfigs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	os.RemoveAll(config.Path())
 
 	os.RemoveAll(filepath.Join(home, ".docker"))
 }
@@ -576,7 +577,7 @@ func withPopulatedFuncAuthConfig(t *testing.T) {
 
 	var err error
 
-	authConfig := filepath.Join(config.Path(), "auth.json")
+	authConfig := filepath.Join(testConfigPath(t), "auth.json")
 	err = os.MkdirAll(filepath.Dir(authConfig), 0700)
 	if err != nil {
 		t.Fatal(err)
@@ -643,18 +644,31 @@ func correctVerifyCbk(ctx context.Context, image string, credentials Credentials
 	return creds.ErrUnauthorized
 }
 
+func testHomeEnvName(t *testing.T) string {
+	if runtime.GOOS == "windows" {
+		return "USERPROFILE"
+	}
+	return "HOME"
+}
+
 func withCleanHome(t *testing.T) {
 	t.Helper()
-	homeName := "HOME"
-	if runtime.GOOS == "windows" {
-		homeName = "USERPROFILE"
-	}
 	tmpHome := t.TempDir()
-	t.Setenv(homeName, tmpHome)
+	t.Setenv(testHomeEnvName(t), tmpHome)
 
 	if runtime.GOOS == "linux" {
 		t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, ".config"))
 	}
+}
+
+func testConfigPath(t *testing.T) string {
+	t.Helper()
+	home := os.Getenv(testHomeEnvName(t))
+	configPath := filepath.Join(home, ".config", "func")
+	if err := os.MkdirAll(configPath, os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	return configPath
 }
 
 func handlerForCredHelper(t *testing.T, credHelper credentials.Helper) http.Handler {

--- a/job.go
+++ b/job.go
@@ -38,7 +38,9 @@ func (j *Job) Stop() {
 func (j *Job) save() error {
 	instancesDir := filepath.Join(j.Function.Root, RunDataDir, "instances")
 	// job metadata is stored in <root>/.func/instances
-	mkdir(instancesDir)
+	if err := os.MkdirAll(instancesDir, os.ModePerm); err != nil {
+		return err
+	}
 
 	// create a file <root>/.func/instances/<port>
 	file, err := os.Create(filepath.Join(instancesDir, j.Port))
@@ -71,7 +73,9 @@ func jobPorts(f Function) []string {
 		return []string{}
 	}
 	instancesDir := filepath.Join(f.Root, RunDataDir, "instances")
-	mkdir(instancesDir)
+	if _, err := os.Stat(instancesDir); err != nil {
+		return []string{} // never started, so path does not exist
+	}
 
 	files, err := os.ReadDir(instancesDir)
 	if err != nil {

--- a/repositories.go
+++ b/repositories.go
@@ -15,13 +15,6 @@ const (
 	// Unless a single-repo override is defined, this is usually referring to the
 	// builtin (embedded) repository.
 	DefaultRepositoryName = "default"
-
-	// DefaultRepositoriesPath is the default location for repositories under
-	// management on local disk.
-	// TODO: the logic which defaults this to ~/.config/func/repositories will
-	// be moved from the CLI to the core in the near future.  For now use the
-	// current working directory.
-	DefaultRepositoriesPath = ""
 )
 
 // Repositories manager
@@ -56,6 +49,8 @@ func newRepositories(client *Client) *Repositories {
 }
 
 // Path returns the currently active repositories path under management.
+// Blank indicates that the system was not instantiated to use any
+// repositories on disk.
 func (r *Repositories) Path() string {
 	return r.path
 }


### PR DESCRIPTION
- :gift: adds an 'effectiveBuilder' function which parses --path flag prior to command instantiation
- :gift: sets the default builder to the builder of the function at --path if it exist

The effectiveBuilder function evaluates arguments prior to Cobra/Viper instantiation such that the value of --path|-p|FUNC_PATH can be used during the creation of the commands.

The use-case used to illustrate its usefulness is to set the default of the `build` command's `--builder` flag to the function at `--path` (if it exists).

This feature will be used heavily in the Global Config, where it will be used during the flow of config precidence:  Static Defaults -> Global Config -> Function State -> Environment Variables -> Flag Values.