### PR TITLE
fix: mock and noop inconsistency

### DIFF
--- a/client.go
+++ b/client.go
@@ -1013,7 +1013,7 @@ func (n *noopLister) List(context.Context) ([]ListItem, error) { return []ListIt
 type noopDescriber struct{ output io.Writer }
 
 func (n *noopDescriber) Describe(context.Context, string) (Instance, error) {
-	return Instance{}, errors.New("no describer provided")
+	return Instance{}, nil
 }
 
 // PipelinesProvider

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -23,9 +23,7 @@ func TestBuild_ImageFlag(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd := NewBuildCmd(NewClientFactory(func() *fn.Client {
-		return fn.New(fn.WithBuilder(builder))
-	}))
+	cmd := NewBuildCmd(NewTestClient(fn.WithBuilder(builder)))
 	cmd.SetArgs(args)
 
 	// Execute the command
@@ -54,9 +52,7 @@ func TestBuild_RegistryOrImageRequired(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd := NewBuildCmd(NewClientFactory(func() *fn.Client {
-		return fn.New()
-	}))
+	cmd := NewBuildCmd(NewTestClient())
 	cmd.SetArgs([]string{})
 
 	if err := cmd.Execute(); err != nil {
@@ -120,9 +116,8 @@ func TestBuild_Push(t *testing.T) {
 		builder = mock.NewBuilder()
 		pusher  = mock.NewPusher()
 	)
-	cmd := NewBuildCmd(NewClientFactory(func() *fn.Client {
-		return fn.New(fn.WithRegistry(TestRegistry), fn.WithBuilder(builder), fn.WithPusher(pusher))
-	}))
+	cmd := NewBuildCmd(NewTestClient(fn.WithRegistry(TestRegistry), fn.WithBuilder(builder), fn.WithPusher(pusher)))
+
 	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -208,9 +203,7 @@ func TestBuild_RegistryHandling(t *testing.T) {
 		},
 	} {
 		var builder = mock.NewBuilder()
-		cmd := NewBuildCmd(NewClientFactory(func() *fn.Client {
-			return fn.New(fn.WithBuilder(builder))
-		}))
+		cmd := NewBuildCmd(NewTestClient(fn.WithBuilder(builder)))
 		cmd.SetArgs(tc.testFnArgs)
 
 		tci := i + 1

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -42,14 +42,12 @@ type ClientConfig struct {
 // during testing.
 type ClientFactory func(ClientConfig, ...fn.Option) (*fn.Client, func())
 
-// NewClientFactory enables simple instantiation of an fn.Client, such as
-// for mocking during tests or for minimal api usage.
-// Given is a minimal Client constructor, Returned is full ClientFactory
-// with the aspects of normal (full) Client construction (namespace, verbosity
-// level, additional options and the returned cleanup function) ignored.
-func NewClientFactory(n func() *fn.Client) ClientFactory {
+// NewTestClient returns a client factory which will ignore options used,
+// instead using those provided when creating the factory.  This allows
+// for tests to create an entirely default client but with N mocks.
+func NewTestClient(options ...fn.Option) ClientFactory {
 	return func(_ ClientConfig, _ ...fn.Option) (*fn.Client, func()) {
-		return n(), func() {}
+		return fn.New(options...), func() {}
 	}
 }
 

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	fn "knative.dev/func"
+	"knative.dev/func/mock"
+)
+
+// Test_NewTestClient ensures that the convenience method for
+// constructing a mocked client for testing properly considers options:
+// options provided to the factory constructor are considered exaustive,
+// such that the test can force the user of the factory to use specific mocks.
+// In other words, options provided when invoking the factory (such as by
+// a command implementation) are ignored.
+func Test_NewTestClient(t *testing.T) {
+	var (
+		remover   = mock.NewRemover()
+		describer = mock.NewDescriber()
+	)
+
+	// Factory constructor options which should be used when invoking later
+	clientFn := NewTestClient(fn.WithRemover(remover))
+	// Factory should ignore options provided when invoking
+	client, _ := clientFn(ClientConfig{}, fn.WithDescriber(describer))
+
+	// Trigger an invocation of the mocks
+	err := client.Remove(context.Background(), fn.Function{Name: "test"}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Describe(context.Background(), "test", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure the first set of options, held on the factory, were used
+	if !remover.RemoveInvoked {
+		t.Fatalf("factory (outer) options not carried through to final client instance")
+	}
+	// Ensure the second set of options, provided when constructing the
+	// client using the factory, were ignored
+	if describer.DescribeInvoked {
+		t.Fatalf("test client factory should ignore options when invoked.")
+	}
+}

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -86,9 +86,7 @@ func TestDelete_ByName(t *testing.T) {
 
 	// Create a command with a client constructor fn that instantiates a client
 	// with a the mocked remover.
-	cmd := NewDeleteCmd(NewClientFactory(func() *fn.Client {
-		return fn.New(fn.WithRemover(remover))
-	}))
+	cmd := NewDeleteCmd(NewTestClient(fn.WithRemover(remover)))
 	cmd.SetArgs([]string{testname})
 
 	if err := cmd.Execute(); err != nil {
@@ -135,9 +133,7 @@ created: 2021-01-01T00:00:00+00:00
 
 	// Command with a Client constructor that returns  client with the
 	// mocked remover.
-	cmd := NewDeleteCmd(NewClientFactory(func() *fn.Client {
-		return fn.New(fn.WithRemover(remover))
-	}))
+	cmd := NewDeleteCmd(NewTestClient(fn.WithRemover(remover)))
 	cmd.SetArgs([]string{}) // Do not use test command args
 
 	// Execute the command simulating no arguments.
@@ -163,9 +159,7 @@ func TestDelete_NameAndPathExclusivity(t *testing.T) {
 	remover := mock.NewRemover()
 
 	// Command with a Client constructor using the mock remover.
-	cmd := NewDeleteCmd(NewClientFactory(func() *fn.Client {
-		return fn.New(fn.WithRemover(remover))
-	}))
+	cmd := NewDeleteCmd(NewTestClient(fn.WithRemover(remover)))
 
 	// Execute the command simulating the invalid argument combination of both
 	// a path and an explicit name.

--- a/cmd/describe_test.go
+++ b/cmd/describe_test.go
@@ -23,9 +23,7 @@ func TestDescribe_ByName(t *testing.T) {
 		return fn.Instance{}, nil
 	}
 
-	cmd := NewDescribeCmd(NewClientFactory(func() *fn.Client {
-		return fn.New(fn.WithDescriber(describer))
-	}))
+	cmd := NewDescribeCmd(NewTestClient(fn.WithDescriber(describer)))
 	cmd.SetArgs([]string{testname})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -59,9 +57,7 @@ func TestDescribe_ByProject(t *testing.T) {
 		}
 		return
 	}
-	cmd := NewDescribeCmd(NewClientFactory(func() *fn.Client {
-		return fn.New(fn.WithDescriber(describer))
-	}))
+	cmd := NewDescribeCmd(NewTestClient(fn.WithDescriber(describer)))
 	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -72,9 +68,7 @@ func TestDescribe_ByProject(t *testing.T) {
 // and a path will generate an error.
 func TestDescribe_NameAndPathExclusivity(t *testing.T) {
 	d := mock.NewDescriber()
-	cmd := NewDescribeCmd(NewClientFactory(func() *fn.Client {
-		return fn.New(fn.WithDescriber(d))
-	}))
+	cmd := NewDescribeCmd(NewTestClient(fn.WithDescriber(d)))
 	cmd.SetArgs([]string{"-p", "./testpath", "testname"})
 	if err := cmd.Execute(); err == nil {
 		// TODO(lkingland): use a typed error

--- a/cmd/languages_test.go
+++ b/cmd/languages_test.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"testing"
-
-	fn "knative.dev/func"
 )
 
 // TestLanguages_Default ensures that the default behavior of listing
@@ -13,9 +11,7 @@ func TestLanguages_Default(t *testing.T) {
 	_ = fromTempDirectory(t)
 
 	buf := piped(t) // gather output
-	cmd := NewLanguagesCmd(NewClientFactory(func() *fn.Client {
-		return fn.New()
-	}))
+	cmd := NewLanguagesCmd(NewClient)
 	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -40,9 +36,7 @@ func TestLanguages_JSON(t *testing.T) {
 	_ = fromTempDirectory(t)
 
 	buf := piped(t) // gather output
-	cmd := NewLanguagesCmd(NewClientFactory(func() *fn.Client {
-		return fn.New()
-	}))
+	cmd := NewLanguagesCmd(NewClient)
 	cmd.SetArgs([]string{"--json"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -114,13 +114,11 @@ created: 2009-11-10 23:00:00`,
 			// using a command whose client will be populated with mock
 			// builder and mock runner, each of which may be set to error if the
 			// test has an error defined.
-			cmd := NewRunCmd(NewClientFactory(func() *fn.Client {
-				return fn.New(
-					fn.WithRunner(runner),
-					fn.WithBuilder(builder),
-					fn.WithRegistry("ghcr.com/reg"),
-				)
-			}))
+			cmd := NewRunCmd(NewTestClient(
+				fn.WithRunner(runner),
+				fn.WithBuilder(builder),
+				fn.WithRegistry("ghcr.com/reg"),
+			))
 			cmd.SetArgs(tt.args) // Do not use test command args
 
 			// set test case's func.yaml

--- a/cmd/templates_test.go
+++ b/cmd/templates_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
-
-	fn "knative.dev/func"
 )
 
 // TestTemplates_Default ensures that the default behavior is listing all
@@ -15,9 +13,7 @@ func TestTemplates_Default(t *testing.T) {
 	_ = fromTempDirectory(t)
 
 	buf := piped(t) // gather output
-	cmd := NewTemplatesCmd(NewClientFactory(func() *fn.Client {
-		return fn.New()
-	}))
+	cmd := NewTemplatesCmd(NewClient)
 	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -50,9 +46,7 @@ func TestTemplates_JSON(t *testing.T) {
 	_ = fromTempDirectory(t)
 
 	buf := piped(t) // gather output
-	cmd := NewTemplatesCmd(NewClientFactory(func() *fn.Client {
-		return fn.New()
-	}))
+	cmd := NewTemplatesCmd(NewClient)
 	cmd.SetArgs([]string{"--json"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -109,9 +103,7 @@ func TestTemplates_JSON(t *testing.T) {
 func TestTemplates_ByLanguage(t *testing.T) {
 	_ = fromTempDirectory(t)
 
-	cmd := NewTemplatesCmd(NewClientFactory(func() *fn.Client {
-		return fn.New()
-	}))
+	cmd := NewTemplatesCmd(NewClient)
 	cmd.SetArgs([]string{"go"})
 
 	// Test plain text
@@ -150,9 +142,7 @@ http`
 func TestTemplates_ErrTemplateRepoDoesNotExist(t *testing.T) {
 	_ = fromTempDirectory(t)
 
-	cmd := NewTemplatesCmd(NewClientFactory(func() *fn.Client {
-		return fn.New()
-	}))
+	cmd := NewTemplatesCmd(NewClient)
 	cmd.SetArgs([]string{"--repository", "https://github.com/boson-project/repo-does-not-exist"})
 	err := cmd.Execute()
 	assert.Assert(t, err != nil)
@@ -162,9 +152,7 @@ func TestTemplates_ErrTemplateRepoDoesNotExist(t *testing.T) {
 func TestTemplates_WrongRepositoryUrl(t *testing.T) {
 	_ = fromTempDirectory(t)
 
-	cmd := NewTemplatesCmd(NewClientFactory(func() *fn.Client {
-		return fn.New()
-	}))
+	cmd := NewTemplatesCmd(NewClient)
 	cmd.SetArgs([]string{"--repository", "wrong://github.com/boson-project/repo-does-not-exist"})
 	err := cmd.Execute()
 	assert.Assert(t, err != nil)

--- a/docs/generator/main.go
+++ b/docs/generator/main.go
@@ -38,9 +38,7 @@ type TemplateOptions struct {
 // This helper application generates markdown help documents
 func main() {
 	// Create a new client so that we can get builtin repo options
-	factory := cmd.NewClientFactory(func() *fn.Client { return fn.New() })
-	client, done := factory(cmd.ClientConfig{}, func(*fn.Client) {})
-	defer done()
+	client := fn.New()
 
 	// Generate options for templates
 	opts, err := cmd.RuntimeTemplateOptions(client)

--- a/docs/reference/func_deploy.md
+++ b/docs/reference/func_deploy.md
@@ -110,7 +110,7 @@ func deploy
   -g, --git-url string          Repo url to push the code to be built (Env: $FUNC_GIT_URL)
   -h, --help                    help for deploy
   -i, --image string            Full image name in the form [registry]/[namespace]/[name]:[tag]@[digest]. This option takes precedence over --registry. Specifying digest is optional, but if it is given, 'build' and 'push' phases are disabled. (Env: $FUNC_IMAGE)
-  -n, --namespace string        Deploy into a specific namespace. (Env: $FUNC_NAMESPACE)
+  -n, --namespace string        Deploy into a specific namespace. Will use function's current namespace by default if already deployed. (Env: $FUNC_NAMESPACE) (default "default")
   -p, --path string             Path to the project directory (Env: $FUNC_PATH) (default ".")
       --platform string         Target platform to build (e.g. linux/amd64).
   -u, --push                    Push the function image to registry before deploying (Env: $FUNC_PUSH) (default true)

--- a/mock/remover.go
+++ b/mock/remover.go
@@ -8,7 +8,7 @@ type Remover struct {
 }
 
 func NewRemover() *Remover {
-	return &Remover{}
+	return &Remover{RemoveFn: func(string) error { return nil }}
 }
 
 func (r *Remover) Remove(ctx context.Context, name string) error {


### PR DESCRIPTION
:bug: fixes missing default remover function implementation in the remover mock
:bug: fixes incorrect error in noop describer impl
:broom: cmd tests simplification via `NewTestClient`
:broom: simplify docs generator's client instantiation
:broom: regen docs

Test cleanup and a few minor testing-related bugs

/kind bug