### PR TITLE
[release-1.8]: Fixes GHSA-5336-2g3f-9g3m

### DIFF
--- a/buildpacks/builder.go
+++ b/buildpacks/builder.go
@@ -32,10 +32,13 @@ var (
 		"springboot": "gcr.io/paketo-buildpacks/builder:base",
 	}
 
+	// Ensure that all entries in this list are terminated with a trailing "/"
+	// See GHSA-5336-2g3f-9g3m for details
 	trustedBuilderImagePrefixes = []string{
-		"quay.io/boson",
-		"gcr.io/paketo-buildpacks",
-		"docker.io/paketobuildpacks",
+		"quay.io/boson/",
+		"gcr.io/paketo-buildpacks/",
+		"docker.io/paketobuildpacks/",
+		"ghcr.io/vmware-tanzu/function-buildpacks-for-knative/",
 	}
 )
 
@@ -121,6 +124,10 @@ func (b *Builder) Build(ctx context.Context, f fn.Function) (err error) {
 	// only trust our known builders
 	opts.TrustBuilder = func(_ string) bool {
 		for _, v := range trustedBuilderImagePrefixes {
+			// Ensure that all entries in this list are terminated with a trailing "/"
+			if !strings.HasSuffix(v, "/") {
+				v = v + "/"
+			}
 			if strings.HasPrefix(opts.Builder, v) {
 				return true
 			}

--- a/buildpacks/builder_test.go
+++ b/buildpacks/builder_test.go
@@ -9,6 +9,43 @@ import (
 	"knative.dev/func/builders"
 )
 
+// Test_BuilderImageUntrusted ensures that only known builder images
+// are to be considered trusted.
+func Test_BuilderImageUntrusted(t *testing.T) {
+	var (
+		i = &mockImpl{}
+		b = NewBuilder(WithImpl(i))
+		f = fn.Function{Runtime: "node"}
+	)
+
+	var untrusted = []string{
+		// Check prefixes that end in a slash
+		"quay.io/bosonhack/",
+		"gcr.io/paketo-buildpackshack/",
+		// And those that don't
+		"docker.io/paketobuildpackshack",
+		"ghcr.io/vmware-tanzu/function-buildpacks-for-knativehack",
+	}
+
+	for _, builder := range untrusted {
+		f.Build = fn.BuildSpec{
+			BuilderImages: map[string]string{
+				builders.Pack: builder,
+			},
+		}
+		i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
+			if opts.TrustBuilder("") != false {
+				t.Fatalf("expected pack builder image %v to be untrusted", f.Build.BuilderImages[builders.Pack])
+			}
+			return nil
+		}
+
+		if err := b.Build(context.Background(), f); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 // Test_BuilderImageTrusted ensures that only known builder images
 // are to be considered trusted.
 func Test_BuilderImageTrusted(t *testing.T) {


### PR DESCRIPTION
# Changes

## GHSA-5336-2g3f-9g3m

The trusted builder prefixes should end with a slash in order to prevent malicious parties from using a builder such as `quay.io/bosonhacks/rootkit`. Should be cherry-picked to `release-1.8`

/kind fix

Signed-off-by: Lance Ball <lball@redhat.com>

**Release Note**

```release-note
❗ Fixes: https://github.com/knative/func/security/advisories/GHSA-5336-2g3f-9g3m
```
