### PR TITLE
chore: add nodejs as a builder key

### DIFF
--- a/buildpacks/builder.go
+++ b/buildpacks/builder.go
@@ -25,6 +25,7 @@ const DefaultName = builders.Pack
 var (
 	DefaultBuilderImages = map[string]string{
 		"node":       "gcr.io/paketo-buildpacks/builder:base",
+		"nodejs":     "gcr.io/paketo-buildpacks/builder:base",
 		"typescript": "gcr.io/paketo-buildpacks/builder:base",
 		"go":         "gcr.io/paketo-buildpacks/builder:base",
 		"python":     "gcr.io/paketo-buildpacks/builder:base",

--- a/s2i/builder.go
+++ b/s2i/builder.go
@@ -36,6 +36,7 @@ const DefaultName = builders.S2I
 // DefaultBuilderImages for s2i builders indexed by Runtime Language
 var DefaultBuilderImages = map[string]string{
 	"node":       "registry.access.redhat.com/ubi8/nodejs-16",
+	"nodejs":     "registry.access.redhat.com/ubi8/nodejs-16",
 	"typescript": "registry.access.redhat.com/ubi8/nodejs-16",
 	"quarkus":    "registry.access.redhat.com/ubi8/openjdk-17",
 }


### PR DESCRIPTION
The https://github.com/knative-sandbox/func-tastic repo uses "nodejs" instead of "node" as the language runtime. This change makes it possible for templates in the func-tastic language pack to work out of the box.

Signed-off-by: Lance Ball <lball@redhat.com>

/kind chore

```release-notes
adds support for "nodejs" as a runtime designation in addition to the default "node"
```