### PR TITLE
fix: improve error message for missing registry name

### DIFF
--- a/client.go
+++ b/client.go
@@ -63,7 +63,7 @@ var ErrNotBuilt = errors.New("not built")
 var ErrNameRequired = errors.New("name required")
 
 // ErrRegistryRequired indicates the operation requires a registry to complete.
-var ErrRegistryRequired = errors.New("registry required")
+var ErrRegistryRequired = errors.New("registry required to build function, please set with `--registry` or the FUNC_REGISTRY environment variable")
 
 // Builder of function source to runnable image.
 type Builder interface {


### PR DESCRIPTION
When a user attempts to build, run or deploy a function and it has not been previously built, the `--registry` flag or `FUNC_REGISTRY` environment variable must be set so that the image name can be calculated. The current error message, `registry required` is not very helpful, and requires the user to divine what needs to happen next to fix the problem. This change updates the error message text to indicate that the user should set the `--registry` flag or `FUNC_REGISTRY` environment variable.

New behavior (https://app.warp.dev/block/YhpjkGod6HI8r2FbaBTeWz):

```
FUNC_REGISTRY='' ./func run -p viewer
   Building function image
Error: registry required to build function, please set with `--registry` or the FUNC_REGISTRY environment variable
```

Fixes: https://github.com/knative/func/issues/1504

Signed-off-by: Lance Ball <lball@redhat.com>

/kind enhancement
