### PR TITLE
Fix bug where user's local .gitignore file would be rewritten everytime `func run` was ran, and also a small but nice enhancement by reducing binary size by 25%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ HASH    := $(shell git rev-parse --short HEAD 2>/dev/null)
 VTAG    := $(shell git tag --points-at HEAD | head -1)
 VTAG    := $(shell [ -z $(VTAG) ] && echo $(ETAG) || echo $(VTAG))
 VERS    ?= $(shell [ -z $(VTAG) ] && echo 'tip' || echo $(VTAG) )
-LDFLAGS := "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.hash=$(HASH)"
+LDFLAGS := "-s -w -X main.date=$(DATE) -X main.vers=$(VERS) -X main.hash=$(HASH)"
 
 # All Code prerequisites, including generated files, etc.
 CODE := $(shell find . -name '*.go') zz_filesystem_generated.go go.mod schema/func_yaml-schema.json

--- a/docs/building-functions/on_cluster_build.md
+++ b/docs/building-functions/on_cluster_build.md
@@ -1,33 +1,56 @@
 # Building Functions on Cluster with Tekton Pipelines
 
-This guide describes how you can build a Function on Cluster with Tekton Pipelines. The on cluster build is enabled by fetching Function source code from a remote Git repository. Buildpacks or S2I builder strategy can be used to build the Function image.
+This guide describes how you can build a Function on Cluster with
+Tekton Pipelines. The on cluster build is enabled by fetching Function
+source code from a remote Git repository. Buildpacks or S2I builder strategy
+can be used to build the Function image.
 
 ## Prerequisite
