### PR TITLE
test: fix tests when running in cluster

### DIFF
--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -19,6 +19,7 @@ func TestDelete_Namespace(t *testing.T) {
 
 	// Ensure that the default is "default" when no context can be identified
 	t.Setenv("KUBECONFIG", filepath.Join(cwd(), "nonexistent"))
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
 	cmd := NewDeleteCmd(func(cc ClientConfig, options ...fn.Option) (*fn.Client, func()) {
 		if cc.Namespace != "default" {
 			t.Fatalf("expected 'default', got '%v'", cc.Namespace)

--- a/cmd/describe_test.go
+++ b/cmd/describe_test.go
@@ -97,6 +97,7 @@ func TestDescribe_Namespace(t *testing.T) {
 
 	// Ensure that the default is "default" when no context can be identified
 	t.Setenv("KUBECONFIG", filepath.Join(cwd(), "nonexistent"))
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
 	cmd := NewDescribeCmd(func(cc ClientConfig, _ ...fn.Option) (*fn.Client, func()) {
 		if cc.Namespace != "default" {
 			t.Fatalf("expected 'default', got '%v'", cc.Namespace)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -183,6 +183,7 @@ func TestDefaultNamespace(t *testing.T) {
 	home, cleanup := Mktemp(t)
 	t.Cleanup(cleanup)
 	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "nonexistent"))
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
 	t.Setenv("XDG_CONFIG_HOME", home)
 	if config.DefaultNamespace() != "default" {
 		t.Fatalf("did not receive expected default namespace 'default', got '%v'", config.DefaultNamespace())


### PR DESCRIPTION
# Changes


- :test_tube: Resetting `KUBECONFIG` environment variable is not sufficient if test runs in cluster.
  We also must unset `KUBERNETES_SERVICE_HOST` environment variable, so in-cluster-config won't kick in.

