### PR TITLE
Cleanup e2e on cluster tests

### DIFF
--- a/test/_common/gitserver.go
+++ b/test/_common/gitserver.go
@@ -90,10 +90,11 @@ func (g *GitTestServerProvider) CreateRepository(repoName string) *GitRemoteRepo
 	if !strings.Contains(cmdResult.Stdout, "created") {
 		g.t.Fatal("unable to create git bare repository " + repoName)
 	}
+	namespace, _, _ := k8s.GetClientConfig().Namespace()
 	gitRepo := &GitRemoteRepo{
 		RepoName:         repoName,
 		ExternalCloneURL: g.ServiceUrl + "/" + repoName + ".git",
-		ClusterCloneURL:  "http://func-git.default.svc.cluster.local/" + repoName + ".git",
+		ClusterCloneURL:  "http://func-git." + namespace + ".svc.cluster.local/" + repoName + ".git",
 	}
 	return gitRepo
 }

--- a/test/_e2e/config.go
+++ b/test/_e2e/config.go
@@ -3,6 +3,8 @@ package e2e
 import (
 	"os"
 	"strings"
+
+	"knative.dev/func/openshift"
 )
 
 // Intended to provide setup configuration for E2E tests
@@ -11,9 +13,23 @@ const (
 	testTemplateRepository = "http://github.com/boson-project/test-templates.git" //nolint:varcheck,deadcode
 )
 
+var testRegistry = ""
+
+func init() {
+	// Setup test Registry.
+	testRegistry = os.Getenv("E2E_REGISTRY_URL")
+	if testRegistry == "" || testRegistry == "default" {
+		if openshift.IsOpenShift() {
+			testRegistry = openshift.GetDefaultRegistry()
+		} else {
+			testRegistry = defaultRegistry
+		}
+	}
+}
+
 // GetRegistry returns registry
 func GetRegistry() string {
-	return getOsEnvOrDefault("E2E_REGISTRY_URL", defaultRegistry)
+	return testRegistry
 }
 
 // GetFuncBinaryPath should return the Path of 'func' binary under test

--- a/test/_oncluster/git_helper.go
+++ b/test/_oncluster/git_helper.go
@@ -22,7 +22,7 @@ func GitInitialCommitAndPush(t *testing.T, gitProjectPath string, originCloneURL
 
 	sh = common.NewShellCmd(t, gitProjectPath)
 	sh.ShouldFailOnError = true
-	sh.ShouldDumpOnSuccess = true
+	sh.ShouldDumpOnSuccess = false
 	sh.Exec(`git init`)
 	sh.Exec(`git branch -M main`)
 	sh.Exec(`git add .`)

--- a/test/_oncluster/scenario_basic_test.go
+++ b/test/_oncluster/scenario_basic_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"k8s.io/apimachinery/pkg/util/rand"
 	common "knative.dev/func/test/_common"
 	e2e "knative.dev/func/test/_e2e"
 )
