### PR TITLE
fix: allow trailing path flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"golang.org/x/term"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/client/pkg/util"
@@ -143,18 +143,14 @@ func registry() string {
 // definition (prior to parsing).
 func effectivePath() (path string) {
 	var (
-		env   = os.Getenv("FUNC_PATH")
-		fs    = flag.NewFlagSet("", flag.ContinueOnError)
-		long  = fs.String("path", "", "")
-		short = fs.String("p", "", "")
+		env  = os.Getenv("FUNC_PATH")
+		fs   = pflag.NewFlagSet("", pflag.ContinueOnError)
+		long = fs.StringP("path", "p", "", "")
 	)
 	fs.SetOutput(io.Discard)
 	_ = fs.Parse(os.Args[1:])
 	if env != "" {
 		path = env
-	}
-	if *short != "" {
-		path = *short
 	}
 	if *long != "" {
 		path = *long

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -312,11 +312,11 @@ func TestRoot_effectivePath(t *testing.T) {
 		}
 	})
 
-	t.Run("--path highest precedence", func(t *testing.T) {
+	t.Run("-p highest precedence", func(t *testing.T) {
 		t.Setenv("FUNC_PATH", "p1")
 		os.Args = []string{"test", "--path=p2", "-p=p3"}
-		if effectivePath() != "p2" {
-			t.Fatalf("the effective path did not take --path with highest precedence over -p and FUNC_PATH.  Expected 'p2', got '%v'", effectivePath())
+		if effectivePath() != "p3" {
+			t.Fatalf("the effective path did not take -p with highest precedence over --path and FUNC_PATH.  Expected 'p3', got '%v'", effectivePath())
 		}
 	})
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: fixes a bug where the --path flag would be ignored if provided after a subcommand

Updates the early-stage `effectivePath` method, which directly evaluates `--path` to use the `pflag` library, which implements a more permissive model for parsing flags (POSIX/GNU-style), including the ability to define a flag _trailing_ subcommands, and is the library used by the command structs internally.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Fixes a bug where --path was sometimes not evaluated.
```
