### PR TITLE
fix: build prompts

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -137,7 +137,7 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 		}
 		sps := strings.Split(f.Image, "/")
 		updImg := prfx + sps[len(sps)-1]
-		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: image tag '%s' contains different registry than the specified '%s'. It will be overwritten with value '%s'\n", f.Image, f.Registry, updImg)
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: function has current image '%s' which has a different registry than the currently configured registry '%s'. The new image tag will be '%s'.  To use an explicit image, use --image.\n", f.Image, f.Registry, updImg)
 		f.Image = updImg
 	}
 	if f.Build.Builder == "" || cmd.Flags().Changed("builder") {
@@ -177,31 +177,6 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 		fn.WithRegistry(cfg.Registry),
 		fn.WithBuilder(builder))
 	defer done()
-
-	// Default Client Registry, Function Registry or explicit Image is required
-	if client.Registry() == "" && f.Registry == "" && f.Image == "" {
-		// It is not necessary that we validate here, since the client API has
-		// its own validation, but it does give us the opportunity to show a very
-		// cli-specific and detailed error message and (at least for now) default
-		// to an interactive prompt.
-		if interactiveTerminal() {
-			fmt.Println("A registry for function images is required. For example, 'docker.io/tigerteam'.")
-			if err = survey.AskOne(
-				&survey.Input{Message: "Registry for function images:"},
-				&cfg.Registry, survey.WithValidator(
-					NewRegistryValidator(cfg.Path))); err != nil {
-				return ErrRegistryRequired
-			}
-			done()
-			client, done = newClient(ClientConfig{Verbose: cfg.Verbose},
-				fn.WithRegistry(cfg.Registry),
-				fn.WithBuilder(builder))
-			defer done()
-			fmt.Println("Note: building a function the first time will take longer than subsequent builds")
-		} else {
-			return ErrRegistryRequired
-		}
-	}
 
 	// This preemptive write call will be unnecessary when the API is updated
 	// to use Function instances rather than file paths. For now it must write
