### PR TITLE
chore: mock deployer method signature

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -441,14 +441,14 @@ func TestClient_New_Delegation(t *testing.T) {
 		return "", nil
 	}
 
-	deployer.DeployFn = func(f fn.Function) error {
+	deployer.DeployFn = func(_ context.Context, f fn.Function) (res fn.DeploymentResult, err error) {
 		if f.Name != expectedName {
 			t.Fatalf("deployer expected name '%v', got '%v'", expectedName, f.Name)
 		}
 		if f.Image != expectedImage {
 			t.Fatalf("deployer expected image '%v', got '%v'", expectedImage, f.Image)
 		}
-		return nil
+		return
 	}
 
 	// Invocation
@@ -559,12 +559,12 @@ func TestClient_Update(t *testing.T) {
 		expectedImage = "example.com/alice/testUpdate:latest"
 		builder       = mock.NewBuilder()
 		pusher        = mock.NewPusher()
-		deployer      = mock.NewDeployerWithResult(&fn.DeploymentResult{
+		deployer      = mock.NewDeployerWithResult(fn.DeploymentResult{
 			Status:    fn.Deployed,
 			URL:       "example.com",
 			Namespace: "test-ns",
 		})
-		deployerUpdated = mock.NewDeployerWithResult(&fn.DeploymentResult{
+		deployerUpdated = mock.NewDeployerWithResult(fn.DeploymentResult{
 			Status:    fn.Updated,
 			URL:       "example.com",
 			Namespace: "test-ns",
@@ -608,14 +608,14 @@ func TestClient_Update(t *testing.T) {
 	}
 
 	// Update whose implementaiton verifed the expected name and image
-	deployer.DeployFn = func(f fn.Function) error {
+	deployer.DeployFn = func(_ context.Context, f fn.Function) (res fn.DeploymentResult, err error) {
 		if f.Name != expectedName {
 			t.Fatalf("updater expected name '%v', got '%v'", expectedName, f.Name)
 		}
 		if f.Image != expectedImage {
 			t.Fatalf("updater expected image '%v', got '%v'", expectedImage, f.Image)
 		}
-		return nil
+		return
 	}
 
 	// Invoke the creation, triggering the function delegates, and

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -114,11 +115,11 @@ func testImageAndRegistry(cmdFn commandConstructor, t *testing.T) {
 	// the resultant Function should have the registry populated and image
 	// derived from the name.
 	cmd.SetArgs([]string{"--registry=example.com/alice"})
-	deployer.DeployFn = func(f fn.Function) error {
+	deployer.DeployFn = func(_ context.Context, f fn.Function) (res fn.DeploymentResult, err error) {
 		if f.Registry != "example.com/alice" {
 			t.Fatal("registry flag not provided to deployer")
 		}
-		return nil
+		return
 	}
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -129,11 +130,11 @@ func testImageAndRegistry(cmdFn commandConstructor, t *testing.T) {
 	// Image member set to what was explicitly provided via the --image flag
 	// (not a derived name)
 	cmd.SetArgs([]string{"--image=example.com/alice/myfunc"})
-	deployer.DeployFn = func(f fn.Function) error {
+	deployer.DeployFn = func(_ context.Context, f fn.Function) (res fn.DeploymentResult, err error) {
 		if f.Image != "example.com/alice/myfunc" {
 			t.Fatalf("deployer expected f.Image 'example.com/alice/myfunc', got '%v'", f.Image)
 		}
-		return nil
+		return
 	}
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -143,14 +144,14 @@ func testImageAndRegistry(cmdFn commandConstructor, t *testing.T) {
 	// they should both be plumbed through such that downstream agents (deployer
 	// in this case) see them set on the Function and can act accordingly.
 	cmd.SetArgs([]string{"--registry=example.com/alice", "--image=example.com/alice/subnamespace/myfunc"})
-	deployer.DeployFn = func(f fn.Function) error {
+	deployer.DeployFn = func(_ context.Context, f fn.Function) (res fn.DeploymentResult, err error) {
 		if f.Registry != "example.com/alice" {
 			t.Fatal("registry flag value not seen on the Function by the deployer")
 		}
 		if f.Image != "example.com/alice/subnamespace/myfunc" {
 			t.Fatal("image flag value not seen on the Function by deployer")
 		}
-		return nil
+		return
 	}
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)

--- a/mock/deployer.go
+++ b/mock/deployer.go
@@ -8,27 +8,25 @@ import (
 
 type Deployer struct {
 	DeployInvoked bool
-	DeployFn      func(fn.Function) error
-	DeployResult  *fn.DeploymentResult
+	DeployFn      func(context.Context, fn.Function) (fn.DeploymentResult, error)
 }
 
 func NewDeployer() *Deployer {
 	return &Deployer{
-		DeployFn: func(fn.Function) error { return nil },
-	}
-}
-
-func NewDeployerWithResult(result *fn.DeploymentResult) *Deployer {
-	return &Deployer{
-		DeployFn:     func(fn.Function) error { return nil },
-		DeployResult: result,
+		DeployFn: func(context.Context, fn.Function) (fn.DeploymentResult, error) { return fn.DeploymentResult{}, nil },
 	}
 }
 
 func (i *Deployer) Deploy(ctx context.Context, f fn.Function) (fn.DeploymentResult, error) {
 	i.DeployInvoked = true
-	if i.DeployResult != nil {
-		return *i.DeployResult, i.DeployFn(f)
+	return i.DeployFn(ctx, f)
+}
+
+// NewDeployerWithResult is a convenience method for creating a mock deployer
+// with a deploy function implementation which returns the given result
+// and no error.
+func NewDeployerWithResult(result fn.DeploymentResult) *Deployer {
+	return &Deployer{
+		DeployFn: func(context.Context, fn.Function) (fn.DeploymentResult, error) { return result, nil },
 	}
-	return fn.DeploymentResult{}, i.DeployFn(f)
 }


### PR DESCRIPTION
- :broom: updates the mock deployer's delegate to match the `Deployer` it is mocking.

Expected usage is illustrated within a refactored implementation of `mock.NewDeployerWithResult`.

/kind techdebt