### PR TITLE
fix: remove ldflags from docs generation make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ clean: clean_templates ## Remove generated artifacts such as binaries and schema
 
 docs:
 	# Generating command reference doc
-	go run docs/generator/main.go -ldflags $(LDFLAGS)
+	go run docs/generator/main.go
 
 #############
 ##@ Templates


### PR DESCRIPTION
Removes ldflags from docs generation make command as they are not used.

Their existence causes a conflict with the related PR which moves --path flag processing into init, causing a (nonfatal but anoying) error that ldflags were used but not defined.