### PR TITLE
feat: adds CSharp runtime

### DIFF
--- a/buildpacks/builder.go
+++ b/buildpacks/builder.go
@@ -31,6 +31,7 @@ var (
 		"quarkus":    "gcr.io/paketo-buildpacks/builder:base",
 		"rust":       "gcr.io/paketo-buildpacks/builder:base",
 		"springboot": "gcr.io/paketo-buildpacks/builder:base",
+		"csharp": 	  "gcr.io/paketo-buildpacks/builder:base",
 	}
 
 	// Ensure that all entries in this list are terminated with a trailing "/"

--- a/client_test.go
+++ b/client_test.go
@@ -1235,6 +1235,7 @@ func TestClient_Runtimes(t *testing.T) {
 		"springboot",
 		"test",
 		"typescript",
+		"csharp",
 	}
 
 	if !reflect.DeepEqual(runtimes, expected) {

--- a/cmd/languages_test.go
+++ b/cmd/languages_test.go
@@ -23,7 +23,8 @@ python
 quarkus
 rust
 springboot
-typescript`
+typescript
+csharp`
 	output := buf()
 	if output != expected {
 		t.Fatalf("expected:\n'%v'\ngot:\n'%v'\n", expected, output)
@@ -49,7 +50,8 @@ func TestLanguages_JSON(t *testing.T) {
   "quarkus",
   "rust",
   "springboot",
-  "typescript"
+  "typescript",
+  "csharp"
 ]`
 	output := buf()
 	if output != expected {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -400,7 +400,7 @@ func (v Version) StringVerbose() string {
 //
 // Usage Example:
 //
-//	languages := []string{ "go", "node", "rust" },
+//	languages := []string{ "go", "node", "rust", "csharp" },
 //	survey.Select{
 //	  Options: options,
 //	  Default: surveySelectDefaut(cfg.Language, languages),

--- a/cmd/templates_test.go
+++ b/cmd/templates_test.go
@@ -33,7 +33,9 @@ rust         http
 springboot   cloudevents
 springboot   http
 typescript   cloudevents
-typescript   http`
+typescript   http
+csharp		 cloudevents
+csharp		 http`
 	output := buf()
 	if output != expected {
 		t.Fatalf("expected:\n'%v'\n\ngot:\n'%v'\n", expected, output)
@@ -78,6 +80,10 @@ func TestTemplates_JSON(t *testing.T) {
     "http"
   ],
   "typescript": [
+    "cloudevents",
+    "http"
+  ],
+  "csharp": [
     "cloudevents",
     "http"
   ]

--- a/function.go
+++ b/function.go
@@ -30,7 +30,7 @@ type Function struct {
 	// Name of the function.
 	Name string `yaml:"name" jsonschema:"pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"`
 
-	// Runtime is the language plus context.  nodejs|go|quarkus|rust etc.
+	// Runtime is the language plus context.  nodejs|go|quarkus|rust|csharp etc.
 	Runtime string `yaml:"runtime"`
 
 	// Template for the function.

--- a/pipelines/tekton/validate_test.go
+++ b/pipelines/tekton/validate_test.go
@@ -104,6 +104,16 @@ func Test_validatePipeline(t *testing.T) {
 			function: fn.Function{Build: fn.BuildSpec{Builder: builders.S2I}, Runtime: "rust"},
 			wantErr:  true,
 		},
+		{
+			name:     "Unsupported runtime - CSharp - pack builder - without additional Buildpacks",
+			function: fn.Function{Build: fn.BuildSpec{Builder: builders.Pack}, Runtime: "csharp"},
+			wantErr:  true,
+		},
+		{
+			name:     "Unsupported runtime - CSharp - s2i builder",
+			function: fn.Function{Build: fn.BuildSpec{Builder: builders.S2I}, Runtime: "csharp"},
+			wantErr:  true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/s2i/builder_test.go
+++ b/s2i/builder_test.go
@@ -72,6 +72,11 @@ func Test_BuildImages(t *testing.T) {
 			function: fn.Function{Runtime: "rust"},
 			wantErr:  true,
 		},
+		{
+			name:     "Without builder - unsupported runtime - csharp",
+			function: fn.Function{Runtime: "csharp"},
+			wantErr:  true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/templates/csharp/http/Program.cs
+++ b/templates/csharp/http/Program.cs
@@ -1,0 +1,15 @@
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddHealthChecks();
+
+var port = Environment.GetEnvironmentVariable("PORT") ?? "8080";
+var url = $"http://0.0.0.0:{port}";
+var target = Environment.GetEnvironmentVariable("TARGET") ?? "World";
+
+var app = builder.Build();
+
+app.MapHealthChecks("/health/readiness");
+app.MapHealthChecks("/health/liveness");
+
+app.MapGet("/", () => $"Hello {target}!");
+
+app.Run(url);

--- a/templates/csharp/manifest.yaml
+++ b/templates/csharp/manifest.yaml
@@ -1,0 +1,5 @@
+# Optional list of additional Buildpacks to be applied to the language pack's
+# builder image when the Function is built using a Buildpack builder.
+buildpacks:
+  - paketo-buildpacks/dotnet-core
+  - gcr.io/paketo-buildpacks/dotnet-core


### PR DESCRIPTION
Hello knative community,

I had a big need for C# runtime and was able to create one directly modifying func. Unfortunately I wasn't able to add C# runtime as per language pack tutorial because func would complain about default bulder image not being found - which is likely a bug. 

``is not a known builder. The available builder is "pack"``

Instead I just went and added new C# runtime that currently only supports http but you are welcome to add cloudevents.

[Linked to this issue](https://github.com/knative/func/issues/1408) 

## Release notes

```release-notes
Adds C# runtime to built-in templates
```

Thanks
