### PR TITLE
chore: ensure all tests clear cmd args

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -26,9 +26,9 @@ func TestBuild_ImageFlag(t *testing.T) {
 	cmd := NewBuildCmd(NewClientFactory(func() *fn.Client {
 		return fn.New(fn.WithBuilder(builder))
 	}))
+	cmd.SetArgs(args)
 
 	// Execute the command
-	cmd.SetArgs(args)
 	err := cmd.Execute()
 	if err != nil {
 		t.Fatal(err)
@@ -57,8 +57,8 @@ func TestBuild_RegistryOrImageRequired(t *testing.T) {
 	cmd := NewBuildCmd(NewClientFactory(func() *fn.Client {
 		return fn.New()
 	}))
+	cmd.SetArgs([]string{})
 
-	cmd.SetArgs([]string{}) // this explicit clearing of args may not be necessary
 	if err := cmd.Execute(); err != nil {
 		if !errors.Is(err, ErrRegistryRequired) {
 			t.Fatalf("expected ErrRegistryRequired, got error: %v", err)
@@ -119,10 +119,11 @@ func TestBuild_Push(t *testing.T) {
 	var (
 		builder = mock.NewBuilder()
 		pusher  = mock.NewPusher()
-		cmd     = NewBuildCmd(NewClientFactory(func() *fn.Client {
-			return fn.New(fn.WithRegistry(TestRegistry), fn.WithBuilder(builder), fn.WithPusher(pusher))
-		}))
 	)
+	cmd := NewBuildCmd(NewClientFactory(func() *fn.Client {
+		return fn.New(fn.WithRegistry(TestRegistry), fn.WithBuilder(builder), fn.WithPusher(pusher))
+	}))
+	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
@@ -210,13 +211,14 @@ func TestBuild_RegistryHandling(t *testing.T) {
 		cmd := NewBuildCmd(NewClientFactory(func() *fn.Client {
 			return fn.New(fn.WithBuilder(builder))
 		}))
+		cmd.SetArgs(tc.testFnArgs)
+
 		tci := i + 1
 		t.Logf("Test case %d: %s", tci, tc.desc)
 
 		err := fn.New().Create(tc.testFn)
 		assert.Assert(t, err == nil)
 
-		cmd.SetArgs(tc.testFnArgs)
 		err = cmd.Execute()
 		assert.Assert(t, err == nil)
 

--- a/cmd/config_labels_test.go
+++ b/cmd/config_labels_test.go
@@ -106,7 +106,7 @@ func TestNewConfigLabelsCmd(t *testing.T) {
 	labels := &loaderSaver.f.Deploy.Labels
 
 	cmd := NewConfigLabelsCmd(&loaderSaver)
-	cmd.SetArgs([]string{}) // Do not use test command args
+	cmd.SetArgs([]string{})
 
 	run := createRunFunc(cmd, t)
 
@@ -144,7 +144,7 @@ func TestListLabels(t *testing.T) {
 	*labels = append(*labels, p("a", "b"), p("c", "d"))
 
 	cmd := NewConfigLabelsCmd(&loaderSaver)
-	cmd.SetArgs([]string{}) // Do not use test command args
+	cmd.SetArgs([]string{})
 
 	ctx := context.Background()
 	c, _, err := vt10x.NewVT10XConsole()

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -30,8 +30,8 @@ func TestDelete_ByName(t *testing.T) {
 	cmd := NewDeleteCmd(NewClientFactory(func() *fn.Client {
 		return fn.New(fn.WithRemover(remover))
 	}))
-
 	cmd.SetArgs([]string{testname})
+
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -41,6 +41,7 @@ func TestDeploy_Default(t *testing.T) {
 	cmd := NewDeployCmd(NewClientFactory(func() *fn.Client {
 		return fn.New()
 	}))
+	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
@@ -410,17 +411,17 @@ func TestDeploy_RemoteBuildURLPermutations(t *testing.T) {
 				deployer  = mock.NewDeployer()
 				builder   = mock.NewBuilder()
 				pipeliner = mock.NewPipelinesProvider()
-				cmd       = NewDeployCmd(NewClientFactory(func() *fn.Client {
-					return fn.New(
-						fn.WithDeployer(deployer),
-						fn.WithBuilder(builder),
-						fn.WithPipelinesProvider(pipeliner),
-						fn.WithRegistry(TestRegistry),
-					)
-				}))
 			)
+			cmd := NewDeployCmd(NewClientFactory(func() *fn.Client {
+				return fn.New(
+					fn.WithDeployer(deployer),
+					fn.WithBuilder(builder),
+					fn.WithPipelinesProvider(pipeliner),
+					fn.WithRegistry(TestRegistry),
+				)
+			}))
 			cmd.SetArgs(toArgs(remote, build, url))
-			err := cmd.Execute()
+			err := cmd.Execute() // err is checked below
 
 			// Assertions
 			if remote != "" && remote != "false" { // default "" is == false.
@@ -573,15 +574,15 @@ func Test_ImageWithDigestErrors(t *testing.T) {
 				deployer  = mock.NewDeployer()
 				builder   = mock.NewBuilder()
 				pipeliner = mock.NewPipelinesProvider()
-				cmd       = NewDeployCmd(NewClientFactory(func() *fn.Client {
-					return fn.New(
-						fn.WithDeployer(deployer),
-						fn.WithBuilder(builder),
-						fn.WithPipelinesProvider(pipeliner),
-						fn.WithRegistry(TestRegistry),
-					)
-				}))
 			)
+			cmd := NewDeployCmd(NewClientFactory(func() *fn.Client {
+				return fn.New(
+					fn.WithDeployer(deployer),
+					fn.WithBuilder(builder),
+					fn.WithPipelinesProvider(pipeliner),
+					fn.WithRegistry(TestRegistry),
+				)
+			}))
 			args := []string{fmt.Sprintf("--image=%s", tt.image)}
 			if tt.build != "" {
 				args = append(args, fmt.Sprintf("--build=%s", tt.build))

--- a/cmd/invoke_test.go
+++ b/cmd/invoke_test.go
@@ -93,7 +93,7 @@ func TestInvoke_Namespace(t *testing.T) {
 		return NewClient(conf, opts...)
 	}
 	cmd := NewInvokeCmd(newClient)
-	_ = cmd.Execute()
+	_ = cmd.Execute() // invocation error expected
 
 	if namespace != "ns" {
 		t.Fatalf("expected client to receive function's current namespace 'ns', got '%v'", namespace)

--- a/cmd/languages_test.go
+++ b/cmd/languages_test.go
@@ -16,6 +16,7 @@ func TestLanguages_Default(t *testing.T) {
 	cmd := NewLanguagesCmd(NewClientFactory(func() *fn.Client {
 		return fn.New()
 	}))
+	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/templates_test.go
+++ b/cmd/templates_test.go
@@ -18,6 +18,7 @@ func TestTemplates_Default(t *testing.T) {
 	cmd := NewTemplatesCmd(NewClientFactory(func() *fn.Client {
 		return fn.New()
 	}))
+	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
@@ -111,10 +112,10 @@ func TestTemplates_ByLanguage(t *testing.T) {
 	cmd := NewTemplatesCmd(NewClientFactory(func() *fn.Client {
 		return fn.New()
 	}))
+	cmd.SetArgs([]string{"go"})
 
 	// Test plain text
 	buf := piped(t)
-	cmd.SetArgs([]string{"go"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Ensures all tests execute with initially clear args
- Minor refactor/cleanup to make this reset more obvious