### PR TITLE
fix: config dir default empty

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,17 +70,13 @@ func (c Config) Write(path string) (err error) {
 
 // Dir is derived in the following order, from lowest
 // to highest precedence.
-// 1.  The static default is DefaultConfigPath (./.config/func)
+// 1.  The default path is the zero value, indicating "no config path available",
+//     and users of this package should act accordingly.
 // 2.  ~/.config/func if it exists (can be expanded: user has a home dir)
 // 3.  The value of $XDG_CONFIG_PATH/func if the environment variable exists.
 // The path is created if it does not already exist.
 func Dir() (path string) {
-	// default path is a relative path used in the unlikely event that
-	// the user has no home directory (no ~), there is no
-	// XDG_CONFIG_HOME set
-	path = filepath.Join(".config", "func")
-
-	// ~/.config/func is the default if ~ can be expanded
+	// Use home if available
 	if home, err := os.UserHomeDir(); err == nil {
 		path = filepath.Join(home, ".config", "func")
 	}

--- a/docker/creds/credentials_test.go
+++ b/docker/creds/credentials_test.go
@@ -432,6 +432,7 @@ func TestNewCredentialsProvider(t *testing.T) {
 }
 
 func TestNewCredentialsProviderEmptyCreds(t *testing.T) {
+	withCleanHome(t)
 	credentialsProvider := creds.NewCredentialsProvider(testConfigPath(t), creds.WithVerifyCredentials(func(ctx context.Context, image string, credentials docker.Credentials) error {
 		if image == "localhost:5555/someorg/someimage:sometag" && credentials == (docker.Credentials{}) {
 			return nil


### PR DESCRIPTION
:bug: fix incorrect default config directory
:bug: add a clean home setup to a test

When the system can not automatically determine a determine a config directory path, it should communicate this by returning the zero value, letting the caller handle the situation accordingly (skip usage, or create a temporary home directory)