### PR TITLE
cleanup(buildpacks): tweak TrustedBuilder()

### DIFF
--- a/buildpacks/builder.go
+++ b/buildpacks/builder.go
@@ -131,7 +131,6 @@ func (b *Builder) Build(ctx context.Context, f fn.Function) (err error) {
 			if !strings.HasSuffix(v, "/") {
 				v = v + "/"
 			}
-			fmt.Println("Checking if", b, "starts with", v)
 			if strings.HasPrefix(b, v) {
 				return true
 			}

--- a/buildpacks/builder.go
+++ b/buildpacks/builder.go
@@ -125,13 +125,14 @@ func (b *Builder) Build(ctx context.Context, f fn.Function) (err error) {
 	}
 
 	// only trust our known builders
-	opts.TrustBuilder = func(_ string) bool {
+	opts.TrustBuilder = func(b string) bool {
 		for _, v := range trustedBuilderImagePrefixes {
 			// Ensure that all entries in this list are terminated with a trailing "/"
 			if !strings.HasSuffix(v, "/") {
 				v = v + "/"
 			}
-			if strings.HasPrefix(opts.Builder, v) {
+			fmt.Println("Checking if", b, "starts with", v)
+			if strings.HasPrefix(b, v) {
 				return true
 			}
 		}

--- a/buildpacks/builder.go
+++ b/buildpacks/builder.go
@@ -125,18 +125,7 @@ func (b *Builder) Build(ctx context.Context, f fn.Function) (err error) {
 	}
 
 	// only trust our known builders
-	opts.TrustBuilder = func(b string) bool {
-		for _, v := range trustedBuilderImagePrefixes {
-			// Ensure that all entries in this list are terminated with a trailing "/"
-			if !strings.HasSuffix(v, "/") {
-				v = v + "/"
-			}
-			if strings.HasPrefix(b, v) {
-				return true
-			}
-		}
-		return false
-	}
+	opts.TrustBuilder = TrustBuilder
 
 	var impl = b.impl
 	// Instantiate the pack build client implementation
@@ -172,6 +161,21 @@ func (b *Builder) Build(ctx context.Context, f fn.Function) (err error) {
 		}
 	}
 	return
+}
+
+// TrustBuilder determines whether the builder image should be trusted
+// based on a set of trusted builder image registry prefixes.
+func TrustBuilder(b string) bool {
+	for _, v := range trustedBuilderImagePrefixes {
+		// Ensure that all entries in this list are terminated with a trailing "/"
+		if !strings.HasSuffix(v, "/") {
+			v = v + "/"
+		}
+		if strings.HasPrefix(b, v) {
+			return true
+		}
+	}
+	return false
 }
 
 // Builder Image chooses the correct builder image or defaults.

--- a/buildpacks/builder_test.go
+++ b/buildpacks/builder_test.go
@@ -34,7 +34,7 @@ func Test_BuilderImageUntrusted(t *testing.T) {
 			},
 		}
 		i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
-			if opts.TrustBuilder("") != false {
+			if opts.TrustBuilder(builder) != false {
 				t.Fatalf("expected pack builder image %v to be untrusted", f.Build.BuilderImages[builders.Pack])
 			}
 			return nil
@@ -62,7 +62,7 @@ func Test_BuilderImageTrusted(t *testing.T) {
 			},
 		}
 		i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
-			if opts.TrustBuilder("") != true {
+			if opts.TrustBuilder(builder) != true {
 				t.Fatalf("expected pack builder image %v to be trusted", f.Build.BuilderImages[builders.Pack])
 			}
 			return nil

--- a/buildpacks/builder_test.go
+++ b/buildpacks/builder_test.go
@@ -12,12 +12,6 @@ import (
 // Test_BuilderImageUntrusted ensures that only known builder images
 // are to be considered trusted.
 func Test_BuilderImageUntrusted(t *testing.T) {
-	var (
-		i = &mockImpl{}
-		b = NewBuilder(WithImpl(i))
-		f = fn.Function{Runtime: "node"}
-	)
-
 	var untrusted = []string{
 		// Check prefixes that end in a slash
 		"quay.io/bosonhack/",
@@ -28,20 +22,8 @@ func Test_BuilderImageUntrusted(t *testing.T) {
 	}
 
 	for _, builder := range untrusted {
-		f.Build = fn.BuildSpec{
-			BuilderImages: map[string]string{
-				builders.Pack: builder,
-			},
-		}
-		i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
-			if opts.TrustBuilder(builder) != false {
-				t.Fatalf("expected pack builder image %v to be untrusted", f.Build.BuilderImages[builders.Pack])
-			}
-			return nil
-		}
-
-		if err := b.Build(context.Background(), f); err != nil {
-			t.Fatal(err)
+		if TrustBuilder(builder) {
+			t.Fatalf("expected pack builder image %v to be untrusted", builder)
 		}
 	}
 }
@@ -49,27 +31,9 @@ func Test_BuilderImageUntrusted(t *testing.T) {
 // Test_BuilderImageTrusted ensures that only known builder images
 // are to be considered trusted.
 func Test_BuilderImageTrusted(t *testing.T) {
-	var (
-		i = &mockImpl{}
-		b = NewBuilder(WithImpl(i))
-		f = fn.Function{Runtime: "node"}
-	)
-
 	for _, builder := range trustedBuilderImagePrefixes {
-		f.Build = fn.BuildSpec{
-			BuilderImages: map[string]string{
-				builders.Pack: builder,
-			},
-		}
-		i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
-			if opts.TrustBuilder(builder) != true {
-				t.Fatalf("expected pack builder image %v to be trusted", f.Build.BuilderImages[builders.Pack])
-			}
-			return nil
-		}
-
-		if err := b.Build(context.Background(), f); err != nil {
-			t.Fatal(err)
+		if !TrustBuilder(builder) {
+			t.Fatalf("expected pack builder image %v to be trusted", builder)
 		}
 	}
 }


### PR DESCRIPTION
# Changes

We have been relying on a closure to validate the builder prefix in the builder image name provided to `pack`. This change ensures that we use the builder image which `pack` is using, whether it's what we provided in options or not.

/kind cleanup

Signed-off-by: Lance Ball <lball@redhat.com>