@@ -17,7 +18,7 @@ import (
 // TestBasicUpload check if direct source upload works
 func TestBasicUpload(t *testing.T) {
 
-	var funcName = "test-func-basic-upload"
+	var funcName = "test-func-basic-upload" + rand.String(5)
 	var funcPath = filepath.Join(t.TempDir(), funcName)
 
 	func() {
@@ -64,7 +65,7 @@ func TestBasicUpload(t *testing.T) {
 // code changes (new commits) will be properly built and deployed on new revision
 func TestBasicGit(t *testing.T) {
 
-	var funcName = "test-func-basic-git"
+	var funcName = "test-func-basic-git" + rand.String(5)
 	var funcPath = filepath.Join(t.TempDir(), funcName)
 
 	func() {

--- a/test/_oncluster/scenario_context-dir_test.go
+++ b/test/_oncluster/scenario_context-dir_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"k8s.io/apimachinery/pkg/util/rand"
 	common "knative.dev/func/test/_common"
 	e2e "knative.dev/func/test/_e2e"
 )
@@ -19,7 +20,7 @@ import (
 //     public git repository from the main branch, to get deployed on my cluster
 func TestContextDirFunc(t *testing.T) {
 
-	var gitProjectName = "test-project"
+	var gitProjectName = "test-project" + rand.String(5)
 	var gitProjectPath = filepath.Join(t.TempDir(), gitProjectName)
 	var funcName = "test-func-context-dir"
 	var funcContextDir = filepath.Join("functions", funcName)

--- a/test/_oncluster/scenario_from-cli-local_test.go
+++ b/test/_oncluster/scenario_from-cli-local_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/rand"
 	fn "knative.dev/func"
 	common "knative.dev/func/test/_common"
 	e2e "knative.dev/func/test/_e2e"
@@ -17,7 +18,7 @@ import (
 // but users wants to run a local build on its machine
 func TestFromCliBuildLocal(t *testing.T) {
 
-	var funcName = "test-func-cli-local"
+	var funcName = "test-func-cli-local" + rand.String(5)
 	var funcPath = filepath.Join(t.TempDir(), funcName)
 
 	knFunc := common.NewKnFuncShellCli(t)

--- a/test/_oncluster/scenario_from-cli_test.go
+++ b/test/_oncluster/scenario_from-cli_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"k8s.io/apimachinery/pkg/util/rand"
 	common "knative.dev/func/test/_common"
 	e2e "knative.dev/func/test/_e2e"
 )
@@ -30,7 +31,7 @@ import (
 // TestFromCliDefaultBranch triggers a default branch test by using CLI flags
 func TestFromCliDefaultBranch(t *testing.T) {
 
-	var gitProjectName = "test-func-yaml-build-local"
+	var gitProjectName = "test-func-yaml-build-local" + rand.String(5)
 	var gitProjectPath = filepath.Join(t.TempDir(), gitProjectName)
 	var funcName = gitProjectName
 	var funcPath = gitProjectPath
@@ -64,7 +65,7 @@ func TestFromCliDefaultBranch(t *testing.T) {
 // TestFromCliFeatureBranch trigger a feature branch test by using CLI flags
 func TestFromCliFeatureBranch(t *testing.T) {
 
-	var funcName = "test-func-cli-feature-branch"
+	var funcName = "test-func-cli-feature-branch" + rand.String(5)
 	var funcPath = filepath.Join(t.TempDir(), funcName)
 
 	gitServer := common.GitTestServerProvider{}
@@ -106,7 +107,7 @@ func TestFromCliFeatureBranch(t *testing.T) {
 // TestFromCliContextDirFunc triggers a context dir test by using CLI flags
 func TestFromCliContextDirFunc(t *testing.T) {
 
-	var gitProjectName = "test-project"
+	var gitProjectName = "test-project" + rand.String(5)
 	var gitProjectPath = filepath.Join(t.TempDir(), gitProjectName)
 	var funcName = "test-func-context-dir"
 	var funcContextDir = filepath.Join("functions", funcName)

--- a/test/_oncluster/scenario_revision_test.go
+++ b/test/_oncluster/scenario_revision_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/rand"
 	fn "knative.dev/func"
 	common "knative.dev/func/test/_common"
 	e2e "knative.dev/func/test/_e2e"
@@ -38,7 +39,7 @@ func TestFromFeatureBranch(t *testing.T) {
 	assertBodyFn := func(response string) bool {
 		return strings.Contains(response, "hello branch")
 	}
-	GitRevisionCheck(t, "test-func-feature-branch", setupCodeFn, assertBodyFn)
+	GitRevisionCheck(t, "test-func-feature-branch"+rand.String(5), setupCodeFn, assertBodyFn)
 }
 
 func TestFromRevisionTag(t *testing.T) {
@@ -61,7 +62,7 @@ func TestFromRevisionTag(t *testing.T) {
 	assertBodyFn := func(response string) bool {
 		return strings.Contains(response, "hello v1")
 	}
-	GitRevisionCheck(t, "test-func-tag", setupCodeFn, assertBodyFn)
+	GitRevisionCheck(t, "test-func-tag"+rand.String(5), setupCodeFn, assertBodyFn)
 }
 
 func TestFromCommitHash(t *testing.T) {
@@ -85,7 +86,7 @@ func TestFromCommitHash(t *testing.T) {
 	assertBodyFn := func(response string) bool {
 		return strings.Contains(response, "hello v1")
 	}
-	GitRevisionCheck(t, "test-func-commit", setupCodeFn, assertBodyFn)
+	GitRevisionCheck(t, "test-func-commit"+rand.String(5), setupCodeFn, assertBodyFn)
 }
 
 func GitRevisionCheck(

--- a/test/_oncluster/scenario_runtime_test.go
+++ b/test/_oncluster/scenario_runtime_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/rand"
 	common "knative.dev/func/test/_common"
 	e2e "knative.dev/func/test/_e2e"
 )
@@ -52,7 +53,7 @@ func TestRuntime(t *testing.T) {
 
 func runtimeImpl(t *testing.T, lang string, builder string) {
 
-	var gitProjectName = fmt.Sprintf("test-runtime-%v-%v", lang, builder)
+	var gitProjectName = fmt.Sprintf("test-runtime-%v-%v-%v", lang, builder, rand.String(5))
 	var gitProjectPath = filepath.Join(t.TempDir(), gitProjectName)
 	var funcName = gitProjectName
 	var funcPath = gitProjectPath


### PR DESCRIPTION
# Changes

Some refinements on e2e on cluster tests:
- :broom: Making function name unique per run (to avoid name conflict on subsequent tests)
- :broom: resolving default test registry name according to the target cluster

/kind cleanup
