### PR TITLE
chore(OWNERS): update to new org

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,7 +5,7 @@ approvers:
 - knative-release-leads
 - client-writers
 - func-writers
-- function-wg-leads
+- functions-wg-leads
 
 reviewers:
 - client-writers

--- a/OWNERS
+++ b/OWNERS
@@ -4,9 +4,10 @@ approvers:
 - technical-oversight-committee
 - knative-release-leads
 - client-writers
-- kn-plugin-func-approvers
+- func-writers
+- function-wg-leads
 
 reviewers:
 - client-writers
-- kn-plugin-func-approvers
+- func-reviewers
 


### PR DESCRIPTION
When we moved to knative org, the groups changed. This addresses that.

/kind chore

Signed-off-by: Lance Ball <lball@redhat.com>
