### PR TITLE
chore: improve func version verbose mode to display image referenced …

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 
 	"knative.dev/func/cmd/templates"
 	"knative.dev/func/config"
+	"knative.dev/func/k8s"
 
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
@@ -383,7 +384,12 @@ func (v Version) StringVerbose() string {
 	if date == "" {
 		date = time.Now().Format(time.RFC3339)
 	}
-	return fmt.Sprintf("%s-%s-%s", vers, hash, date)
+	funcVersion := fmt.Sprintf("%s-%s-%s", vers, hash, date)
+	return fmt.Sprintf("Version: %s\n"+
+		"SocatImage: %s\n"+
+		"TarImage: %s", funcVersion,
+		k8s.SocatImage,
+		k8s.TarImage)
 }
 
 // surveySelectDefault returns 'value' if defined and exists in 'options'.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -214,24 +214,28 @@ func TestRoot_CommandNameParameterized(t *testing.T) {
 
 func TestVerbose(t *testing.T) {
 	tests := []struct {
-		name string
-		args []string
-		want string
+		name   string
+		args   []string
+		want   string
+		wantLF int
 	}{
 		{
-			name: "verbose as version's flag",
-			args: []string{"version", "-v"},
-			want: "v0.42.0-cafe-1970-01-01\n",
+			name:   "verbose as version's flag",
+			args:   []string{"version", "-v"},
+			want:   "Version: v0.42.0-cafe-1970-01-01",
+			wantLF: 3,
 		},
 		{
-			name: "no verbose",
-			args: []string{"version"},
-			want: "v0.42.0\n",
+			name:   "no verbose",
+			args:   []string{"version"},
+			want:   "v0.42.0",
+			wantLF: 1,
 		},
 		{
-			name: "verbose as root's flag",
-			args: []string{"--verbose", "version"},
-			want: "v0.42.0-cafe-1970-01-01\n",
+			name:   "verbose as root's flag",
+			args:   []string{"--verbose", "version"},
+			want:   "Version: v0.42.0-cafe-1970-01-01",
+			wantLF: 3,
 		},
 	}
 	for _, tt := range tests {
@@ -254,8 +258,12 @@ func TestVerbose(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if out.String() != tt.want {
-				t.Errorf("expected output: %q but got: %q", tt.want, out.String())
+			outLines := strings.Split(out.String(), "\n")
+			if len(outLines)-1 != tt.wantLF {
+				t.Errorf("expected output with %v line breaks but got %v:", tt.wantLF, len(outLines)-1)
+			}
+			if outLines[0] != tt.want {
+				t.Errorf("expected output: %q but got: %q", tt.want, outLines[0])
 			}
 		})
 	}


### PR DESCRIPTION
# Changes

- :gift: Dumping images references (socat and tar) on func version command (on verbose mode) 

/kind cleanup

With this PR, the output of the command will look similar to the below:
```
$ ./func version --verbose
Version: tip-148f30ae-20221115T202406Z
SocatImage: quay.io/boson/alpine-socat:1.7.4.3-r1-non-root
TarImage: quay.io/boson/alpine-socat:1.7.4.3-r1-non-root
```