### PR TITLE
feat: registry globally configurable

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -9,7 +9,6 @@ import (
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
-	"knative.dev/func/openshift"
 
 	"knative.dev/func/buildpacks"
 	"knative.dev/func/config"
@@ -257,10 +256,10 @@ type buildConfig struct {
 }
 
 func newBuildConfig() buildConfig {
-	cfg := buildConfig{
+	return buildConfig{
 		Image:        viper.GetString("image"),
 		Path:         getPathFlag(),
-		Registry:     viper.GetString("registry"),
+		Registry:     registry(),
 		Verbose:      viper.GetBool("verbose"), // defined on root
 		Confirm:      viper.GetBool("confirm"),
 		Builder:      viper.GetString("builder"),
@@ -268,10 +267,6 @@ func newBuildConfig() buildConfig {
 		Push:         viper.GetBool("push"),
 		Platform:     viper.GetString("platform"),
 	}
-	if cfg.Registry == "" && openshift.IsOpenShift() {
-		cfg.Registry = openshift.GetDefaultRegistry()
-	}
-	return cfg
 }
 
 // Prompt the user with value of config members, allowing for interaractive changes.

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
 	"knative.dev/client/pkg/util"
-	"knative.dev/func/openshift"
 
 	fn "knative.dev/func"
 	"knative.dev/func/builders"
@@ -569,10 +568,6 @@ func newDeployConfig(cmd *cobra.Command) (deployConfig, error) {
 		GitDir:      viper.GetString("git-dir"),
 		ImageDigest: "", // automatically split off --image if provided below
 	}
-	if c.Registry == "" && openshift.IsOpenShift() {
-		c.Registry = openshift.GetDefaultRegistry()
-	}
-
 	if c.Image, c.ImageDigest, err = parseImage(c.Image); err != nil {
 		return c, err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"knative.dev/func/cmd/templates"
+	"knative.dev/func/config"
 
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
@@ -123,6 +124,16 @@ EXAMPLES
 
 // Helpers
 // ------------------------------------------
+
+// registry to use is that provided as --registry or FUNC_REGISTRY.
+// If not provided, global configuration determines the default to use.
+func registry() string {
+	if r := viper.GetString("registry"); r != "" {
+		return r
+	}
+	cfg, _ := config.NewDefault()
+	return cfg.RegistryDefault()
+}
 
 // interactiveTerminal returns whether or not the currently attached process
 // terminal is interactive.  Used for determining whether or not to

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"knative.dev/func/builders"
 	"knative.dev/func/k8s"
+	"knative.dev/func/openshift"
 )
 
 const (
@@ -40,6 +41,7 @@ type Config struct {
 	Confirm   bool   `yaml:"confirm,omitempty"`
 	Language  string `yaml:"language,omitempty"`
 	Namespace string `yaml:"namespace,omitempty"`
+	Registry  string `yaml:"registry,omitempty"`
 }
 
 // New Config struct with all members set to static defaults.  See NewDefaults
@@ -50,6 +52,22 @@ func New() Config {
 		Language:  DefaultLanguage,
 		Namespace: DefaultNamespace(),
 		// ...
+	}
+}
+
+// RegistyDefault is a convenience method for deferred calculation of a
+// default registry taking into account both the global config file and cluster
+// detection.
+func (c Config) RegistryDefault() string {
+	// If defined, the user's choice for global registry default value is used
+	if c.Registry != "" {
+		return c.Registry
+	}
+	switch {
+	case openshift.IsOpenShift():
+		return openshift.GetDefaultRegistry()
+	default:
+		return ""
 	}
 }
 


### PR DESCRIPTION
:gift: registry globally configurable

Deferred evaluation of cluster type is preserved by making registry a helper in the `cmd` package and a calculated field of the global config struct.

/kind enhancement

```release-notes
Image registry is now globally configurable
```