### PR TITLE
chore: list command namespace

### DIFF
--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"testing"
+
+	fn "knative.dev/func"
+	"knative.dev/func/mock"
+)
+
+// TestList_Namespace ensures that list command options for specifying a
+// namespace (--namespace) or all namespaces (--all-namespacs) are  properly
+// evaluated.
+func TestList_Namespace(t *testing.T) {
+	_ = fromTempDirectory(t)
+
+	tests := []struct {
+		name      string
+		all       bool   // --all-namespaces
+		namespace string // use specific namespace
+		expected  string // expected
+		err       bool   // expected error
+	}{
+		{
+			name:     "default",
+			expected: "default",
+		},
+		{
+			name:      "namespace provided",
+			namespace: "ns",
+			expected:  "ns",
+		},
+		{
+			name:     "all namespaces",
+			all:      true,
+			expected: "", // blank is implemented by lister as meaning all
+		},
+		{
+			name:      "both flags error",
+			namespace: "ns",
+			all:       true,
+			err:       true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var (
+				lister = mock.NewLister()
+				client = fn.New(fn.WithLister(lister))
+			)
+			cmd := NewListCmd(func(cc ClientConfig, options ...fn.Option) (*fn.Client, func()) {
+				if cc.Namespace != test.expected {
+					t.Fatalf("expected '%v', got '%v'", test.expected, cc.Namespace)
+				}
+				return client, func() {}
+			})
+			args := []string{}
+			if test.namespace != "" {
+				args = append(args, "--namespace", test.namespace)
+			}
+			if test.all {
+				args = append(args, "-A")
+			}
+			cmd.SetArgs(args)
+
+			err := cmd.Execute()
+			if err != nil && !test.err {
+				// TODO: typed error for --namespace with -A.  Perhaps ErrFlagConflict?
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && test.err {
+				t.Fatalf("did not receive expected error ")
+			}
+		})
+	}
+}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -22,7 +22,7 @@ func TestList_Namespace(t *testing.T) {
 	}{
 		{
 			name:     "default",
-			expected: "default",
+			expected: "func", // see ./testdata/default_kubeconfig
 		},
 		{
 			name:      "namespace provided",

--- a/docs/reference/func_list.md
+++ b/docs/reference/func_list.md
@@ -31,16 +31,16 @@ func list --all-namespaces --output json
 ### Options
 
 ```
-  -A, --all-namespaces   List functions in all namespaces. If set, the --namespace flag is ignored.
-  -h, --help             help for list
-  -o, --output string    Output format (human|plain|json|xml|yaml) (Env: $FUNC_OUTPUT) (default "human")
+  -A, --all-namespaces     List functions in all namespaces. If set, the --namespace flag is ignored.
+  -h, --help               help for list
+  -n, --namespace string   The namespace for which to list functions. (Env: $FUNC_NAMESPACE) (default "default")
+  -o, --output string      Output format (human|plain|json|xml|yaml) (Env: $FUNC_OUTPUT) (default "human")
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
-  -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
+  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
- Adds namespace test to list command
- Moves namespace flag into list command for
  - Better help text
  - Easier testing
- Sets static default namespace for flag to "default"

/kind techdebt
