### PR TITLE
Add VMware builder as trusted

### DIFF
--- a/buildpacks/builder.go
+++ b/buildpacks/builder.go
@@ -38,6 +38,7 @@ var (
 		"quay.io/boson",
 		"gcr.io/paketo-buildpacks",
 		"docker.io/paketobuildpacks",
+		"ghcr.io/vmware-tanzu/function-buildpacks-for-knative",
 	}
 
 	v330 = semver.MustParse("v3.3.0") // for checking podman version


### PR DESCRIPTION
Adding VMware function builders as trusted.

Fixes https://github.com/knative/func/issues/1379

```release-notes
adds VMWare function builder as trusted
```