### PR TITLE
fix: path default is current working directory

### DIFF
--- a/buildpacks/builder.go
+++ b/buildpacks/builder.go
@@ -135,7 +135,7 @@ func (b *Builder) Build(ctx context.Context, f fn.Function) (err error) {
 
 		cli, dockerHost, err = docker.NewClient(client.DefaultDockerHost)
 		if err != nil {
-			return fmt.Errorf("cannot craete docker client: %w", err)
+			return fmt.Errorf("cannot create docker client: %w", err)
 		}
 		defer cli.Close()
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -258,7 +258,7 @@ type buildConfig struct {
 func newBuildConfig() buildConfig {
 	return buildConfig{
 		Image:        viper.GetString("image"),
-		Path:         getPathFlag(),
+		Path:         viper.GetString("path"),
 		Registry:     registry(),
 		Verbose:      viper.GetBool("verbose"), // defined on root
 		Confirm:      viper.GetBool("confirm"),

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -148,7 +148,7 @@ type configCmdConfig struct {
 
 func newConfigCmdConfig() configCmdConfig {
 	return configCmdConfig{
-		Path:    getPathFlag(),
+		Path:    viper.GetString("path"),
 		Verbose: viper.GetBool("verbose"),
 	}
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -120,11 +120,11 @@ func newDeleteConfig(args []string) deleteConfig {
 		name = args[0]
 	}
 	return deleteConfig{
-		Path:      getPathFlag(),
+		Path:      viper.GetString("path"),
 		Namespace: viper.GetString("namespace"),
 		DeleteAll: viper.GetBool("all"),
-		Name:      deriveName(name, getPathFlag()), // args[0] or derived
-		Verbose:   viper.GetBool("verbose"),        // defined on root
+		Name:      deriveName(name, viper.GetString("path")), // args[0] or derived
+		Verbose:   viper.GetBool("verbose"),                  // defined on root
 	}
 }
 

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -118,7 +118,7 @@ func newDescribeConfig(args []string) describeConfig {
 	c := describeConfig{
 		Namespace: viper.GetString("namespace"),
 		Output:    viper.GetString("output"),
-		Path:      getPathFlag(),
+		Path:      viper.GetString("path"),
 		Verbose:   viper.GetBool("verbose"),
 	}
 	if len(args) > 0 {

--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -224,7 +224,7 @@ type invokeConfig struct {
 
 func newInvokeConfig(newClient ClientFactory) (cfg invokeConfig, err error) {
 	cfg = invokeConfig{
-		Path:        getPathFlag(),
+		Path:        viper.GetString("path"),
 		Target:      viper.GetString("target"),
 		Format:      viper.GetString("format"),
 		ID:          viper.GetString("id"),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -294,18 +294,7 @@ func mergeEnvs(envs []fn.Env, envToUpdate *util.OrderedMap, envToRemove []string
 
 // setPathFlag ensures common text/wording when the --path flag is used
 func setPathFlag(cmd *cobra.Command) {
-	cmd.Flags().StringP("path", "p", ".", "Path to the project directory (Env: $FUNC_PATH)")
-}
-
-// getPathFlag returns the value of the --path flag.
-// The special value '.' is returned as the abolute path to the current
-// working directory.
-func getPathFlag() string {
-	path := viper.GetString("path")
-	if path == "." {
-		path = cwd()
-	}
-	return path
+	cmd.Flags().StringP("path", "p", "", "Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)")
 }
 
 // cwd returns the current working directory or exits 1 printing the error.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -172,7 +172,7 @@ func newRunConfig(cmd *cobra.Command) (cfg runConfig, err error) {
 	}
 	cfg = runConfig{
 		Build:       viper.GetString("build"),
-		Path:        getPathFlag(),
+		Path:        viper.GetString("path"),
 		Verbose:     viper.GetBool("verbose"), // defined on root
 		Registry:    viper.GetString("registry"),
 		EnvToUpdate: envToUpdate,

--- a/docs/reference/func_build.md
+++ b/docs/reference/func_build.md
@@ -49,7 +49,7 @@ func build --builder=pack --builder-image cnbs/sample-builder:bionic
   -c, --confirm                Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)
   -h, --help                   help for build
   -i, --image string           Full image name in the form [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over --registry (Env: $FUNC_IMAGE)
-  -p, --path string            Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -p, --path string            Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)
       --platform string        Target platform to build (e.g. linux/amd64).
   -u, --push                   Attempt to push the function image after being successfully built
   -r, --registry string        Registry + namespace part of the image to build, ex 'quay.io/myuser'.  The full image name is automatically determined (Env: $FUNC_REGISTRY)

--- a/docs/reference/func_config.md
+++ b/docs/reference/func_config.md
@@ -19,7 +19,7 @@ func config
 
 ```
   -h, --help          help for config
-  -p, --path string   Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -p, --path string   Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/func_config_envs.md
+++ b/docs/reference/func_config_envs.md
@@ -19,7 +19,7 @@ func config envs
 ```
   -h, --help            help for envs
   -o, --output string   Output format (human|json) (Env: $FUNC_OUTPUT) (default "human")
-  -p, --path string     Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -p, --path string     Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/func_config_envs_add.md
+++ b/docs/reference/func_config_envs_add.md
@@ -43,7 +43,7 @@ func config envs add --value='{{ configMap:confMapName }}'
 ```
   -h, --help           help for add
       --name string    Name of the environment variable.
-  -p, --path string    Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -p, --path string    Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)
       --value string   Value of the environment variable.
 ```
 

--- a/docs/reference/func_config_envs_remove.md
+++ b/docs/reference/func_config_envs_remove.md
@@ -18,7 +18,7 @@ func config envs remove
 
 ```
   -h, --help          help for remove
-  -p, --path string   Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -p, --path string   Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/func_config_labels.md
+++ b/docs/reference/func_config_labels.md
@@ -18,7 +18,7 @@ func config labels
 
 ```
   -h, --help          help for labels
-  -p, --path string   Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -p, --path string   Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/func_config_labels_add.md
+++ b/docs/reference/func_config_labels_add.md
@@ -21,7 +21,7 @@ func config labels add
 
 ```
   -h, --help          help for add
-  -p, --path string   Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -p, --path string   Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/func_config_labels_remove.md
+++ b/docs/reference/func_config_labels_remove.md
@@ -18,7 +18,7 @@ func config labels remove
 
 ```
   -h, --help          help for remove
-  -p, --path string   Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -p, --path string   Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/func_config_volumes.md
+++ b/docs/reference/func_config_volumes.md
@@ -18,7 +18,7 @@ func config volumes
 
 ```
   -h, --help          help for volumes
-  -p, --path string   Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -p, --path string   Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/func_config_volumes_add.md
+++ b/docs/reference/func_config_volumes_add.md
@@ -18,7 +18,7 @@ func config volumes add
 
 ```
   -h, --help          help for add
-  -p, --path string   Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -p, --path string   Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/func_config_volumes_remove.md
+++ b/docs/reference/func_config_volumes_remove.md
@@ -18,7 +18,7 @@ func config volumes remove
 
 ```
   -h, --help          help for remove
-  -p, --path string   Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -p, --path string   Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/func_delete.md
+++ b/docs/reference/func_delete.md
@@ -36,7 +36,7 @@ func delete -n apps myfunc
   -c, --confirm            Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)
   -h, --help               help for delete
   -n, --namespace string   The namespace in which to delete. (Env: $FUNC_NAMESPACE) (default "default")
-  -p, --path string        Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -p, --path string        Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/func_deploy.md
+++ b/docs/reference/func_deploy.md
@@ -110,8 +110,8 @@ func deploy
   -g, --git-url string          Repo url to push the code to be built (Env: $FUNC_GIT_URL)
   -h, --help                    help for deploy
   -i, --image string            Full image name in the form [registry]/[namespace]/[name]:[tag]@[digest]. This option takes precedence over --registry. Specifying digest is optional, but if it is given, 'build' and 'push' phases are disabled. (Env: $FUNC_IMAGE)
-  -n, --namespace string        Deploy into a specific namespace. (Env: $FUNC_NAMESPACE)
-  -p, --path string             Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -n, --namespace string        Deploy into a specific namespace. Will use function's current namespace by default if already deployed. (Env: $FUNC_NAMESPACE) (default "default")
+  -p, --path string             Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)
       --platform string         Target platform to build (e.g. linux/amd64).
   -u, --push                    Push the function image to registry before deploying (Env: $FUNC_PUSH) (default true)
   -r, --registry string         Registry + namespace part of the image to build, ex 'ghcr.io/myuser'.  The full image name is automatically determined. (Env: $FUNC_REGISTRY)

--- a/docs/reference/func_describe.md
+++ b/docs/reference/func_describe.md
@@ -32,7 +32,7 @@ func info --output yaml --path myotherfunc
   -h, --help               help for describe
   -n, --namespace string   The namespace in which to look for the named function. (Env: $FUNC_NAMESPACE) (default "default")
   -o, --output string      Output format (human|plain|json|xml|yaml|url) (Env: $FUNC_OUTPUT) (default "human")
-  -p, --path string        Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -p, --path string        Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/func_invoke.md
+++ b/docs/reference/func_invoke.md
@@ -102,7 +102,7 @@ func invoke
   -h, --help                  help for invoke
       --id string             ID for the request data. (Env: $FUNC_ID)
   -i, --insecure              Allow insecure server connections when using SSL. (Env: $FUNC_INSECURE)
-  -p, --path string           Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -p, --path string           Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)
       --source string         Source value for the request data. (Env: $FUNC_SOURCE) (default "/boson/fn")
   -t, --target string         Function instance to invoke.  Can be 'local', 'remote' or a URL.  Defaults to auto-discovery if not provided. (Env: $FUNC_TARGET)
       --type string           Type value for the request data. (Env: $FUNC_TYPE) (default "boson.fn")

--- a/docs/reference/func_run.md
+++ b/docs/reference/func_run.md
@@ -45,7 +45,7 @@ func run --build=false
   -b, --build string[="true"]   Build the function. [auto|true|false]. (default "auto")
   -e, --env stringArray         Environment variable to set in the form NAME=VALUE. You may provide this flag multiple times for setting multiple environment variables. To unset, specify the environment variable name followed by a "-" (e.g., NAME-).
   -h, --help                    help for run
-  -p, --path string             Path to the project directory (Env: $FUNC_PATH) (default ".")
+  -p, --path string             Path to the project directory.  Default is current working directory (Env: $FUNC_PATH)
   -r, --registry string         Registry + namespace part of the image if building, ex 'quay.io/myuser' (Env: $FUNC_REGISTRY)
 ```
 

--- a/function.go
+++ b/function.go
@@ -170,9 +170,17 @@ func NewFunctionWith(defaults Function) Function {
 // concerning itself with backwards compatibility. Migrators must therefore
 // selectively consider the minimal validation necessary to enable migration.
 func NewFunction(path string) (f Function, err error) {
-	f.Root = path // path is not persisted, as this is the purview of the FS itself
 	f.Build.BuilderImages = make(map[string]string)
 	f.Deploy.Annotations = make(map[string]string)
+
+	// Path defaults to current working directory, and if provided explicitly
+	// Path must exist and be a directory
+	if path == "" {
+		if path, err = os.Getwd(); err != nil {
+			return
+		}
+	}
+	f.Root = path // path is not persisted, as this is the purview of the FS
 
 	// Path must exist and be a directory
 	fd, err := os.Stat(path)

--- a/function_test.go
+++ b/function_test.go
@@ -15,6 +15,31 @@ import (
 	. "knative.dev/func/testing"
 )
 
+// TestFunction_PathDefault ensures that the default path when instantiating
+// a NewFunciton is to use the current working directory.
+func TestFunction_PathDefault(t *testing.T) {
+	root, rm := Mktemp(t)
+	defer rm()
+
+	var f fn.Function
+	var err error
+
+	if f, err = fn.NewFunction(root); err != nil {
+		t.Fatal(err)
+	}
+	f.Name = "f"
+	f.Runtime = "go"
+	if err := f.Write(); err != nil {
+		t.Fatal(err)
+	}
+	if f, err = fn.NewFunction(""); err != nil {
+		t.Fatal(err)
+	}
+	if f.Name != "f" {
+		t.Fatalf("expected function 'f', got '%v'", f.Name)
+	}
+}
+
 // TestFunction_PathErrors ensures that instantiating a function errors if
 // the path does not exist or is not a directory, but does not require the
 // path contain an initialized function.


### PR DESCRIPTION
:broom: default path is current working directory

Cleans up logic to correctly treat the current working directory as the default effective function path unless a value for path is provided.  Removes all references to "." because the shell is responsible for path expansion.

```release-notes
Ensures current working directory is always the default effective function path
```