### PR TITLE
fix: on cluster build - fix url in the output msg

### DIFF
--- a/pipelines/tekton/pipeplines_provider.go
+++ b/pipelines/tekton/pipeplines_provider.go
@@ -195,9 +195,9 @@ func (pp *PipelinesProvider) Run(ctx context.Context, f fn.Function) error {
 	}
 
 	if ksvc.Generation == 1 {
-		pp.progressListener.Increment(fmt.Sprintf("Function deployed in namespace %q and exposed at URL: \n%s", ksvc.Namespace, ksvc.Status.URL.String()))
+		pp.progressListener.Increment(fmt.Sprintf("✅ Function deployed in namespace %q and exposed at URL: \n   %s", ksvc.Namespace, ksvc.Status.URL.String()))
 	} else {
-		pp.progressListener.Increment(fmt.Sprintf("Function updated in namespace %q and exposed at URL: \n%s", ksvc.Namespace, ksvc.Status.URL.String()))
+		pp.progressListener.Increment(fmt.Sprintf("✅ Function updated in namespace %q and exposed at URL: \n   %s", ksvc.Namespace, ksvc.Status.URL.String()))
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thanks for sending a pull request! -->

# Changes

Fixing output, from:
```
$ func deploy --remote
   Function updated in namespace "demo" and exposed at URL:
🕘 ps://test-function-demo.apps.mycluster.com
```
to:
```
$ func deploy --remote
   ✅ Function updated in namespace "demo" and exposed at URL:
🕐 https://test-function-demo.apps.mycluster.com
```

Probably caused by: #1513 


<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🐛 fix: on cluster build - fix url in the output msg