@@ -273,13 +248,53 @@ func newBuildConfig() buildConfig {
 // Skipped if not in an interactive terminal (non-TTY), or if --confirm false (agree to
 // all prompts) was set (default).
 func (c buildConfig) Prompt() (buildConfig, error) {
-	if !interactiveTerminal() || !c.Confirm {
+	if !interactiveTerminal() {
 		return c, nil
 	}
 
-	imageName := deriveImage(c.Image, c.Registry, c.Path)
+	// If there is no registry nor explicit image name defined, the
+	// Registry prompt is shown whether or not we are in confirm mode.
+	// Otherwise, it is only showin if in confirm mode
+	// NOTE: the default in this latter situation will ignore the current function
+	// value and will always use the value from the config (flag or env variable).
+	// This is not strictly correct and will be fixed when Global Config: Function
+	// Context is available (PR#1416)
+	f, err := fn.NewFunction(c.Path)
+	if err != nil {
+		return c, err
+	}
+	if (f.Registry == "" && c.Registry == "" && c.Image == "") || c.Confirm {
+		fmt.Println("A registry for function images is required. For example, 'docker.io/tigerteam'.")
+		err := survey.AskOne(
+			&survey.Input{Message: "Registry for function images:", Default: c.Registry},
+			&c.Registry,
+			survey.WithValidator(NewRegistryValidator(c.Path)))
+		if err != nil {
+			return c, fn.ErrRegistryRequired
+		}
+		fmt.Println("Note: building a function the first time will take longer than subsequent builds")
+	}
 
-	var qs = []*survey.Question{
+	// Remainder of prompts are optional and only shown if in --confirm mode
+	if !c.Confirm {
+		return c, nil
+	}
+
+	// Image Name Override
+	// Calculate a better image name mesage which shows the value of the final
+	// image name as it will be calclated if an explicit image name is not used.
+	var imagePromptMessageSuffix string
+	if name := deriveImage(c.Image, c.Registry, c.Path); name != "" {
+		imagePromptMessageSuffix = fmt.Sprintf(". if not specified, the default '%v' will be used')", name)
+	}
+
+	qs := []*survey.Question{
+		{
+			Name: "image",
+			Prompt: &survey.Input{
+				Message: fmt.Sprintf("Image name to use (e.g. quay.io/boson/node-sample)%v:", imagePromptMessageSuffix),
+			},
+		},
 		{
 			Name: "path",
 			Prompt: &survey.Input{
@@ -287,34 +302,10 @@ func (c buildConfig) Prompt() (buildConfig, error) {
 				Default: c.Path,
 			},
 		},
-		{
-			Name: "image",
-			Prompt: &survey.Input{
-				Message: "Full image name (e.g. quay.io/boson/node-sample):",
-				Default: imageName,
-			},
-		},
 	}
-	err := survey.Ask(qs, &c)
-	if err != nil {
-		return c, err
-	}
-
-	// if the result of imageName is empty (unset, underivable),
-	// and the value of c.Image is empty (none provided explicitly by flag, env
-	// variable or prompt), then try one more time to get enough to to derive an
-	// image name: explicitly ask for registry.
-	if imageName == "" && c.Image == "" {
-		qs = []*survey.Question{
-			{
-				Name: "registry",
-				Prompt: &survey.Input{
-					Message: "Registry for function image:",
-					Default: c.Registry, // This should be innefectual
-				},
-			},
-		}
-	}
+	//
+	// TODO(lkingland): add confirmation prompts for other config members here
+	//
 	err = survey.Ask(qs, &c)
 	return c, err
 }

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -11,7 +11,8 @@ import (
 	"knative.dev/func/mock"
 )
 
-// TestBuild_ImageFlag ensures that the image flag is used when specified.
+// TestBuild_ImageFlag ensures that the image flag is used when specified, and
+// is used in place of a configured registry.
 func TestBuild_ImageFlag(t *testing.T) {
 	var (
 		args    = []string{"--image", "docker.io/tigerteam/foo"}
@@ -19,7 +20,7 @@ func TestBuild_ImageFlag(t *testing.T) {
 	)
 	root := fromTempDirectory(t)
 
-	if err := fn.New().Create(fn.Function{Runtime: "go", Root: root, Registry: TestRegistry}); err != nil {
+	if err := fn.New().Create(fn.Function{Runtime: "go", Root: root}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -27,6 +28,7 @@ func TestBuild_ImageFlag(t *testing.T) {
 	cmd.SetArgs(args)
 
 	// Execute the command
+	// Should not error that registry is missing because --image was provided.
 	err := cmd.Execute()
 	if err != nil {
 		t.Fatal(err)
@@ -56,7 +58,7 @@ func TestBuild_RegistryOrImageRequired(t *testing.T) {
 	cmd.SetArgs([]string{})
 
 	if err := cmd.Execute(); err != nil {
-		if !errors.Is(err, ErrRegistryRequired) {
+		if !errors.Is(err, fn.ErrRegistryRequired) {
 			t.Fatalf("expected ErrRegistryRequired, got error: %v", err)
 		}
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -286,17 +286,17 @@ func runDeploy(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 		if interactiveTerminal() {
 			// to be consistent, this should throw an error, with the registry
 			// prompting code placed within cfg.Prompt and triggered with --confirm
-			fmt.Println("A registry for function images is required. For example, 'docker.io/tigerteam'.")
+			fmt.Println("Please choose a registry for the function image. For example, 'docker.io/tigerteam'.")
 			if err = survey.AskOne(
 				&survey.Input{Message: "Registry for function images:"},
 				&cfg.Registry, survey.WithValidator(
 					NewRegistryValidator(cfg.Path))); err != nil {
-				return ErrRegistryRequired
+				return fn.ErrRegistryRequired
 			}
 			fmt.Println("Note: building a function the first time will take longer than subsequent builds")
 		}
 
-		return ErrRegistryRequired
+		return fn.ErrRegistryRequired
 	}
 
 	// Perform the deployment either remote or local.
@@ -352,7 +352,7 @@ func NewRegistryValidator(path string) survey.Validator {
 
 		// if the value passed in is the zero value of the appropriate type
 		if len(val.(string)) == 0 {
-			return ErrRegistryRequired
+			return fn.ErrRegistryRequired
 		}
 
 		f, err := fn.NewFunction(path)
@@ -751,8 +751,3 @@ func namespaceWarnings(cfg deployConfig, cmd *cobra.Command) {
 		fmt.Fprintf(out, "Warning: function is in namespace '%s', but requested namespace is '%s'. Continuing with deployment to '%v'.\n", current, target, target)
 	}
 }
-
-var ErrRegistryRequired = errors.New(`A container registry is required.  For example:
---registry docker.io/myusername
-
-To run the command in an interactive mode, use --confirm (-c)`)

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -66,7 +66,7 @@ func testRegistryOrImageRequired(cmdFn commandConstructor, t *testing.T) {
 	// instantiated with a default registry, a ErrRegistryRequired is expected.
 	cmd.SetArgs([]string{}) // this explicit clearing of args may not be necessary
 	if err := cmd.Execute(); err != nil {
-		if !errors.Is(err, ErrRegistryRequired) {
+		if !errors.Is(err, fn.ErrRegistryRequired) {
 			t.Fatalf("expected ErrRegistryRequired, got error: %v", err)
 		}
 	}


### PR DESCRIPTION
:broom: build prompts cleanup

Fixes a few small bugs with build prompts by embracing the system:  there is a dedicated method for prompting a user: a command config's `.Prompt()` method.  Its use results in overall reduction in complexity and removal of some small bugs when combining with --confirm.

This primary purpose of this cleanup, however, is to assists in the integration of global config's function context (PR 1416) into the runBuild method by reducing the logic handled therein

/kind cleanup