### PR TITLE
Fix Tekton tasks install failures on CI

### DIFF
--- a/hack/tekton.sh
+++ b/hack/tekton.sh
@@ -25,12 +25,15 @@ export TERM="${TERM:-dumb}"
 tekton_release="previous/v0.38.3"
 git_clone_release="0.4"
 namespace="${NAMESPACE:-default}"
+tasks_source_path=$(dirname $(cd $(dirname $0) && pwd ))
 
 tekton() {
   echo "Installing Tekton..."
   kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/${tekton_release}/release.yaml
   sleep 10
   kubectl wait pod --for=condition=Ready --timeout=180s -n tekton-pipelines -l "app=tekton-pipelines-controller"
+  kubectl wait pod --for=condition=Ready --timeout=180s -n tekton-pipelines -l "app=tekton-pipelines-webhook"
+  sleep 10
 
   kubectl create clusterrolebinding ${namespace}:knative-serving-namespaced-admin \
   --clusterrole=knative-serving-namespaced-admin  --serviceaccount=${namespace}:default
@@ -39,9 +42,9 @@ tekton() {
 tekton_tasks() {
   echo "Creating Pipeline tasks..."
   kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/git-clone/${git_clone_release}/git-clone.yaml
-  kubectl apply -f ./pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
-  kubectl apply -f ./pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
-  kubectl apply -f ./pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+  kubectl apply -f ${tasks_source_path}/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
+  kubectl apply -f ${tasks_source_path}/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+  kubectl apply -f ${tasks_source_path}/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
 }
 
 ## Parse input parameters


### PR DESCRIPTION
# Changes

- :broom: Waiting for tekton webhook to be ready before applying tekton tasks (improve ci)

/kind cleanup
