### PR TITLE
fix: add default PodSecurityContext to the uploader (#1432)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
-	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/semver v1.5.0
 	github.com/Microsoft/go-winio v0.5.2
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/alecthomas/jsonschema v0.0.0-20210526225647-edb03dcab7bc

--- a/k8s/dialer.go
+++ b/k8s/dialer.go
@@ -135,6 +135,7 @@ func (c *contextDialer) startDialerPod(ctx context.Context) (err error) {
 			Annotations: nil,
 		},
 		Spec: coreV1.PodSpec{
+			SecurityContext: defaultPodSecurityContext(),
 			Containers: []coreV1.Container{
 				{
 					Name:            c.podName,

--- a/k8s/persistent_volumes.go
+++ b/k8s/persistent_volumes.go
@@ -114,6 +114,7 @@ func runWithVolumeMounted(ctx context.Context, podImage string, podCommand []str
 			Annotations: nil,
 		},
 		Spec: corev1.PodSpec{
+			SecurityContext: defaultPodSecurityContext(),
 			Containers: []corev1.Container{
 				{
 					Name:       podName,

--- a/k8s/security_context.go
+++ b/k8s/security_context.go
@@ -8,6 +8,17 @@ import (
 
 var oneTwentyFour = semver.MustParse("1.24")
 
+func defaultPodSecurityContext() *corev1.PodSecurityContext {
+	// change ownership of the mounted volume to the first non-root user uid=1000
+	runAsUser := int64(1000)
+	runAsGroup := int64(1000)
+	return &corev1.PodSecurityContext{
+		RunAsUser:  &runAsUser,
+		RunAsGroup: &runAsGroup,
+		FSGroup:    &runAsGroup,
+	}
+}
+
 func defaultSecurityContext(client *kubernetes.Clientset) *corev1.SecurityContext {
 	runAsNonRoot := true
 	sc := &corev1.SecurityContext{


### PR DESCRIPTION
Adds `PodSecurityContext` with defined non-root `uid` and `gid` and `fsGroup`, so that the ownership of a volume is changed and the non-cluster user can operate on the volume without "permission denied" error (see #1432 for more).