### PR TITLE
[releaese-1.8] include image sha in `func version`

### DIFF
--- a/buildpacks/builder.go
+++ b/buildpacks/builder.go
@@ -32,10 +32,13 @@ var (
 		"springboot": "gcr.io/paketo-buildpacks/builder:base",
 	}
 
+	// Ensure that all entries in this list are terminated with a trailing "/"
+	// See GHSA-5336-2g3f-9g3m for details
 	trustedBuilderImagePrefixes = []string{
-		"quay.io/boson",
-		"gcr.io/paketo-buildpacks",
-		"docker.io/paketobuildpacks",
+		"quay.io/boson/",
+		"gcr.io/paketo-buildpacks/",
+		"docker.io/paketobuildpacks/",
+		"ghcr.io/vmware-tanzu/function-buildpacks-for-knative/",
 	}
 )
 
@@ -121,6 +124,10 @@ func (b *Builder) Build(ctx context.Context, f fn.Function) (err error) {
 	// only trust our known builders
 	opts.TrustBuilder = func(_ string) bool {
 		for _, v := range trustedBuilderImagePrefixes {
+			// Ensure that all entries in this list are terminated with a trailing "/"
+			if !strings.HasSuffix(v, "/") {
+				v = v + "/"
+			}
 			if strings.HasPrefix(opts.Builder, v) {
 				return true
 			}

--- a/buildpacks/builder_test.go
+++ b/buildpacks/builder_test.go
@@ -9,6 +9,43 @@ import (
 	"knative.dev/func/builders"
 )
 
+// Test_BuilderImageUntrusted ensures that only known builder images
+// are to be considered trusted.
+func Test_BuilderImageUntrusted(t *testing.T) {
+	var (
+		i = &mockImpl{}
+		b = NewBuilder(WithImpl(i))
+		f = fn.Function{Runtime: "node"}
+	)
+
+	var untrusted = []string{
+		// Check prefixes that end in a slash
+		"quay.io/bosonhack/",
+		"gcr.io/paketo-buildpackshack/",
+		// And those that don't
+		"docker.io/paketobuildpackshack",
+		"ghcr.io/vmware-tanzu/function-buildpacks-for-knativehack",
+	}
+
+	for _, builder := range untrusted {
+		f.Build = fn.BuildSpec{
+			BuilderImages: map[string]string{
+				builders.Pack: builder,
+			},
+		}
+		i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
+			if opts.TrustBuilder("") != false {
+				t.Fatalf("expected pack builder image %v to be untrusted", f.Build.BuilderImages[builders.Pack])
+			}
+			return nil
+		}
+
+		if err := b.Build(context.Background(), f); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 // Test_BuilderImageTrusted ensures that only known builder images
 // are to be considered trusted.
 func Test_BuilderImageTrusted(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"knative.dev/func/cmd/templates"
+	"knative.dev/func/k8s"
 
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
@@ -361,7 +362,12 @@ func (v Version) StringVerbose() string {
 	if date == "" {
 		date = time.Now().Format(time.RFC3339)
 	}
-	return fmt.Sprintf("%s-%s-%s", vers, hash, date)
+	funcVersion := fmt.Sprintf("%s-%s-%s", vers, hash, date)
+	return fmt.Sprintf("Version: %s\n"+
+		"SocatImage: %s\n"+
+		"TarImage: %s", funcVersion,
+		k8s.SocatImage,
+		k8s.TarImage)
 }
 
 // surveySelectDefault returns 'value' if defined and exists in 'options'.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -209,24 +209,28 @@ func TestRoot_CommandNameParameterized(t *testing.T) {
 
 func TestVerbose(t *testing.T) {
 	tests := []struct {
-		name string
-		args []string
-		want string
+		name   string
+		args   []string
+		want   string
+		wantLF int
 	}{
 		{
-			name: "verbose as version's flag",
-			args: []string{"version", "-v"},
-			want: "v0.42.0-cafe-1970-01-01\n",
+			name:   "verbose as version's flag",
+			args:   []string{"version", "-v"},
+			want:   "Version: v0.42.0-cafe-1970-01-01",
+			wantLF: 3,
 		},
 		{
-			name: "no verbose",
-			args: []string{"version"},
-			want: "v0.42.0\n",
+			name:   "no verbose",
+			args:   []string{"version"},
+			want:   "v0.42.0",
+			wantLF: 1,
 		},
 		{
-			name: "verbose as root's flag",
-			args: []string{"--verbose", "version"},
-			want: "v0.42.0-cafe-1970-01-01\n",
+			name:   "verbose as root's flag",
+			args:   []string{"--verbose", "version"},
+			want:   "Version: v0.42.0-cafe-1970-01-01",
+			wantLF: 3,
 		},
 	}
 	for _, tt := range tests {
@@ -249,8 +253,12 @@ func TestVerbose(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if out.String() != tt.want {
-				t.Errorf("expected output: %q but got: %q", tt.want, out.String())
+			outLines := strings.Split(out.String(), "\n")
+			if len(outLines)-1 != tt.wantLF {
+				t.Errorf("expected output with %v line breaks but got %v:", tt.wantLF, len(outLines)-1)
+			}
+			if outLines[0] != tt.want {
+				t.Errorf("expected output: %q but got: %q", tt.want, outLines[0])
 			}
 		})
 	}

--- a/k8s/dialer.go
+++ b/k8s/dialer.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os"
 	"sync"
 	"time"
 
@@ -23,7 +22,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-var socatImage = "quay.io/boson/alpine-socat:1.7.4.3-r1-non-root"
+var SocatImage = "quay.io/boson/alpine-socat:1.7.4.3-r1-non-root"
 
 // NewInClusterDialer creates context dialer that will dial TCP connections via POD running in k8s cluster.
 // This is useful when accessing k8s services that are not exposed outside cluster (e.g. openshift image registry).
@@ -129,11 +128,6 @@ func (c *contextDialer) startDialerPod(ctx context.Context) (err error) {
 		}
 	}()
 
-	img := socatImage
-	if i, ok := os.LookupEnv("SOCAT_IMAGE"); ok {
-		img = i
-	}
-
 	pod := &coreV1.Pod{
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:        c.podName,
@@ -144,7 +138,7 @@ func (c *contextDialer) startDialerPod(ctx context.Context) (err error) {
 			Containers: []coreV1.Container{
 				{
 					Name:            c.podName,
-					Image:           img,
+					Image:           SocatImage,
 					Stdin:           true,
 					StdinOnce:       true,
 					Command:         []string{"socat", "-u", "-", "OPEN:/dev/null"},


### PR DESCRIPTION
# Changes

This is a cherry-pick of  98001dc3512af45782f95bf836078da0b0c27a69 and 1ca662557714736c2f1d11607f90de69e54d66af to the `release-1.8` branch. Small improvements to UX.

* make socat image public and remove socat image env
* improve output for `func version`