### PR TITLE
fix: error instantiating empty function

### DIFF
--- a/function.go
+++ b/function.go
@@ -27,8 +27,7 @@ type Function struct {
 	// Root on disk at which to find/create source and config files.
 	Root string `yaml:"-"`
 
-	// Name of the function.  If not provided, path derivation is attempted when
-	// required (such as for initialization).
+	// Name of the function.
 	Name string `yaml:"name" jsonschema:"pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"`
 
 	// Runtime is the language plus context.  nodejs|go|quarkus|rust etc.
@@ -216,18 +215,12 @@ func NewFunction(path string) (f Function, err error) {
 		errorText += "\n" + "Migration: " + functionMigrationError.Error()
 		return Function{}, errors.New(errorText)
 	}
-	return f, f.Validate()
+	return
 }
 
 // Validate function is logically correct, returning a bundled, and quite
 // verbose, formatted error detailing any issues.
 func (f Function) Validate() error {
-	if f.Name == "" {
-		return errors.New("function name is required")
-	}
-	if f.Runtime == "" {
-		return errors.New("function language runtime is required")
-	}
 	if f.Root == "" {
 		return errors.New("function root path is required")
 	}
@@ -331,7 +324,11 @@ func nameFromPath(path string) string {
 }
 
 // Write aka (save, serialize, marshal) the function to disk at its path.
+// Only valid functions can be written.
 func (f Function) Write() (err error) {
+	if err = f.Validate(); err != nil {
+		return
+	}
 	path := filepath.Join(f.Root, FunctionFile)
 	var bb []byte
 	if bb, err = yaml.Marshal(&f); err != nil {
@@ -472,10 +469,10 @@ func assertEmptyRoot(path string) (err error) {
 // indicate the namespace at the default registry.
 func (f Function) ImageName() (image string, err error) {
 	if f.Registry == "" {
-		return "", errors.New("registry is required")
+		return "", ErrRegistryRequired
 	}
 	if f.Name == "" {
-		return "", errors.New("name is required")
+		return "", ErrNameRequired
 	}
 
 	f.Registry = strings.Trim(f.Registry, "/") // too defensive?

--- a/function_unit_test.go
+++ b/function_unit_test.go
@@ -48,7 +48,7 @@ func TestFunction_Validate(t *testing.T) {
 	// NOTE: this depends on an implementation detail of the package: the yaml
 	// serialization of the Function struct to a known filename. This is why this
 	// test belongs here in the same package as the implementation rather than in
-	// package function_test which treats the function package as a black-box.
+	// package function_test which treats the function package as an opaque-box.
 	path := filepath.Join(root, FunctionFile)
 	bb, err := yaml.Marshal(&f)
 	if err != nil {
@@ -62,7 +62,7 @@ func TestFunction_Validate(t *testing.T) {
 	if f, err = NewFunction(root); err != nil {
 		t.Fatal(err)
 	}
-	if err = f.Validate(); err == nil { // sanity check; not strictly part of this test
+	if err = f.Validate(); err == nil { // axiom check; not strictly part of this test
 		t.Fatal("did not receive an error validating a known-invlaid (incomplete) function")
 	}
 

--- a/instances.go
+++ b/instances.go
@@ -113,5 +113,12 @@ func (s *Instances) Remote(ctx context.Context, name, root string) (Instance, er
 			return Instance{}, err
 		}
 	}
+
+	// If the function has no name, it is not deployed and thus has no remote
+	// instances
+	if f.Name == "" {
+		return Instance{}, nil
+	}
+
 	return s.client.describer.Describe(ctx, f.Name)
 }

--- a/repository.go
+++ b/repository.go
@@ -462,6 +462,9 @@ func (r *Repository) Templates(runtimeName string) ([]Template, error) {
 
 // Runtime of the given name within the repository.
 func (r *Repository) Runtime(name string) (runtime Runtime, err error) {
+	if name == "" {
+		return Runtime{}, ErrRuntimeRequired
+	}
 	for _, runtime = range r.Runtimes {
 		if runtime.Name == name {
 			return runtime, err

--- a/templates.go
+++ b/templates.go
@@ -10,7 +10,8 @@ var (
 	ErrRepositoryNotFound        = errors.New("repository not found")
 	ErrRepositoriesNotDefined    = errors.New("custom template repositories location not specified")
 	ErrTemplatesNotFound         = errors.New("templates path (runtimes) not found")
-	ErrRuntimeNotFound           = errors.New("runtime not found")
+	ErrRuntimeNotFound           = errors.New("language runtime not found")
+	ErrRuntimeRequired           = errors.New("language runtime required")
 	ErrTemplateNotFound          = errors.New("template not found")
 	ErrTemplateMissingRepository = errors.New("template name missing repository prefix")
 )
@@ -94,8 +95,7 @@ func (t *Templates) Get(runtime, fullname string) (Template, error) {
 // of the template (which can define default function fields, builders,
 // buildpacks, etc)
 func (t *Templates) Write(f *Function) error {
-	// Templates require an initially valid function to write
-	// (has name, path, runtime etc)
+	// Ensure the function itself is syntactically valid
 	if err := f.Validate(); err != nil {
 		return err
 	}


### PR DESCRIPTION
:bug: validate function on write
:broom: adds typed errors for required name, registry and runtime
:broom: defers member requirements until needed

In the spirit of "Be permissive on what is accepted, and strict on what is emitted", function validation now happens on write rather than load, defers as much as possible until needed, and moves closer towards validating syntax, not state.

This fixes a bug where a function missing members was unable to be loaded (and thus fixed), forcing a manual edit of func.yaml

/kind bug

```release-notes
Fixes a scenario where the CLI is unable to load invalid func.yaml files and repair them in memory before rewriting
```