### PR TITLE
fix: envvar parsing for pack tekton task

### DIFF
--- a/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
+++ b/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
@@ -119,7 +119,7 @@ spec:
         mkdir -p "$ENV_DIR"
 
         for env in "${envs[@]}"; do
-            IFS='=' read -r key value string <<< "$env"
+            IFS='=' read -r key value <<< "$env"
             if [[ "$key" != "" && "$value" != "" ]]; then
                 path="${ENV_DIR}/${key}"
                 echo "--> Writing ${path}..."


### PR DESCRIPTION
# Changes

- :bug: Fix envvar parsing for pack tekton task when envvar contains the `=` char

/kind bug

```release-note
fix: envvar parsing for pack tekton task when envvar contains the `=` char
```