-1. Install Tekton Pipelines on the cluster. Please refer to [Tekton Pipelines documentation](https://github.com/tektoncd/pipeline/blob/main/docs/install.md) or run the following command:
+
+Install Tekton Pipelines on the cluster. Please refer to
+[Tekton Pipelines documentation](https://github.com/tektoncd/pipeline/blob/main/docs/install.md)
+or run the following command:
+
 ```bash
 kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
 ```
 
 ## Enabling a namespace to run Function related Tekton Pipelines
-In each namespace that you would like to run Pipelines and deploy a Function you need to create or install the following resources.
+
+In each namespace that you would like to run Pipelines and deploy a Function you
+need to create or install the following resources.
+
 1. Install the Git Clone Tekton Task to fetch the Function source code:
-```bash
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/git-clone/0.4/git-clone.yaml
-```
-2. Install a Tekton Task responsible for building the Function, based on the builder preference (Buildpacks or S2I)
-   1. For Buildpacks builder install the Functions Buildpacks Tekton Task:
-      ```bash
-      kubectl apply -f https://raw.githubusercontent.com/knative-sandbox/kn-plugin-func/main/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
-      ```
-   2. For S2I builder install the S2I task:
-      ```bash
-      kubectl apply -f https://raw.githubusercontent.com/knative-sandbox/kn-plugin-func/main/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
-      ```
-3. Install the `kn func` Deploy Tekton Task to be able to deploy the Function on in the Pipeline:
-```bash
-kubectl apply -f https://raw.githubusercontent.com/knative-sandbox/kn-plugin-func/main/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
-```
-4. Add permission to deploy on Knative to `default` Service Account: (This is not needed on OpenShift)
+
+   ```bash
+   kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/git-clone/0.4/git-clone.yaml
+   ```
+
+2. Install a Tekton Task responsible for building the Function, based on the
+   builder preference (Buildpacks or S2I)
+
+   - For Buildpacks builder install the Functions Buildpacks Tekton Task:
+
+   ```bash
+   kubectl apply -f https://raw.githubusercontent.com/knative-sandbox/kn-plugin-func/main/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
+   ```
+
+   - For S2I builder install the S2I task:
+
+   ```bash
+   kubectl apply -f https://raw.githubusercontent.com/knative-sandbox/kn-plugin-func/main/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+   ```
+
+3. Install the `kn func` Deploy Tekton Task to be able to deploy the Function on
+   in the Pipeline:
+
+   ```bash
+   kubectl apply -f https://raw.githubusercontent.com/knative-sandbox/kn-plugin-func/main/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+   ```
+
+4. Add permission to deploy on Knative to `default` Service Account:
+   (This is not needed on OpenShift)
+
 ```bash
 export NAMESPACE=<INSERT_YOUR_NAMESPACE>
 kubectl create clusterrolebinding $NAMESPACE:knative-serving-namespaced-admin \
@@ -35,62 +58,84 @@ kubectl create clusterrolebinding $NAMESPACE:knative-serving-namespaced-admin \
 ```
 
 ## Building a Function on Cluster
-1. Create a Function and implement the business logic
-```bash
-kn func create my-function
-```
-2. Get a reference to the remote Git repository that will host your Function source code (eg. `https://github.com/my-repo/my-function.git`)
-3. Initialize a Git repository in your Function project and add a reference to the remote repo
-```bash
-cd my-function
-git init
-git branch -M main
-git remote add origin git@github.com:my-repo/my-function.git
-```
-4. Update the Function configuration in `func.yaml` to enable on cluster builds for the Git repository:
-```yaml
-build: git                                          # required, specify `git` build type
-git:
-  url: https://github.com/my-repo/my-function.git   # required, git repository with the function source code
-  revision: main                                    # optional, git revision to be used (branch, tag, commit)
-  # contextDir: myfunction                          # optional, needed only if the function is not located
-                                                    # in the repository root folder
-```
-5. Implement the business logic of your Function, then commit and push changes
-```bash
-git add .
-git commit -a -m "implementing my-function"
-git push origin main
-```
-6. Deploy your Function
-```bash
-kn func deploy
-```
-If you are not logged in the container registry referenced in your function configuration,
-you will prompted to provide credentials for the remote container registry that hosts the Function image. You should see output similar to the following:
-```bash
-$ kn func deploy
-🕕 Creating Pipeline resources
-Please provide credentials for image registry used by Pipeline.
-? Server: https://index.docker.io/v1/
-? Username: my-repo
-? Password: ********
-   Function deployed at URL: http://test-function.default.svc.cluster.local
-```
 
-7. To update your Function, commit and push new changes, then run `kn func deploy` again.
+1. Create a Function and implement the business logic
+
+   ```bash
+   kn func create my-function
+   ```
+
+2. Get a reference to the remote Git repository that will host your Function
+   source code (e.g. `https://github.com/my-repo/my-function.git`)
+3. Initialize a Git repository in your Function project and add a reference
+   to the remote repo
+
+   ```bash
+   cd my-function
+   git init
+   git branch -M main
+   git remote add origin git@github.com:my-repo/my-function.git
+   ```
+
+4. Update the Function configuration in `func.yaml` to enable on cluster builds
+   for the Git repository:
+
+   ```yaml
+   build: git # required, specify `git` build type
+   git:
+   url: https://github.com/my-repo/my-function.git # required, git repository with the function source code
+   revision: main # optional, git revision to be used (branch, tag, commit)
+   # contextDir: myfunction                          # optional, needed only if the function is not located
+   # in the repository root folder
+   ```
+
+5. Implement the business logic of your Function, then commit and push changes
+
+   ```bash
+   git add .
+   git commit -a -m "implementing my-function"
+   git push origin main
+   ```
+
+6. Deploy your Function
+
+   ```bash
+   kn func deploy
+   ```
+
+   If you are not logged in the container registry referenced in your function configuration,
+   you will prompted to provide credentials for the remote container registry that
+   hosts the Function image. You should see output similar to the following:
+
+   ```bash
+   $ kn func deploy
+   🕕 Creating Pipeline resources
+   Please provide credentials for image registry used by Pipeline.
+   ? Server: https://index.docker.io/v1/
+   ? Username: my-repo
+   ? Password: ********
+   Function deployed at URL: http://test-function.default.svc.cluster.local
+   ```
+
+7. To update your Function, commit and push new changes, then run
+   `kn func deploy` again.
 
 ## Uninstall and clean-up
-1. In each namespace where Pipelines and Functions were deployed, uninstall following resources:
-```bash
-export NAMESPACE=<INSERT_YOUR_NAMESPACE>
-kubectl delete clusterrolebinding $NAMESPACE:knative-serving-namespaced-admin
-kubectl delete task.tekton.dev git-clone
-kubectl delete task.tekton.dev func-buildpacks
-kubectl delete task.tekton.dev func-s2i
-kubectl delete task.tekton.dev func-deploy
-```
+
+1. In each namespace where Pipelines and Functions were deployed,
+   uninstall following resources:
+
+   ```bash
+   export NAMESPACE=<INSERT_YOUR_NAMESPACE>
+   kubectl delete clusterrolebinding $NAMESPACE:knative-serving-namespaced-admin
+   kubectl delete task.tekton.dev git-clone
+   kubectl delete task.tekton.dev func-buildpacks
+   kubectl delete task.tekton.dev func-s2i
+   kubectl delete task.tekton.dev func-deploy
+   ```
+
 2. Uninstall Tekton Pipelines
-```bash
-kubectl delete -f https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
-```
+
+   ```bash
+   kubectl delete -f https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+   ```

--- a/docs/function-templates/golang.md
+++ b/docs/function-templates/golang.md
@@ -4,7 +4,7 @@ When creating a Go (Golang) function using the `func` CLI, the project directory
 looks like a typical Go project. Both HTTP and Event functions have the same
 template structure.
 
-```
+```bash
 ❯ func create -l go fn
 Project path: /home/developer/projects/fn
 Function name: fn
@@ -25,7 +25,7 @@ any Go project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file that is used when building your project.
 If you're really interested, check out the [reference doc](../reference/func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
-the [CLI Commands document](../reference/commands.txt).
+the [reference](../reference/) folder.
 
 ## Running the function locally
 
@@ -33,21 +33,21 @@ To run a function, you'll first need to build it. This step creates an OCI
 container image that can be run locally on your computer, or on a Kubernetes
 cluster.
 
-```
+```bash
 ❯ func build
 ```
 
 After the function has been built, it can be run locally.
 
-```
+```bash
 ❯ func run
 ```
 
-Functions can be invoked with a simple HTTP request. 
+Functions can be invoked with a simple HTTP request.
 You can test to see if the function is working by using your browser to visit
-http://localhost:8080. You can also access liveness and readiness
-endpoints at http://localhost:8080/health/liveness and
-http://localhost:8080/health/readiness. These two endpoints are used
+<http://localhost:8080>. You can also access liveness and readiness
+endpoints at <http://localhost:8080/health/liveness> and
+<http://localhost:8080/health/readiness>. These two endpoints are used
 by Kubernetes to determine the health of your function. If everything
 is good, both of these will return `{"ok":true}`.
 
@@ -55,52 +55,54 @@ is good, both of these will return `{"ok":true}`.
 
 To deploy your function to a Kubernetes cluster, use the `deploy` command.
 
-```
+```bash
 ❯ func deploy
 ```
 
 You can get the URL for your deployed function with the `info` command.
 
-```
+```bash
 ❯ func info
 ```
 
 ## Testing a function locally
 
-
 Go functions can be tested locally on your computer. In the project there is
-a `handle_test.go` file which contains simple test which can be extended as needed. 
+a `handle_test.go` file which contains simple test which can be extended as needed.
 Yo can run this test locally as you would do with any Go project.
 
-```
+```bash
 ❯ go test
 ```
 
 ## Function reference
 
 Boson Go functions have very few restrictions. You can add any required dependencies
-in `go.mod` and you may include additional local Go files. The only real requirement are 
-that your project is defined in a `function` module and exports the function `Handle()` 
-(supported contracts of this function will be discussed more deeply later).
-In this section, we will look in a little more detail at how Boson functions are invoked,
-and what APIs are available to you as a developer.
+in `go.mod` and you may include additional local Go files. The only real
+requirement is that your project is defined in a `function` module and exports
+the function `Handle()` (supported contracts of this function will be
+discussed more deeply later). In this section, we will look in a little more
+detail at how Boson functions are invoked, and what APIs are available to you
+as a developer.
 
 ### Invocation parameters
 
-When using the `func` CLI to create a function project, you may choose to generate a project
-that responds to a `CloudEvent` or simple HTTP. `CloudEvents` in Knative are transported over
-HTTP as a `POST` request, so in many ways, the two types of functions are very much the same.
-They each will listen and respond to incoming HTTP events.
+When using the `func` CLI to create a function project, you may choose to
+generate a project that responds to a `CloudEvent` or simple HTTP. `CloudEvents`
+in Knative are transported over HTTP as a `POST` request, so in many ways, the
+two types of functions are very much the same. They each will listen and respond
+to incoming HTTP events.
 
 #### Function triggered by HTTP request
 
 When an incoming request is received, your function will be invoked with a standard
-Golang [Context](https://golang.org/pkg/context/) as the first parameter followed by
-two parameters: Golang's [http.ResponseWriter](https://golang.org/pkg/net/http/#ResponseWriter)
-and [http.Request](https://golang.org/pkg/net/http/#Request). 
+Golang [Context](https://golang.org/pkg/context/)
+as the first parameter followed by two parameters: Golang's [http.ResponseWriter](https://golang.org/pkg/net/http/#ResponseWriter)
+and [http.Request](https://golang.org/pkg/net/http/#Request).
 
-Then you can use standard Golang techniques to access the request (eg. read the body)
-and set a proper HTTP response of your function, as you can see on the following example:
+Then you can use standard Golang techniques to access the request
+(e.g. read the body) and set a proper HTTP response of your function, as
+you can see on the following example:
 
 ```go
 func Handle(ctx context.Context, res http.ResponseWriter, req *http.Request) {
@@ -109,8 +111,8 @@ func Handle(ctx context.Context, res http.ResponseWriter, req *http.Request) {
   body, err := ioutil.ReadAll(req.Body)
   defer req.Body.Close()
   if err != nil {
-	http.Error(res, err.Error(), 500)
-	return
+    http.Error(res, err.Error(), 500)
+    return
   }
 
   // Process body & function logic
@@ -123,8 +125,9 @@ func Handle(ctx context.Context, res http.ResponseWriter, req *http.Request) {
 If the incoming request is a `CloudEvent`, the event is provided via
 [CloudEvents Golang SDK](https://cloudevents.github.io/sdk-go/) and its `Event` type
 as a parameter. There's possibility to leverage Golang's
-[Context](https://golang.org/pkg/context/) as the optional parameter in the function contract,
-as you can see in the list of supported function signatures:
+[Context](https://golang.org/pkg/context/) as the optional parameter
+in the function contract, as you can see in the list
+of supported function signatures:
 
 ```go
 Handle()
@@ -141,17 +144,18 @@ Handle(context.Context, cloudevents.Event) *cloudevents.Event
 Handle(context.Context, cloudevents.Event) (*cloudevents.Event, error)
 ```
 
-For example, a `CloudEvent` is received which contains a JSON string such as this in its data property, 
+For example, a `CloudEvent` is received which contains a JSON string such as
+this in its data property,
 
 ```json
-{ 
+{
   "customerId": "0123456",
   "productId": "6543210"
 }
 ```
 
-to access this data, we need to define `Purchase` structure, which maps properties in `CloudEvents`
-data and retrieve it from the incoming event:
+to access this data, we need to define `Purchase` structure, which maps
+properties in `CloudEvents` data and retrieve it from the incoming event:
 
 ```go
 type Purchase struct {
@@ -160,21 +164,21 @@ type Purchase struct {
 }
 
 func Handle(ctx context.Context, event cloudevents.Event) err error {
-	  
+
   purchase := &Purchase{}
   if err = cloudevents.DataAs(purchase); err != nil {
-	fmt.Fprintf(os.Stderr, "failed to parse incoming CloudEvent %s\n", err)
-	return
+    fmt.Fprintf(os.Stderr, "failed to parse incoming CloudEvent %s\n", err)
+    return
   }
 
   // ...
 }
 ```
 
-Or we can use Golang's `encoding/json` package to access the `CloudEvent` directly as
-a JSON in form of bytes array:
+Or we can use Golang's `encoding/json` package to access the `CloudEvent`
+directly as a JSON in the form of a byte array:
 
-```golang
+```go
 func Handle(ctx context.Context, event cloudevents.Event) {
 
   bytes, err := json.Marshal(event)
@@ -184,6 +188,7 @@ func Handle(ctx context.Context, event cloudevents.Event) {
 ```
 
 ### Return Values
+
 As mentioned above, HTTP triggered functions can set the response directly via
 Golang's [http.ResponseWriter](https://golang.org/pkg/net/http/#ResponseWriter).
 
@@ -197,14 +202,15 @@ func Handle(ctx context.Context, res http.ResponseWriter, req *http.Request) {
 
   _, err := fmt.Fprintf(res, "OK\n")
   if err != nil {
-	fmt.Fprintf(os.Stderr, "error or response write: %v", err)
+    fmt.Fprintf(os.Stderr, "error or response write: %v", err)
   }
 }
 ```
 
-Functions triggered by `CloudEvent` may return nothing, `error` and/or `CloudEvent` in order
-to push events into the Knative eventing system. In this case, the developer is required
-to set a unique `ID`, proper `Source` and a `Type` of the CloudEvent. The data can be populated
+Functions triggered by `CloudEvent` may return nothing, `error` and/or
+`CloudEvent` in order to push events into the Knative eventing system.
+In this case, the developer is required to set a unique `ID`, proper
+`Source` and a `Type` of the CloudEvent. The data can be populated
 from a defined structure or from a `map`.
 
 ```go
@@ -219,8 +225,8 @@ func Handle(ctx context.Context, event cloudevents.Event) (resp *cloudevents.Eve
 
   // Set the data from Purchase type
   response.SetData(cloudevents.ApplicationJSON, Purchase{
-	CustomerId: custId,
-	ProductId:  prodId,
+    CustomerId: custId,
+    ProductId:  prodId,
   })
 
   // OR set the data directly from map
@@ -229,7 +235,7 @@ func Handle(ctx context.Context, event cloudevents.Event) (resp *cloudevents.Eve
   // Validate the response
   resp = &response
   if err = resp.Validate(); err != nil {
-	fmt.Printf("invalid event created. %v", err)
+    fmt.Printf("invalid event created. %v", err)
   }
 
   return
@@ -237,12 +243,14 @@ func Handle(ctx context.Context, event cloudevents.Event) (resp *cloudevents.Eve
 ```
 
 ## Dependencies
+
 Developers are not restricted to the dependencies provided in the template
 `go.mod` file. Additional dependencies can be added as they would be in any
 other Golang project.
 
 ### Example
-```console
+
+```bash
 go get gopkg.in/yaml.v2@v2.4.0
 ```
 

--- a/docs/function-templates/nodejs.md
+++ b/docs/function-templates/nodejs.md
@@ -4,7 +4,7 @@ When creating a Node.js function using the `func` CLI, the project directory
 looks like a typical Node.js project. Both HTTP and Event functions have the same
 template structure.
 
-```
+```bash
 ❯ func create fn
 Project path: /home/developer/projects/fn
 Function name: fn
@@ -34,21 +34,21 @@ To run a function, you'll first need to build it. This step creates an OCI
 container image that can be run locally on your computer, or on a Kubernetes
 cluster.
 
-```
+```bash
 ❯ func build
 ```
 
 After the function has been built, it can be run locally.
 
-```
+```bash
 ❯ func run
 ```
 
-Functions can be invoked with a simple HTTP request. 
+Functions can be invoked with a simple HTTP request.
 You can test to see if the function is working by using your browser to visit
-http://localhost:8080. You can also access liveness and readiness
-endpoints at http://localhost:8080/health/liveness and
-http://localhost:8080/health/readiness. These two endpoints are used
+<http://localhost:8080>. You can also access liveness and readiness
+endpoints at <http://localhost:8080/health/liveness> and
+<http://localhost:8080/health/readiness>. These two endpoints are used
 by Kubernetes to determine the health of your function. If everything
 is good, both of these will return `OK`.
 
@@ -56,25 +56,24 @@ is good, both of these will return `OK`.
 
 To deploy your function to a Kubernetes cluster, use the `deploy` command.
 
-```
+```bash
 ❯ func deploy
 ```
 
 You can get the URL for your deployed function with the `info` command.
 
-```
+```bash
 ❯ func info
 ```
 
 ## Testing a function locally
-
 
 Node.js functions can be tested locally on your computer. In the project there is
 a `test` folder which contains some simple unit and integration tests. To run these
 locally, you'll need to install the required dependencies. You do this as you would
 with any Node.js project.
 
-```
+```bash
 ❯ npm install
 ```
 
@@ -89,7 +88,7 @@ Boson Node.js functions have very few restrictions. You can add any
 required dependencies in `package.json`, and you may include
 additional local JavaScript files. The only real requirements are that
 your project contain an `index.js` file which exports a single
-function.  In this section, we will look in a little more detail at
+function. In this section, we will look in a little more detail at
 how Boson functions are invoked, and what APIs are available to you as
 a developer.
 
@@ -99,7 +98,7 @@ When using the `func` CLI to create a function project, you may choose
 to generate a project that responds to a `CloudEvent` or simple
 HTTP. `CloudEvents` in Knative are transported over HTTP as a `POST`
 request, so in many ways, the two types of functions are very much the
-same.  They each will listen and respond to incoming HTTP events.
+same. They each will listen and respond to incoming HTTP events.
 
 When an incoming request is received, your function will be invoked
 with a `Context` object as the first parameter. If the incoming
@@ -108,7 +107,7 @@ parameter. For example, a `CloudEvent` is received which contains a
 JSON string such as this in its data property,
 
 ```json
-{ 
+{
   "customerId": "0123456",
   "productId": "6543210"
 }
@@ -121,7 +120,9 @@ function handle(context, event) {
   console.log(JSON.stringify(event.data, null, 2));
 }
 ```
+
 ### Return Values
+
 Functions may return any valid JavaScript type, or nothing at all. When a
 function returns nothing, and no failure is indicated, the caller will receive
 a `204 No Content"` response. Functions may also return a `CloudEvent`, or a
@@ -131,50 +132,56 @@ CloudEvent messaging specification. Headers and other relevant information from
 the returned values are extracted and sent with the response.
 
 #### Example
+
 ```js
 function handle(context, event) {
-  return processCustomer(event.data)
+  return processCustomer(event.data);
 }
 function processCustomer(customer) {
   // process customer and return a new CloudEvent
   return new CloudEvent({
-    source: 'customer.processor',
-    type: 'customer.processed'
-  })
+    source: "customer.processor",
+    type: "customer.processed",
+  });
 }
 ```
 
 ### Response headers
+
 Functions may additionally set headers to be sent with the response by adding a
 `headers` property to the object being returned. These headers will be
 extracted and sent with the response to the caller.
 
 #### Example
+
 ```js
 function processCustomer(customer) {
   // process customer and return custom headers
   // the response will be '204 No content'
-  return { headers: { customerid: customer.id } }; 
+  return { headers: { customerid: customer.id } };
 }
 ```
 
 ### Response codes
+
 Developers may set the response code returned to the caller by adding a
 `statusCode` property to the response.
 
 #### Example
+
 ```js
 function processCustomer(customer) {
   // process customer
   if (customer.restricted) {
-    return { statusCode: 451 }
-  } 
+    return { statusCode: 451 };
+  }
 }
 ```
 
 This also works with `Error` objects thrown from the function.
 
 #### Example
+
 ```js
 function processCustomer(customer) {
   // process customer
@@ -182,11 +189,12 @@ function processCustomer(customer) {
     const err = new Error(‘Unavailable for legal reasons’);
     err.statusCode = 451;
     throw err;
-  } 
+  }
 }
 ```
 
 ## The Context Object
+
 Functions are invoked with a context object as the first parameter. This object
 provides access to the incoming request information. Developers can get the
 HTTP request method, any query strings sent with the request, the headers, the
@@ -197,13 +205,15 @@ The `Context` object has several properties that may be accessed by the
 function developer.
 
 ### `log`
+
 Provides a logging object that can be used to write output to the cluster logs.
 The log adheres to the Pino logging API. For detailed documentation on this
-logging instance, see the Pino API documentation (https://getpino.io/#/docs/api).
+logging instance, see the Pino API documentation (<https://getpino.io/#/docs/api>).
 
 #### Example
+
 ```js
-Function handle(context) {
+function handle(context) {
   context.log.info(“Processing customer”);
 }
 ```
@@ -214,16 +224,25 @@ Access the function via `curl` to invoke it.
 curl http://example.com
 ```
 
-The function will log 
+The function will log
 
-```console
-{"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"Processing customer"}
+```json
+{
+  "level": 30,
+  "time": 1604511655265,
+  "pid": 3430203,
+  "hostname": "localhost.localdomain",
+  "reqId": 1,
+  "msg": "Processing customer"
+}
 ```
+
 #### Setting the log level
+
 Developers can control the log level by setting the `logLevel` value in
 `func.yaml` The possible options for this adhere to the options available
 for [`pino`](https://getpino.io/#/docs/api?id=level-string),
-and may be one of 
+and may be one of
 `'fatal'`, `'error'`, `'warn'`, `'info'`, `'debug'`, `'trace'` or `'silent'`.
 
 To temporarily override this value, set the environment variable `FUNC_LOG_LEVEL`
@@ -231,12 +250,14 @@ to one of the options listed above. To set the environment variable, use the
 [`config` command](commands#config).
 
 ### `query`
+
 Returns the query string for the request, if any, as key value pairs. These
 attributes are also found on the context object itself.
 
 #### Example
+
 ```js
-Function handle(context) {
+function handle(context) {
   // Log the 'name' query parameter
   context.log.info(context.query.name);
   // Query parameters also are attached to the context
@@ -246,23 +267,26 @@ Function handle(context) {
 
 Access the function via `curl` to invoke it.
 
-```sh
+```bash
 curl http://example.com?name=tiger
 ```
-The function will log 
 
-```console
+The function will log
+
+```json
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"tiger"}
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"tiger"}
 ```
 
 ### `body`
+
 Returns the request body if any. If the request body contains JSON, this will
 be parsed so that the attributes are directly available.
 
 #### Example
+
 ```js
-Function handle(context) {
+function handle(context) {
   // log the incoming request body's 'hello' parameter
   context.log.info(context.body.hello);
 }
@@ -274,26 +298,32 @@ Access the function via `curl` to invoke it.
 curl -X POST -d '{"hello": "world"}'  -H'Content-type: application/json' http://example.com
 ```
 
-The function will log 
+The function will log
+
 ```console
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"world"}
 ```
 
 ### `headers`
+
 Returns the HTTP request headers as an object.
 
 #### Example
+
 ```js
-Function handle(context) {
-  context.log.info(context.headers[custom-header]);
+function handle(context) {
+  context.log.info(context.headers[custom - header]);
 }
 ```
+
 Access the function via `curl` to invoke it.
 
 ```console
 curl -H'x-custom-header: some-value’' http://example.com
 ```
-The function will log 
+
+The function will log
+
 ```console
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"some-value"}
 ```
@@ -302,8 +332,8 @@ The function will log
 
 Returns the HTTP request method as a string.
 
-
 ### `httpVersion`
+
 Returns the HTTP version as a string.
 
 ### `httpVersionMajor`
@@ -311,12 +341,15 @@ Returns the HTTP version as a string.
 Returns the HTTP major version number as a string.
 
 ### `httpVersionMinor`
+
 Returns the HTTP minor version number as a string.
 
 ### `httpVersionMinor`
+
 Returns the HTTP minor version number as a string.
 
 ## Context Methods
+
 There is a single method on the `Context` object which is a convenience
 function for returning a `CloudEvent` object. In Knative systems, if a function
 service is invoked by an event broker with a `CloudEvent`, the broker will
@@ -324,9 +357,11 @@ examine the response. If the response is a `CloudEvent`, this event will then
 be handled by the broker just as with any other event it receives.
 
 ### cloudEventResponse()
+
 A function which accepts a data value and returns a CloudEvent.
 
 #### Example
+
 ```js
 // Expects to receive a CloudEvent with customer data
 function handle(context, event) {
@@ -337,11 +372,13 @@ function handle(context, event) {
 ```
 
 ## Dependencies
+
 Developers are not restricted to the dependencies provided in the template
 `package.json` file. Additional dependencies can be added as they would be in any
 other Node.js project.
 
 ### Example
+
 ```console
 npm install --save opossum
 ```

--- a/docs/function-templates/nodejs.md
+++ b/docs/function-templates/nodejs.md
@@ -26,7 +26,7 @@ any Node.js project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file that is used when building your project.
 If you're really interested, check out the [reference doc](../reference/func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
-the [CLI Commands document](../reference/commands.txt).
+the [reference](../reference/) folder.
 
 ## Running the function locally
 
@@ -115,7 +115,7 @@ JSON string such as this in its data property,
 
 So to log that string from your function, you might do this:
 
-```js
+```javascript
 function handle(context, event) {
   console.log(JSON.stringify(event.data, null, 2));
 }

--- a/docs/function-templates/python.md
+++ b/docs/function-templates/python.md
@@ -4,7 +4,7 @@ When creating a Python function using the `func` CLI, the project directory
 looks like a typical Python project. Both HTTP and Event functions have the same
 template structure.
 
-```
+```bash
 ❯ func create -l python fn
 Project path: /home/developer/src/fn
 Function name: fn
@@ -24,7 +24,7 @@ any Python project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file that is used when building your project.
 If you're really interested, check out the [reference doc](../reference/func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
-the [CLI Commands document](../reference/commands.txt).
+the [reference](../reference/) folder.
 
 ## Running the function locally
 
@@ -32,21 +32,21 @@ To run a function, you'll first need to build it. This step creates an OCI
 container image that can be run locally on your computer, or on a Kubernetes
 cluster.
 
-```
+```bash
 ❯ func build
 ```
 
 After the function has been built, it can be run locally.
 
-```
+```bash
 ❯ func run
 ```
 
-Functions can be invoked with a simple HTTP request. 
+Functions can be invoked with a simple HTTP request.
 You can test to see if the function is working by using your browser to visit
-http://localhost:8080. You can also access liveness and readiness
-endpoints at http://localhost:8080/health/liveness and
-http://localhost:8080/health/readiness. These two endpoints are used
+<http://localhost:8080>. You can also access liveness and readiness
+endpoints at <http://localhost:8080/health/liveness> and
+<http://localhost:8080/health/readiness>. These two endpoints are used
 by Kubernetes to determine the health of your function. If everything
 is good, both of these will return `OK`.
 
@@ -54,25 +54,24 @@ is good, both of these will return `OK`.
 
 To deploy your function to a Kubernetes cluster, use the `deploy` command.
 
-```
+```bash
 ❯ func deploy
 ```
 
 You can get the URL for your deployed function with the `info` command.
 
-```
+```bash
 ❯ func info
 ```
 
 ## Testing a function locally
-
 
 Python functions can be tested locally on your computer. In the project there is
 a `test_func.py` file which contains a simple unit test. To run the test locally,
 you'll need to install the required dependencies. You do this as you would
 with any Python project.
 
-```
+```bash
 ❯ pip install -r requirements.txt
 ```
 
@@ -83,28 +82,30 @@ that's no problem. Just install a test framework more to your liking.
 ## Function reference
 
 Boson Python functions have very few restrictions. You can add any required dependencies
-in `requirements.txt`, and you may include additional local Python files. The only real
-requirements are that your project contain a `func.py` file which contains a `main()` function.
-In this section, we will look in a little more detail at how Boson functions are invoked,
-and what APIs are available to you as a developer.
+in `requirements.txt`, and you may include additional local Python files.
+The only real requirements are that your project contain a `func.py` file
+which contains a `main()` function. In this section, we will look in a little
+more detail at how Boson functions are invoked, and what APIs are available to
+you as a developer.
 
 ### Invocation parameters
 
-When using the `func` CLI to create a function project, you may choose to generate a project
-that responds to a `CloudEvent` or simple HTTP. `CloudEvents` in Knative are transported over
-HTTP as a `POST` request, so in many ways, the two types of functions are very much the same.
-They each will listen and respond to incoming HTTP events.
+When using the `func` CLI to create a function project, you may choose to
+generate a project that responds to a `CloudEvent` or simple HTTP. `CloudEvents`
+in Knative are transported over HTTP as a `POST` request, so in many ways, the
+two types of functions are very much the same. They each will listen and respond
+to incoming HTTP events.
 
 When an incoming request is received, your function will be invoked with a `Context`
-object as the first parameter. This object is a Python class with two attributes. The
-`request` attribute will always be present, and contains the Flask `request` object.
-The second attribute, `cloud_event`, will be populated if the incoming request is a
-`CloudEvent`. Developers may access any `CloudEvent` data from the context object.
-For example:
+object as the first parameter. This object is a Python class with two attributes.
+The `request` attribute will always be present, and contains the Flask `request`
+object. The second attribute, `cloud_event`, will be populated if the incoming
+request is a `CloudEvent`. Developers may access any `CloudEvent` data from the
+context object. For example:
 
 ```python
 def main(context: Context):
-    """ 
+    """
     The context parameter contains the Flask request object and any
     CloudEvent received with the request.
     """
@@ -114,12 +115,14 @@ def main(context: Context):
 ```
 
 ### Return Values
+
 Functions may return any value supported by Flask, as the invocation framework
-proxies these values directly to the Flask server. See the Flask 
+proxies these values directly to the Flask server. See the Flask
 [documentation](https://flask.palletsprojects.com/en/1.1.x/quickstart/#about-responses)
 for more information.
 
 #### Example
+
 ```python
 def main(context: Context):
     body = { "message": "Howdy!" }
@@ -131,6 +134,7 @@ Note that functions may set both headers and response codes as secondary
 and tertiary response values from function invocation.
 
 ### CloudEvents
+
 All event messages in Knative are sent as `CloudEvents` over HTTP. As noted
 above, function developers may access an event through the `context` parameter
 when the function is invoked. Additionally, developers may use an `@event`
@@ -153,6 +157,7 @@ If not supplied, the CloudEvent's source attribute will be set to
 `"/parliament/function"` and the type will be set to `"parliament.response"`.
 
 ## Dependencies
+
 Developers are not restricted to the dependencies provided in the template
 `requirements.txt` file. Additional dependencies can be added as they would be
 in any other project by simply adding them to the `requirements.txt` file.

--- a/docs/function-templates/quarkus.md
+++ b/docs/function-templates/quarkus.md
@@ -4,13 +4,13 @@ When creating a Quarkus function using the `func` CLI, the project directory
 looks like a typical `maven` project. Both HTTP and Event functions have the same
 template structure.
 
-```
+```bash
 ❯ func create -l quarkus fn
 Project path: /home/developer/projects/fn
 Function name: fn
 Runtime: quarkus
 
-❯ tree         
+❯ tree
 fn
 ├── func.yaml
 ├── mvnw
@@ -38,7 +38,7 @@ any Java Maven project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file that is used when building your project.
 If you're really interested, check out the [reference doc](../reference/func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
-the [CLI Commands document](../reference/commands.txt).
+the [reference](../reference/) folder.
 
 ## Running the function locally
 
@@ -46,68 +46,72 @@ To run a function, you'll first need to build it. This step creates an OCI
 container image that can be run locally on your computer, or on a Kubernetes
 cluster.
 
-```
+```bash
 ❯ func build
 ```
+
 You might be asked about docker registry during the build step.
 After the function has been built, it can be run locally.
 
-```
+```bash
 ❯ func run
 ```
 
-Functions can be invoked with a simple HTTP request. 
+Functions can be invoked with a simple HTTP request.
 You can test to see if the function is working by using your browser to visit
-http://localhost:8080.
+<http://localhost:8080>.
 
 ## Deploying the function to a cluster
 
 To deploy your function to a Kubernetes cluster, use the `deploy` command.
 
-```
+```bash
 ❯ func deploy
 ```
 
 You can get the URL for your deployed function with the `info` command.
 
-```
+```bash
 ❯ func info
 ```
 
 ## Testing a function locally
 
-
 Quarkus functions can be tested locally on your computer.
 The project contains tests which you can run.
 You do this as you would with any Maven project.
 
-```
+```bash
 ❯ mvn test
 ```
 
 ## Function reference
 
-Boson Quarkus functions have very few restrictions. You can work with it as with any Java Maven project.
-The only real requirements is that your project contain a method annotated with `@Funq`.
-In this section, we will look in a little more detail at how Boson functions are invoked,
-and what APIs are available to you as a developer.
+Boson Quarkus functions have very few restrictions. You can work with it as with
+any Java Maven project. The only real requirements is that your project contain a
+method annotated with `@Funq`. In this section, we will look in a little more detail
+at how Boson functions are invoked, and what APIs are available to you as a developer.
 
 ### Invocation parameters
 
-When using the `func` CLI to create a function project, you may choose to generate a project
-that responds to a `CloudEvent` or simple HTTP. `CloudEvents` in Knative are transported over
-HTTP as a `POST` request, so in many ways, the two types of functions are very much the same.
-They each will listen and respond to incoming HTTP events.
+When using the `func` CLI to create a function project, you may choose to generate
+a project that responds to a `CloudEvent` or simple HTTP. `CloudEvents` in Knative
+are transported over HTTP as a `POST` request, so in many ways, the two types of
+functions are very much the same. They each will listen and respond to incoming
+HTTP events.
 
-When an incoming request is received, your function will be invoked with an instance of type of your choice, see [Types](#types).
+When an incoming request is received, your function will be invoked with an instance
+of type your choice, see [Types](#types).
 
 The instance will contain one of:
-* `data` of `CloudEvent`
-* Body of HTTP POST request
-* Query parameters of HTTP GET request
+
+- `data` of `CloudEvent`
+- Body of HTTP POST request
+- Query parameters of HTTP GET request
 
 For example, imagine a function that is meant to receive and process purchase data.
 Your function signature may look like this:
+
 ```java
 public class Functions {
     @Funq
@@ -116,7 +120,9 @@ public class Functions {
     }
 }
 ```
+
 With a `Purchase` bean that looks like this:
+
 ```java
 public class Purchase {
     private long customerId;
@@ -124,19 +130,24 @@ public class Purchase {
     // getters and setter here
 }
 ```
+
 Expecting data that may be represented in JSON like this:
+
 ```json
 {
   "customerId": "0123456",
   "productId": "6543210"
 }
 ```
+
 Depending on the deployment, this function will be invoked in one of three ways:
-* An incoming `CloudEvent` with a JSON object such as above in its `data` property.
-* An ordinary HTTP POST with a JSON object such as above in the body of the request
-* An ordinary HTTP GET with a query string like `?customerId=0123456&productId=6543210`
+
+- An incoming `CloudEvent` with a JSON object such as above in its `data` property.
+- An ordinary HTTP POST with a JSON object such as above in the body of the request
+- An ordinary HTTP GET with a query string like `?customerId=0123456&productId=6543210`
 
 ### Return Values
+
 Functions may return an instance of type satisfying condition described in [Types](#types).
 
 You can also return `Uni<T>`.
@@ -145,16 +156,19 @@ This is useful when the function calls asynchronous APIs (e.g. Vert.x HTTP clien
 
 The object you return will be serialized in the same format as the object you received.
 
-If the function received `CloudEvent` in binary encoding,
-then the object you return will be sent in the `data` property of a binary encoded `CloudEvent`.
+If the function received `CloudEvent` in binary encoding, then the object you return
+will be sent in the `data` property of a binary encoded `CloudEvent`.
 
 If the function received vanilla HTTP,
-then the object you return will be sent as the HTTP response body. In the example below, an invocation of this function
-through an incoming `CloudEvent`, will receive a response with a `CloudEvent` containing a list of purchases as its 
-`data` property. If the invocation was via an ordinary HTTP request, the response will contain the same list of purchases
-in the HTTP response body, but no `CloudEvent` headers will be included.
+then the object you return will be sent as the HTTP response body. In the example
+below, an invocation of this function through an incoming `CloudEvent`, will receive
+a response with a `CloudEvent` containing a list of purchases as its `data` property.
+If the invocation was via an ordinary HTTP request, the response will contain the
+same list of purchases in the HTTP response body, but no `CloudEvent` headers will
+be included.
 
 #### Example
+
 ```java
 public class Functions {
     @Funq
@@ -165,16 +179,19 @@ public class Functions {
 ### Types
 
 The input and output types of a function can be:
-* `void`
-* `String`,
-* `byte[]`
-* Primitive types and their wrappers (e.g. `int`, `Double`),
-* JavaBeans (the attributes of the bean must also follow the rules defined here)
-* Map, List or Array of the above
 
-In addition to above, there is one special type: `CloudEvents<T>` described below [CloudEvent attributes](#cloudevent-attributes).
+- `void`
+- `String`,
+- `byte[]`
+- Primitive types and their wrappers (e.g. `int`, `Double`),
+- JavaBeans (the attributes of the bean must also follow the rules defined here)
+- Map, List or Array of the above
+
+In addition to above, there is one special type: `CloudEvents<T>` described below
+[CloudEvent attributes](#cloudevent-attributes).
 
 #### Example
+
 ```java
 public class Functions {
     public List<Integer> getIds();
@@ -189,22 +206,25 @@ public class Functions {
 
 Above we described cases where we handle just the `data` portion of a `CloudEvent`.
 In many cases this is all we need.
-However sometimes you may need to also read or write the attributes of a `CloudEvent`, such as `type` or `subject`.
+However sometimes you may need to also read or write the attributes of a `CloudEvent`,
+such as `type` or `subject`.
 
-For this purpose `Funqy` offers the generic interface `CloudEvent<T>` and a builder, `CloudEventBuilder`.
-Note that the type parameter of `CloudEvent<T>` must satisfy the conditions described in [Types](#types).
+For this purpose `Funqy` offers the generic interface `CloudEvent<T>` and a builder,
+`CloudEventBuilder`. Note that the type parameter of `CloudEvent<T>` must satisfy
+the conditions described in [Types](#types).
 
 #### Example
+
 ```java
 public class Functions {
-    
+
     private boolean _processPurchase(Purchase purchase) {
         // do stuff
     }
-    
+
     public CloudEvent<Void> processPurchase(CloudEvent<Purchase> purchaseEvent) {
         System.out.println("subject is: ", purchaseEvent.subject());
-        
+
         if (!_processPurchase(purchaseEvent.data())) {
             return CloudEventBuilder.create()
                     .type("purchase.error")
@@ -258,20 +278,23 @@ public class Functions {
 
 The `Functions::withBeans` function above can be invoked by:
 
-* Simple HTTP POST with JSON body
-```shell
+- Simple HTTP POST with JSON body
+
+```bash
 curl "http://localhost:8080/" -X POST \
   -H "Content-Type: application/json" \
   -d '{"message": "Hello there."}'
 ```
 
-* Simple HTTP GET with query parameters
-```shell
+- Simple HTTP GET with query parameters
+
+```bash
 curl "http://localhost:8080?message=Hello%20there." -X GET
 ```
 
-* CloudEvent in binary encoding:
-```shell
+- CloudEvent in binary encoding:
+
+```bash
 curl "http://localhost:8080/" -X POST \
   -H "Content-Type: application/json" \
   -H "Ce-SpecVersion: 1.0" \
@@ -281,8 +304,9 @@ curl "http://localhost:8080/" -X POST \
   -d '{"message": "Hello there."}'
 ```
 
-* CloudEvent in structured (JSON) encoding:
-```shell
+- CloudEvent in structured (JSON) encoding:
+
+```bash
 curl http://localhost:8080/ \
   -H "Content-Type: application/cloudevents+json" \
   -d '{ "data": {"message":"Hello there."},
@@ -294,12 +318,14 @@ curl http://localhost:8080/ \
 ```
 
 The `Functions::withCloudEvent` function can be invoked similarly to `Functions::withBeans`,
-however only the last two examples are correct, the first two (raw HTTP) would result in error.
+however only the last two examples are correct, the first two (raw HTTP) would
+result in error.
 
 The `Functions::withBinary` function can be invoked by:
 
-* CloudEvent in binary encoding:
-```shell
+- CloudEvent in binary encoding:
+
+```bash
 curl "http://localhost:8080/" -X POST \
   -H "Content-Type: application/octet-stream" \
   -H "Ce-SpecVersion: 1.0"\
@@ -310,8 +336,9 @@ curl "http://localhost:8080/" -X POST \
 
 ```
 
-* CloudEvent in structured (JSON) encoding:
-```shell
+- CloudEvent in structured (JSON) encoding:
+
+```bash
 curl http://localhost:8080/ \
   -H "Content-Type: application/cloudevents+json" \
   -d "{ \"data_base64\": \"$(base64 img.jpg)\",

--- a/docs/function-templates/rust.md
+++ b/docs/function-templates/rust.md
@@ -4,7 +4,7 @@ When creating a Rust function using the `func` CLI, the project
 directory looks like a typical Rust project. Both HTTP and Event
 functions have the same template structure:
 
-```
+```bash
 ❯ func create -l rust fn
 Project path: /home/jim/src/func/fn
 Function name: fn
@@ -37,11 +37,11 @@ For an event-triggered function, pass the `-t events` option to
 generate an app capable of responding to
 [CloudEvents](https://cloudevents.io):
 
-```
+```bash
 ❯ func create -l rust -t events fn
 ```
 
 The handlers of each app differ slightly. See its generated
-[README.md](../../templates/rust/events/README.md) for more details.
+[README.md](../../templates/rust/cloudevents/README.md) for more details.
 
 Have fun!

--- a/docs/function-templates/typescript.md
+++ b/docs/function-templates/typescript.md
@@ -4,7 +4,7 @@ When creating a Node.js function using the `func` CLI, the project directory
 looks like a typical Node.js project. Both HTTP and Event functions have the same
 template structure.
 
-```
+```bash
 ❯ func create fn
 Project path: /home/developer/projects/fn
 Function name: fn
@@ -29,7 +29,7 @@ any TypeScript project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file used when building your project.
 If you are interested, check out the [reference doc](../reference/func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
-the [CLI Commands document](../reference/commands.txt).
+the [reference](../reference/) folder.
 
 ## Running the function locally
 
@@ -37,21 +37,21 @@ To run a function, you'll first need to build it. This step creates an OCI
 container image that can be run locally on your computer, or on a Kubernetes
 cluster.
 
-```
+```bash
 ❯ func build
 ```
 
 After the function has been built, it can be run locally.
 
-```
+```bash
 ❯ func run
 ```
 
-Functions can be invoked with a simple HTTP request. 
+Functions can be invoked with a simple HTTP request.
 You can test to see if the function is working by using your browser to visit
-http://localhost:8080. You can also access liveness and readiness
-endpoints at http://localhost:8080/health/liveness and
-http://localhost:8080/health/readiness. These two endpoints are used
+<http://localhost:8080>. You can also access liveness and readiness
+endpoints at <http://localhost:8080/health/liveness> and
+<http://localhost:8080/health/readiness>. These two endpoints are used
 by Kubernetes to determine the health of your function. If everything
 is good, both of these will return `OK`.
 
@@ -59,25 +59,24 @@ is good, both of these will return `OK`.
 
 To deploy your function to a Kubernetes cluster, use the `deploy` command.
 
-```
+```bash
 ❯ func deploy
 ```
 
 You can get the URL for your deployed function with the `info` command.
 
-```
+```bash
 ❯ func info
 ```
 
 ## Testing a function locally
-
 
 Node.js functions can be tested locally on your computer. In the project there is
 a `test` folder which contains some simple unit and integration tests. To run these
 locally, you'll need to install the required dependencies. You do this as you would
 with any TypeScript project.
 
-```
+```bash
 ❯ npm install
 ```
 
@@ -88,23 +87,33 @@ If you prefer another, that's no problem. Just remove the `tape` dependency from
 
 ## Function reference
 
-Boson Node.js functions have very few restrictions. You can add any required dependencies in `package.json`, and you may include additional local JavaScript or TypeScript files in the `src` directory.
+Boson Node.js functions have very few restrictions. You can add any required
+dependencies in `package.json`, and you may include additional local JavaScript
+or TypeScript files in the `src` directory.
 
-The one primary requirement is that your project contain a `src/index.ts` file which exports a function named `handle`. In this section, we will look in a little more detail at how Boson functions are invoked, and what APIs are available to you as a developer.
+The one primary requirement is that your project contain a `src/index.ts` file
+which exports a function named `handle`. In this section, we will look in a
+little more detail at how Boson functions are invoked, and what APIs are
+available to you as a developer.
 
 ### Invocation parameters
 
-When using the `func` CLI to create a function project, you may choose to generate a project
-that responds to a `CloudEvent` or simple HTTP. `CloudEvents` in Knative are transported over
-HTTP as a `POST` request, so in many ways, the two types of functions are very much the same.
-They each will listen and respond to incoming HTTP events.
+When using the `func` CLI to create a function project, you may choose to
+generate a project that responds to a `CloudEvent` or simple HTTP. `CloudEvents`
+in Knative are transported over HTTP as a `POST` request, so in many ways, the
+two types of functions are very much the same. They each will listen and respond
+to incoming HTTP events.
 
-When an incoming request is received, your function will be invoked with a `Context` object as the first parameter. If the incoming request is a `CloudEvent`, then the `CloudEvent` is extracted from the incoming message and provided as a second parameter.
+When an incoming request is received, your function will be invoked with a `Context`
+object as the first parameter. If the incoming request is a `CloudEvent`, then the
+`CloudEvent` is extracted from the incoming message and provided as a second parameter.
 
-```js
-function handle(context: Context, cloudevent?: CloudEvent): CloudEvent
+```typescript
+function handle(context: Context, cloudevent?: CloudEvent): CloudEvent;
 ```
+
 ### Return Values
+
 Functions may return any valid JavaScript type, or nothing at all. When a
 function returns nothing, and no failure is indicated, the caller will receive
 a `204 No Content"` response. Functions may also return a `CloudEvent`, or a
@@ -114,57 +123,69 @@ CloudEvent messaging specification. Headers and other relevant information from
 the returned values are extracted and sent with the response.
 
 #### Example
-```js
+
+```typescript
 function handle(context: Context, cloudevent?: CloudEvent): CloudEvent {
   // process customer and return a new CloudEvent
   const customer = cloudevent.data;
   return new CloudEvent({
-    source: 'customer.processor',
-    type: 'customer.processed'
-  })
+    source: "customer.processor",
+    type: "customer.processed",
+  });
 }
 ```
 
 ### Response headers
+
 Functions may additionally set headers to be sent with the response by adding a
 `headers` property to the object being returned. These headers will be
 extracted and sent with the response to the caller.
 
 #### Example
-```js
-function handle(context: Context, cloudevent?: CloudEvent): Record<string, string> {
+
+```typescript
+function handle(
+  context: Context,
+  cloudevent?: CloudEvent
+): Record<string, string> {
   // process customer and return custom headers
   // the response will be '204 No content'
   const customer = cloudevent.data;
-  return { headers: { "customer-id": customer.id } }; 
+  return { headers: { "customer-id": customer.id } };
 }
 ```
 
 ### Response codes
+
 Developers may set the response code returned to the caller by adding a
 `statusCode` property to the response.
 
 #### Example
-```js
-function handle(context: Context, cloudevent?: CloudEvent): Record<string, string> {
-  // process customer 
+
+```typescript
+function handle(
+  context: Context,
+  cloudevent?: CloudEvent
+): Record<string, string> {
+  // process customer
   const customer = cloudevent.data;
   if (customer.restricted) {
-    return { 
-      statusCode: 451
-    }
+    return {
+      statusCode: 451,
+    };
   }
   // business logic, then
   return {
-    statusCode: 240
-  }
+    statusCode: 240,
+  };
 }
 ```
 
 This also works with `Error` objects thrown from the function.
 
 #### Example
-```js
+
+```typescript
 function handle(context: Context, cloudevent?: CloudEvent) Record<string, string> {
   // process customer
   const customer = cloudevent.data;
@@ -172,11 +193,12 @@ function handle(context: Context, cloudevent?: CloudEvent) Record<string, string
     const err = new Error(‘Unavailable for legal reasons’);
     err.statusCode = 451;
     throw err;
-  } 
+  }
 }
 ```
 
 ## The Context Object
+
 Functions are invoked with a context object as the first parameter. This object
 provides access to the incoming request information. Developers can get the
 HTTP request method, any query strings sent with the request, the headers, the
@@ -187,106 +209,140 @@ The `Context` object has several properties that may be accessed by the
 function developer.
 
 ### `log`
+
 Provides a logging object that can be used to write output to the cluster logs.
-The log adheres to the Pino logging API (https://getpino.io/#/docs/api).
+The log adheres to the Pino logging API (<https://getpino.io/#/docs/api>).
 
 #### Example
-```js
-function handle(context:Context): string {
-  context.log.info('Processing customer');
-  return 'OK';
+
+```typescript
+function handle(context: Context): string {
+  context.log.info("Processing customer");
+  return "OK";
 }
 ```
 
 Access the function via `curl` to invoke it.
 
-```sh
+```bash
 curl http://example.com
 ```
 
-The function will log 
+The function will log
 
-```console
-{"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"Processing customer"}
+```json
+{
+  "level": 30,
+  "time": 1604511655265,
+  "pid": 3430203,
+  "hostname": "localhost.localdomain",
+  "reqId": 1,
+  "msg": "Processing customer"
+}
 ```
 
 ### `query`
+
 Returns the query string for the request, if any, as key value pairs. These
 attributes are also found on the context object itself.
 
 #### Example
-```js
+
+```typescript
 function handle(context: Context): string {
   // Log the 'name' query parameter
   context.log.info(context.query.name);
   // Query parameters also are attached to the context
   context.log.info(context.name);
-  return 'OK';
+  return "OK";
 }
 ```
 
 Access the function via `curl` to invoke it.
 
-```sh
+```bash
 curl "http://example.com?name=tiger"
 ```
-The function will log 
 
-```console
+The function will log
+
+```json
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"tiger"}
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"tiger"}
 ```
 
 ### `body`
+
 Returns the request body if any. If the request body contains JSON, this will
 be parsed so that the attributes are directly available.
 
 #### Example
-```js
+
+```typescript
 function handle(context: Context): string {
   // log the incoming request body's 'hello' parameter
   context.log.info(context.body.hello);
-  return 'OK';
+  return "OK";
 }
 ```
 
 Access the function via `curl` to invoke it.
 
-```console
+```bash
 curl -X POST -d '{"hello": "world"}'  -H'Content-type: application/json' http://example.com
 ```
 
-The function will log 
-```console
-{"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"world"}
+The function will log
+
+```json
+{
+  "level": 30,
+  "time": 1604511655265,
+  "pid": 3430203,
+  "hostname": "localhost.localdomain",
+  "reqId": 1,
+  "msg": "world"
+}
 ```
 
 ### `headers`
+
 Returns the HTTP request headers as an object.
 
 #### Example
-```js
+
+```typescript
 function handle(context: Context): string {
-  context.log.info(context.headers['custom-header']);
-  return 'OK';
+  context.log.info(context.headers["custom-header"]);
+  return "OK";
 }
 ```
+
 Access the function via `curl` to invoke it.
 
-```console
-curl -H'x-custom-header: some-value’' http://example.com
+```bash
+curl -H'x-custom-header: some-value' http://example.com
 ```
-The function will log 
-```console
-{"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"some-value"}
+
+The function will log
+
+```json
+{
+  "level": 30,
+  "time": 1604511655265,
+  "pid": 3430203,
+  "hostname": "localhost.localdomain",
+  "reqId": 1,
+  "msg": "some-value"
+}
 ```
 
 ### `method`
 
 Returns the HTTP request method as a string.
 
-
 ### `httpVersion`
+
 Returns the HTTP version as a string.
 
 ### `httpVersionMajor`
@@ -294,12 +350,15 @@ Returns the HTTP version as a string.
 Returns the HTTP major version number as a string.
 
 ### `httpVersionMinor`
+
 Returns the HTTP minor version number as a string.
 
 ### `httpVersionMinor`
+
 Returns the HTTP minor version number as a string.
 
 ## Context Methods
+
 There is a single method on the `Context` object which is a convenience
 function for returning a `CloudEvent` object. In Knative systems, if a function
 service is invoked by an event broker with a `CloudEvent`, the broker will
@@ -307,23 +366,27 @@ examine the response. If the response is a `CloudEvent`, this event will then
 be handled by the broker just as with any other event it receives.
 
 ### cloudEventResponse()
+
 A function which accepts a data value and returns a CloudEvent.
 
 #### Example
-```js
+
+```typescript
 // Expects to receive a CloudEvent with customer data
 function handle(context: Context, cloudevent?: CloudEvent): CloudEvent {
   // process the customer
   const customer = cloudevent.data;
   const processed = processCustomer(customer);
-  return context.cloudEventResponse(customer)
-    .source('/customer/process')
-    .type('customer.processed')
+  return context
+    .cloudEventResponse(customer)
+    .source("/customer/process")
+    .type("customer.processed")
     .response();
 }
 ```
 
 ### Context types
+
 The TypeScript type definition files export the following for use
 in your functions. Usage for these types is described in the previous
 sections.
@@ -331,53 +394,55 @@ sections.
 ```typescript
 // Invokable is the expected Function signature for user functions
 export interface Invokable {
-    (context: Context, cloudevent?: CloudEvent): any
+  (context: Context, cloudevent?: CloudEvent): any;
 }
 
 // Logger can be used for structural logging to the console
 export interface Logger {
-  debug: (msg: any) => void,
-  info:  (msg: any) => void,
-  warn:  (msg: any) => void,
-  error: (msg: any) => void,
-  fatal: (msg: any) => void,
-  trace: (msg: any) => void,
+  debug: (msg: any) => void;
+  info: (msg: any) => void;
+  warn: (msg: any) => void;
+  error: (msg: any) => void;
+  fatal: (msg: any) => void;
+  trace: (msg: any) => void;
 }
 
 // Context represents the function invocation context, and provides
 // access to the event itself as well as raw HTTP objects.
 export interface Context {
-    log: Logger;
-    req: IncomingMessage;
-    query?: Record<string, any>;
-    body?: Record<string, any>|string;
-    method: string;
-    headers: IncomingHttpHeaders;
-    httpVersion: string;
-    httpVersionMajor: number;
-    httpVersionMinor: number;
-    cloudevent: CloudEvent;
-    cloudEventResponse(data: string|object): CloudEventResponse;
+  log: Logger;
+  req: IncomingMessage;
+  query?: Record<string, any>;
+  body?: Record<string, any> | string;
+  method: string;
+  headers: IncomingHttpHeaders;
+  httpVersion: string;
+  httpVersionMajor: number;
+  httpVersionMinor: number;
+  cloudevent: CloudEvent;
+  cloudEventResponse(data: string | object): CloudEventResponse;
 }
 
 // CloudEventResponse is a convenience class used to create
 // CloudEvents on function returns
 export interface CloudEventResponse {
-    id(id: string): CloudEventResponse;
-    source(source: string): CloudEventResponse;
-    type(type: string): CloudEventResponse;
-    version(version: string): CloudEventResponse;
-    response(): CloudEvent;
+  id(id: string): CloudEventResponse;
+  source(source: string): CloudEventResponse;
+  type(type: string): CloudEventResponse;
+  version(version: string): CloudEventResponse;
+  response(): CloudEvent;
 }
 ```
 
 ## Dependencies
+
 Developers are not restricted to the dependencies provided in the template
 `package.json` file. Additional dependencies can be added as they would be in any
 other Node.js project.
 
 ### Example
-```console
+
+```bash
 npm install --save opossum
 ```
 

--- a/docs/language-packs/language-pack-contract.md
+++ b/docs/language-packs/language-pack-contract.md
@@ -1,80 +1,127 @@
 # Language Packs and Function Templates
 
-Language Packs is the mechanism by which the Knative Functions binary can be extended to support additional runtimes, function signatures, even operating systems and installed tooling for a Function. Language Packs are typically distributed via Git repositories but may also simply exist as a directory on a disc.
+Language Packs is the mechanism by which the Knative Functions binary can be extended
+to support additional runtimes, function signatures, even operating systems and installed
+tooling for a Function. Language Packs are typically distributed via Git repositories
+but may also simply exist as a directory on a disc.
 
-A Language Pack is the basis for what is written to the filesystem when a Function developer types `func create`. It can be thought of in a simplistic way as a "template" that provides the Function developer a source code file within which she may write her Function. When a Language Pack template is manifested on the filesystem, it also includes standard supporting files as would exist with traditional projects such as `pom.xml` or `package.json`, as well as a `func.yaml` file which has values derived from metadata supplied in the Language Pack. The Language Pack metadata includes information about the Function language runtime, invocation and build, and is used by the `func` CLI to manage the full Function lifecycle; from creation to deployment.
+A Language Pack is the basis for what is written to the filesystem when a Function
+developer types `func create`. It can be thought of in a simplistic way as a "template"
+that provides the Function developer a source code file within which he/she may write
+his/her Function. When a Language Pack template is manifested on the filesystem,
+it also includes standard supporting files as would exist with traditional projects
+such as `pom.xml` or `package.json`, as well as a `func.yaml` file which has values
+derived from metadata supplied in the Language Pack. The Language Pack metadata
+includes information about the Function language runtime, invocation and build,
+and is used by the `func` CLI to manage the full Function lifecycle; from creation
+to deployment.
 
 ## Purpose
 
-Knative Function Language Packs are meant to drastically reduce the code required for developers to be productive on Knative, and in concert with the `func` CLI make deploying event driven, container-based Knative Services simple and straightfoward. Language Packs and the `func` CLI streamline a Knative developer's experience by eliminating or reducing developer tasks that are not directly related to solving their business problems.
+Knative Function Language Packs are meant to drastically reduce the code required
+for developers to be productive on Knative, and in concert with the `func` CLI make
+deploying event driven, container-based Knative Services simple and straightfoward.
+Language Packs and the `func` CLI streamline a Knative developer's experience by
+eliminating or reducing developer tasks that are not directly related to solving
+their business problems.
 
-All of the built-in templates used by `func create` are considered together to be the `default` Language Pack. Vendors, development shops and even individuals may also provide "external" Language Packs of their own in order to augment and extend the `func` CLI.
+All of the built-in templates used by `func create` are considered together to be
+the `default` Language Pack. Vendors, development shops and even individuals may
+also provide "external" Language Packs of their own in order to augment and extend
+the `func` CLI.
 
-This document (in)formally describes a Language Pack contract followed by the `default` built-in, and what is expected of externally provided Language Packs.
+This document (in)formally describes a Language Pack contract followed by the `default`
+built-in, and what is expected of externally provided Language Packs.
 
 ## Built-in Language Packs
 
 The Language Pack contract is implemented in the following built-in templates.
 
-|Language|Format|
-|---|---|
-|Go|[CloudEvents](https://github.com/knative/func/tree/main/templates/go/cloudevents)|
-|Go|[HTTP](https://github.com/knative/func/tree/main/templates/go/http)|
-|Node.js|[CloudEvents](https://github.com/knative/func/tree/main/templates/node/cloudevents)|
-|Node.js|[HTTP](https://github.com/knative/func/tree/main/templates/node/http)|
-|Python|[CloudEvents](https://github.com/knative/func/tree/main/templates/python/cloudevents)|
-|Python|[HTTP](https://github.com/knative/func/tree/main/templates/python/http)|
-|Quarkus|[CloudEvents](https://github.com/knative/func/tree/main/templates/quarkus/cloudevents)|
-|Quarkus|[HTTP](https://github.com/knative/func/tree/main/templates/quarkus/http)|
-|Rust|[CloudEvents](https://github.com/knative/func/tree/main/templates/rust/cloudevents)|
-|Rust|[HTTP](https://github.com/knative/func/tree/main/templates/rust/http)|
-|Springboot|[CloudEvents](https://github.com/knative/func/tree/main/templates/springboot/cloudevents)|
-|Springboot|[HTTP](https://github.com/knative/func/tree/main/templates/springboot/http)|
-|TypeScript|[CloudEvents](https://github.com/knative/func/tree/main/templates/typescript/cloudevents)|
-|TypeScript|[HTTP](https://github.com/knative/func/tree/main/templates/typescript/http)|
+| Language   | Format                                                                                    |
+| ---------- | ----------------------------------------------------------------------------------------- |
+| Go         | [CloudEvents](https://github.com/knative/func/tree/main/templates/go/cloudevents)         |
+| Go         | [HTTP](https://github.com/knative/func/tree/main/templates/go/http)                       |
+| Node.js    | [CloudEvents](https://github.com/knative/func/tree/main/templates/node/cloudevents)       |
+| Node.js    | [HTTP](https://github.com/knative/func/tree/main/templates/node/http)                     |
+| Python     | [CloudEvents](https://github.com/knative/func/tree/main/templates/python/cloudevents)     |
+| Python     | [HTTP](https://github.com/knative/func/tree/main/templates/python/http)                   |
+| Quarkus    | [CloudEvents](https://github.com/knative/func/tree/main/templates/quarkus/cloudevents)    |
+| Quarkus    | [HTTP](https://github.com/knative/func/tree/main/templates/quarkus/http)                  |
+| Rust       | [CloudEvents](https://github.com/knative/func/tree/main/templates/rust/cloudevents)       |
+| Rust       | [HTTP](https://github.com/knative/func/tree/main/templates/rust/http)                     |
+| Springboot | [CloudEvents](https://github.com/knative/func/tree/main/templates/springboot/cloudevents) |
+| Springboot | [HTTP](https://github.com/knative/func/tree/main/templates/springboot/http)               |
+| TypeScript | [CloudEvents](https://github.com/knative/func/tree/main/templates/typescript/cloudevents) |
+| TypeScript | [HTTP](https://github.com/knative/func/tree/main/templates/typescript/http)               |
 
 ### Built-in Template APIs
 
-The built-in Language Packs support two separate function signatures for each runtime - CloudEvent or HTTP. What exactly this means for each runtime differs due to differences in language syntax and idioms.
+The built-in Language Packs support two separate function signatures for each
+runtime - CloudEvent or HTTP. What exactly this means for each runtime differs due
+to differences in language syntax and idioms.
 
 ## Extensible Language Packs
 
-The Knative Functions project provides the ability to customize its function templates and build strategies through Language Packs. Language Pack authors can add support for additional runtimes, provide templates that expose additional, custom built-in APIs, or any number of other capabilities. The function templates that are built into the `func` binary are considered the "built-in" or default Language Pack. The default, and all external Knative Function Language Packs should conform to the contract described in this document.
+The Knative Functions project provides the ability to customize its function templates
+and build strategies through Language Packs. Language Pack authors can add support
+for additional runtimes, provide templates that expose additional, custom built-in
+APIs, or any number of other capabilities. The function templates that are built
+into the `func` binary are considered the "built-in" or default Language Pack. The
+default, and all external Knative Function Language Packs should conform to the
+contract described in this document.
 
 ## Language Pack Summary
 
-A Knative Function Language Pack provides runtime and invocation capabilities for user-provided Function code.
+A Knative Function Language Pack provides runtime and invocation capabilities for
+user-provided Function code.
 
-- A Language Pack must be accessible as a git repository or a path to a location on disk.
+- A Language Pack must be accessible as a git repository or a path to a location
+  on disk.
 - A Language Pack must provide one or more code templates generated via `func create`.
-- A Language Pack must expose an invokable function interface for function developers in the code template.
-- A Language Pack project must be buildable in the form of an OCI container image via `func build`.
+- A Language Pack must expose an invokable function interface for function developers
+  in the code template.
+- A Language Pack project must be buildable in the form of an OCI container image
+  via `func build`.
 - A Language Pack OCI container image must be runnable via `func run`.
-- A Language Pack may provide create, build, runtime and invocation metadata with a `manifest.yaml` file.
-- A Language Pack project may be executable natively on a local host via host-specific tooling (e.g. `npm start`).
+- A Language Pack may provide create, build, runtime and invocation metadata with
+  a `manifest.yaml` file.
+- A Language Pack project may be executable natively on a local host via
+  host-specific tooling (e.g. `npm start`).
 
 ## Components
 
 A Knative Function Language Pack consists, broadly, of two conceptual components:
 
-- Build and runtime metadata provided via its directory structure and, optionally, a `manifest.yaml` file, all of which support the Function's lifecycle described below.
-- Project templates for Functions and supporting code. This is the function developer's UX - a Function project, which in most cases should look just like any other project of its type.
+- Build and runtime metadata provided via its directory structure and, optionally,
+  a `manifest.yaml` file, all of which support the Function's lifecycle described
+  below.
+- Project templates for Functions and supporting code. This is the function developer's
+  UX - a Function project, which in most cases should look just like any other project
+  of its type.
 
 ## Build and Runtime Metadata
 
-A Language Pack is a directory of files, typically named for the language or runtime being templated. Its structure is
+A Language Pack is a directory of files, typically named for the language or runtime
+being templated. Its structure is
 
 - The `root` directory containing one or more Language Packs
-- A [`manifest.yaml`](#language-pack-manifests) file in the root directory with metadata about the Language Pack
-- One or more "runtime" directories in `root` named for the languages or runtimes being templated
-- An optional `manifest.yaml` file in the runtime directory which may override metadata provided in a `manifest.yaml` at the `root`
-- One or more template directories within a runtime containing templates for the Language Pack's recognized function signatures
-- An optional `manifest.yaml` file in each template directory which may override the values set in the `root` or runtime `manifest.yaml` files
+- A [`manifest.yaml`](#language-pack-manifests) file in the root directory with metadata
+  about the Language Pack
+- One or more "runtime" directories in `root` named for the languages or runtimes
+  being templated
+- An optional `manifest.yaml` file in the runtime directory which may override metadata
+  provided in a `manifest.yaml` at the `root`
+- One or more template directories within a runtime containing templates for the
+  Language Pack's recognized function signatures
+- An optional `manifest.yaml` file in each template directory which may override
+  the values set in the `root` or runtime `manifest.yaml` files
 - tests and documentation
 
-For example, a Language Pack directory for Ruby with templates for both a CloudEvent function signature and an HTTP function signature, may look similar to the following directory tree.
+For example, a Language Pack directory for Ruby with templates for both a CloudEvent
+function signature and an HTTP function signature, may look similar to the following
+directory tree.
 
-```
+```bash
 root
 ├── ruby
 |    ├── cloudevent
@@ -95,13 +142,19 @@ root
 
 ### Language Pack Manifests
 
-A Language Pack's root level `manifest.yaml` file contains metadata that Language Pack providers may include to configure the build and deployment of Function projects created with the Language Pack. The following fields are recognized and may be used to override any defaults set in the repository's root directory `manifest.yaml`.
+A Language Pack's root level `manifest.yaml` file contains metadata that Language
+Pack providers may include to configure the build and deployment of Function projects
+created with the Language Pack. The following fields are recognized and may be used
+to override any defaults set in the repository's root directory `manifest.yaml`.
 
 #### `builders`
 
-OPTIONAL: A set of key value pairs identifying builder images capable of building a project from this Language Pack. The `default` key will be set as the builder image in `func.yaml` for a newly created project from the template. If not set in the Language Pack's `manifest.yaml`, these values must be provided in repository root `manifest.yaml`
+OPTIONAL: A set of key value pairs identifying builder images capable of building
+a project from this Language Pack. The `default` key will be set as the builder image
+in `func.yaml` for a newly created project from the template. If not set in the Language
+Pack's `manifest.yaml`, these values must be provided in repository root `manifest.yaml`
 
-```
+```yaml
 builders:
   default: paketobuildpacks/builder:base
   base: paketobuildpacks/builder:base
@@ -110,9 +163,13 @@ builders:
 
 #### `buildpacks`
 
-OPTIONAL: An ordered list of additional buildpacks to be applied to the builder image in addition to those already known by the builder. For example, the Paketo builder is widely used for Node.js, but it does not include a Buildpack for Kotlin. A Language Pack may use the Paketo builder in combination with a custom Kotlin buildpack, by specifying the additional Kotlin buildpack here.
+OPTIONAL: An ordered list of additional buildpacks to be applied to the builder image
+in addition to those already known by the builder. For example, the Paketo builder
+is widely used for Node.js, but it does not include a Buildpack for Kotlin. A Language
+Pack may use the Paketo builder in combination with a custom Kotlin buildpack, by
+specifying the additional Kotlin buildpack here.
 
-```
+```yaml
 builders:
   default: gcr.io/paketo-buildpacks/builder:base
   base: gcr.io/paketo-buildpacks/builder:base
@@ -124,32 +181,41 @@ buildpacks:
 ```
 
 #### `healthEndpoints`
-OPTIONAL: A set of key value pairs for `liveness` and `readiness` endpoints for functions created using the language pack. For example
 
-```
+OPTIONAL: A set of key value pairs for `liveness` and `readiness` endpoints for functions
+created using the language pack. For example
+
+```yaml
 healthEndpoints:
   liveness: /health/liveness
   readiness: /health/readiness
 ```
 
-If not provided, the values `/health/liveness` and `/health/readiness` will be used by default.
+If not provided, the values `/health/liveness` and `/health/readiness` will be used
+by default.
 
-Built in to the Functions library are Language Packs for Go, Node.js, Python, Quarkus, Rust, SpringBoot and TypeScript, each of which provide templates for HTTP and CloudEvents.
+Built in to the Functions library are Language Packs for Go, Node.js, Python, Quarkus,
+Rust, SpringBoot and TypeScript, each of which provide templates for HTTP and CloudEvents.
 
 ### Distributing Language Packs
 
-Language Packs are distributed as a set of templates for one or more languages via Git repositories, and installed by the developer locally using the `func` CLI.
+Language Packs are distributed as a set of templates for one or more languages via
+Git repositories, and installed by the developer locally using the `func` CLI.
 
-```
+```bash
 func repository add func https://github.com/knative-sandbox/func-tastic
 func create -l go -t func/hello-world
 ```
 
-See the `repository` section of the [commands guide](../reference/commands.md) for more information on installing and managing Language Pack repositories.
+See the [repository](../reference/func_repository.md) file of the [reference](../reference/)
+folder for more information on installing and managing Language Pack repositories.
 
 ### Repository Manifests
 
-In the root directory of a Language Pack Git repository there may be a `manifest.yaml` file describing the language packs therein. This file can be used to set the default values for builders, buildpacks and health endpoints for all Language Packs within a repository.
+In the root directory of a Language Pack Git repository there may be a `manifest.yaml`
+file describing the language packs therein. This file can be used to set the default
+values for builders, buildpacks and health endpoints for all Language Packs within
+a repository.
 
 ```yaml
 # The name used for this language pack repository
@@ -163,37 +229,71 @@ healthEndpoints:
 
 # Runtimes is a list of language packs supported by this repository
 runtimes:
-  - path: go       # Required. The path of the runtime directory from the repository root
-    name: go       # Optional. Name of the runtime; if not provided, path will be used
+  - path: go # Required. The path of the runtime directory from the repository root
+    name: go # Optional. Name of the runtime; if not provided, path will be used
 
     # A list of templates supplied by this language pack
-    templates:     # Required. One or more templates that correspond to directories within this language pack
-    - path: events # Required. The path to the template directory from the language pack root
-      name: events # Optional. The name of the template; if not provided path will be used
+    templates: # Required. One or more templates that correspond to directories within this language pack
+      - path: events # Required. The path to the template directory from the language pack root
+        name: events # Optional. The name of the template; if not provided path will be used
 ```
 
 ## Lifecycle
 
-- `create` Function projects are created using the `func create` command, during which, template and metadata files are copied from the Language Pack to a directory structure on the developer's local host.
-- `build` The Function project is converted into a runnable OCI container image using the `func build` command with metadata provided by the Language Pack's `manifest.yaml` if provided. Any dependencies declared by the Function are installed onto the image filesystem, and the Function invocation code is applied.
-- `run` Using the `func run` command to start the image, a controlling process loads the function project into memory and listens on port 8080 for incoming HTTP requests. The process is determined by the Language Pack. For example, a Node.js Language Pack may use `npm start` as the controlling process, while a Go Language Pack may invoke a binary compiled during the `build` phase.
-- `invoke` When an incoming HTTP request is received by the controlling process, the CloudEvent, if sent, is unmarshalled and the Function invoked with the payload.
-- `response` After a Function has been invoked by the invocation framework, the return value is sent to the caller. If the Function returns a CloudEvent, the invocation framework should respond to the caller with the CloudEvent unchanged. If the Function returns any other data, it is sent to the caller. Function invocation frameworks may each provide their own APIs and specifications to augment a Function developer's experience. For example, the Function developer may be able to return a structure containing a numeric HTTP response code, HTTP headers, and response data. These APIs and specifications are typically unique to the runtime environment and language, and as such are left to Language Pack implementors to provide and document. API capabilities for built-in `default` Language Pack runtimes are documented in the Function templates themselves.
+- `create` Function projects are created using the `func create` command, during
+  which, template and metadata files are copied from the Language Pack to a directory
+  structure on the developer's local host.
+- `build` The Function project is converted into a runnable OCI container image using
+  the `func build` command with metadata provided by the Language Pack's `manifest.yaml`
+  if provided. Any dependencies declared by the Function are installed onto the image
+  filesystem, and the Function invocation code is applied.
+- `run` Using the `func run` command to start the image, a controlling process loads
+  the function project into memory and listens on port 8080 for incoming HTTP requests.
+  The process is determined by the Language Pack. For example, a Node.js Language
+  Pack may use `npm start` as the controlling process, while a Go Language Pack may
+  invoke a binary compiled during the `build` phase.
+- `invoke` When an incoming HTTP request is received by the controlling process,
+  the CloudEvent, if sent, is unmarshalled and the Function invoked with the payload.
+- `response` After a Function has been invoked by the invocation framework, the return
+  value is sent to the caller. If the Function returns a CloudEvent, the invocation
+  framework should respond to the caller with the CloudEvent unchanged. If the Function
+  returns any other data, it is sent to the caller. Function invocation frameworks
+  may each provide their own APIs and specifications to augment a Function developer's
+  experience. For example, the Function developer may be able to return a structure
+  containing a numeric HTTP response code, HTTP headers, and response data. These
+  APIs and specifications are typically unique to the runtime environment and language,
+  and as such are left to Language Pack implementors to provide and document. API
+  capabilities for built-in `default` Language Pack runtimes are documented in the
+  Function templates themselves.
 
 ## Execution Scope
 
-When `func create` is used to generate a Function project, the Language Pack provides all of the information necessary for the project to be built as an OCI image. Including for example, specifying use of buildpacks or s2i, what builder images should be used, which environment variables are recognized, and more. In some cases, however, it is possible to simulate the containerized runtime environment locally on a developer's laptop. For example, the built-in `default` Node.js templates can be run locally using standard Node.js development tooling, such as `npm install` and `npm run`. Running Functions in this way can be quite convenient, but it is important to remember that a Knative Function project is meant to run within a tightly controlled execution space, where the environment is well defined. Not all Language Packs can provide this functionality, and there is no guarantee that the Function invocation will be identical in a local environment.
+When `func create` is used to generate a Function project, the Language Pack provides
+all of the information necessary for the project to be built as an OCI image. Including
+for example, specifying use of buildpacks or s2i, what builder images should be used,
+which environment variables are recognized, and more. In some cases, however, it
+is possible to simulate the containerized runtime environment locally on a developer's
+machine. For example, the built-in `default` Node.js templates can be run locally
+using standard Node.js development tooling, such as `npm install` and `npm run`.
+Running Functions in this way can be quite convenient, but it is important to remember
+that a Knative Function project is meant to run within a tightly controlled execution
+space, where the environment is well defined. Not all Language Packs can provide
+this functionality, and there is no guarantee that the Function invocation will be
+identical in a local environment.
 
 - Install user Function's dependencies
 - Load the user Function
 - Opening an HTTP socket and listening on a port
-- Receive incoming HTTP requests and convert any received CloudEvent into its native form for the runtime
+- Receive incoming HTTP requests and convert any received CloudEvent into its native
+  form for the runtime
 
 ## Usage
 
-Using external Language Packs is made possible through the `func repository` command, which allows Function developers to add and remove Language Packs from their local development environment. For example:
+Using external Language Packs is made possible through the `func repository` command,
+which allows Function developers to add and remove Language Packs from their local
+development environment. For example:
 
-```
+```bash
 ❯ func repository add https://github.com/knative-sandbox/func-tastic functastic # Add the func-tastic repo to the local environment
 ❯ func repo list # list repos
 default

--- a/templates/rust/cloudevents/README.md
+++ b/templates/rust/cloudevents/README.md
@@ -10,9 +10,9 @@ some resources for your function, you can do that in the [`configure` function](
 
 The app will expose three endpoints:
 
-  * `/` Triggers the `handle` function for a POST method
-  * `/health/readiness` The endpoint for a readiness health check
-  * `/health/liveness` The endpoint for a liveness health check
+- `/` Triggers the `handle` function for a POST method
+- `/health/readiness` The endpoint for a readiness health check
+- `/health/liveness` The endpoint for a liveness health check
 
 You may use any of the available [actix
 features](https://actix.rs/docs/) to fulfill the requests at those
@@ -23,7 +23,7 @@ endpoints.
 This is a fully self-contained application, so you can develop it as
 you would any other Rust application, e.g.
 
-```shell script
+```bash
 cargo build
 cargo test
 cargo run
@@ -34,7 +34,7 @@ the health checks are at <http://localhost:8080/health/readiness> and
 <http://localhost:8080/health/liveness>. To POST an event to the
 function, a utility such as `curl` may be used:
 
-```console
+```bash
 curl -v -d '{"name": "Bootsy"}' \
   -H'content-type: application/json' \
   -H'ce-specversion: 1.0' \
@@ -49,7 +49,7 @@ curl -v -d '{"name": "Bootsy"}' \
 Use `func` to containerize your application, publish it to a registry
 and deploy it as a Knative Service in your Kubernetes cluster:
 
-```shell script
+```bash
 func deploy --registry=docker.io/<YOUR_ACCOUNT>
 ```
 
@@ -59,7 +59,7 @@ environment variable. And if you forget, you'll be prompted.
 The output from a successful deploy should show the URL for the
 service, which you can also get via `func info`, e.g.
 
-```console
+```bash
 curl -v -d '{"name": "Bootsy"}' \
   -H'content-type: application/json' \
   -H'ce-specversion: 1.0' \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- When running subsequent `func run` commands on a function, the local .gitignore file is overwritten, so a user might lose other files they want to have ignored by git as well
- Fixes by checking if the file exists, and if it does then check each line to see if variations of ".func" exist, but also ensures its the entire directory and not matching against a file in the directory (e.g. .func/file1)

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1420 

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
If you were previously having an issue where your local .gitignore file was being overwritten every time you ran `func run`, this is now fixed!
```