### PR TITLE
[release-1.8] Backport Node.js and TypeScript template updates to release 1.8

### DIFF
--- a/buildpacks/builder.go
+++ b/buildpacks/builder.go
@@ -32,10 +32,13 @@ var (
 		"springboot": "gcr.io/paketo-buildpacks/builder:base",
 	}
 
+	// Ensure that all entries in this list are terminated with a trailing "/"
+	// See GHSA-5336-2g3f-9g3m for details
 	trustedBuilderImagePrefixes = []string{
-		"quay.io/boson",
-		"gcr.io/paketo-buildpacks",
-		"docker.io/paketobuildpacks",
+		"quay.io/boson/",
+		"gcr.io/paketo-buildpacks/",
+		"docker.io/paketobuildpacks/",
+		"ghcr.io/vmware-tanzu/function-buildpacks-for-knative/",
 	}
 )
 
@@ -121,6 +124,10 @@ func (b *Builder) Build(ctx context.Context, f fn.Function) (err error) {
 	// only trust our known builders
 	opts.TrustBuilder = func(_ string) bool {
 		for _, v := range trustedBuilderImagePrefixes {
+			// Ensure that all entries in this list are terminated with a trailing "/"
+			if !strings.HasSuffix(v, "/") {
+				v = v + "/"
+			}
 			if strings.HasPrefix(opts.Builder, v) {
 				return true
 			}

--- a/buildpacks/builder_test.go
+++ b/buildpacks/builder_test.go
@@ -9,6 +9,43 @@ import (
 	"knative.dev/func/builders"
 )
 
+// Test_BuilderImageUntrusted ensures that only known builder images
+// are to be considered trusted.
+func Test_BuilderImageUntrusted(t *testing.T) {
+	var (
+		i = &mockImpl{}
+		b = NewBuilder(WithImpl(i))
+		f = fn.Function{Runtime: "node"}
+	)
+
+	var untrusted = []string{
+		// Check prefixes that end in a slash
+		"quay.io/bosonhack/",
+		"gcr.io/paketo-buildpackshack/",
+		// And those that don't
+		"docker.io/paketobuildpackshack",
+		"ghcr.io/vmware-tanzu/function-buildpacks-for-knativehack",
+	}
+
+	for _, builder := range untrusted {
+		f.Build = fn.BuildSpec{
+			BuilderImages: map[string]string{
+				builders.Pack: builder,
+			},
+		}
+		i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
+			if opts.TrustBuilder("") != false {
+				t.Fatalf("expected pack builder image %v to be untrusted", f.Build.BuilderImages[builders.Pack])
+			}
+			return nil
+		}
+
+		if err := b.Build(context.Background(), f); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 // Test_BuilderImageTrusted ensures that only known builder images
 // are to be considered trusted.
 func Test_BuilderImageTrusted(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- 🧹 backport 64e7452c9a84ee6e2446ebed9e89856e157bb866
- 🧹 backport 06693859be3275eff7cc5879b7cc29f803115eda

/kind chore

```release-notes
Updates Node.js and TypeScript templates to latest faas-js-runtime and cloudevents modules
```