### PR TITLE
e2e tests log stdout and stderr

### DIFF
--- a/test/common/cmd.go
+++ b/test/common/cmd.go
@@ -104,8 +104,9 @@ func (f *TestExecCmd) Exec(args ...string) TestExecCmdResult {
 		}
 	}
 	if err != nil {
-		f.T.Log(err.Error())
+		f.T.Log(result.Stdout)
 		f.T.Log(result.Stderr)
+		f.T.Log(err.Error())
 		if f.ShouldFailOnError {
 			f.T.Fail()
 		}

--- a/test/common/cmd.go
+++ b/test/common/cmd.go
@@ -42,9 +42,8 @@ type TestExecCmd struct {
 
 // TestExecCmdResult stored command result
 type TestExecCmdResult struct {
-	Stdout string
-	Stderr string
-	Error  error
+	Out   string
+	Error error
 }
 
 func (f *TestExecCmd) WithEnv(envKey string, envValue string) *TestExecCmd {
@@ -76,12 +75,11 @@ func (f *TestExecCmd) Exec(args ...string) TestExecCmdResult {
 		f.T.Log(f.Binary, strings.Join(finalArgs, " "))
 	}
 
-	var stderr bytes.Buffer
-	var stdout bytes.Buffer
+	var out bytes.Buffer
 
 	cmd := exec.Command(f.Binary, finalArgs...)
-	cmd.Stderr = &stderr
-	cmd.Stdout = &stdout
+	cmd.Stderr = &out
+	cmd.Stdout = &out
 	if f.SourceDir != "" {
 		cmd.Dir = f.SourceDir
 	}
@@ -89,23 +87,21 @@ func (f *TestExecCmd) Exec(args ...string) TestExecCmdResult {
 	err := cmd.Run()
 
 	result := TestExecCmdResult{
-		Stdout: stdout.String(),
-		Stderr: stderr.String(),
-		Error:  err,
+		Out:   out.String(),
+		Error: err,
 	}
 
 	if err == nil && f.ShouldDumpOnSuccess {
-		if result.Stdout != "" {
+		if result.Out != "" {
 			if f.DumpLogger != nil {
-				f.DumpLogger(result.Stdout)
+				f.DumpLogger(result.Out)
 			} else {
-				f.T.Logf("%v", result.Stdout)
+				f.T.Logf("%v", result.Out)
 			}
 		}
 	}
 	if err != nil {
-		f.T.Log(result.Stdout)
-		f.T.Log(result.Stderr)
+		f.T.Log(result.Out)
 		f.T.Log(err.Error())
 		if f.ShouldFailOnError {
 			f.T.Fail()

--- a/test/common/gitserver.go
+++ b/test/common/gitserver.go
@@ -87,7 +87,7 @@ func (g *GitTestServerProvider) Init(T *testing.T) {
 func (g *GitTestServerProvider) CreateRepository(repoName string) *GitRemoteRepo {
 	// kubectl exec $podname -c user-container -- git-repo create $reponame
 	cmdResult := g.Kubectl.Exec("exec", g.PodName, "-c", "user-container", "--", "git-repo", "create", repoName)
-	if !strings.Contains(cmdResult.Stdout, "created") {
+	if !strings.Contains(cmdResult.Out, "created") {
 		g.t.Fatal("unable to create git bare repository " + repoName)
 	}
 	namespace, _, _ := k8s.GetClientConfig().Namespace()
@@ -101,7 +101,7 @@ func (g *GitTestServerProvider) CreateRepository(repoName string) *GitRemoteRepo
 
 func (g *GitTestServerProvider) DeleteRepository(repoName string) {
 	cmdResult := g.Kubectl.Exec("exec", g.PodName, "-c", "user-container", "--", "git-repo", "delete", repoName)
-	if !strings.Contains(cmdResult.Stdout, "deleted") {
+	if !strings.Contains(cmdResult.Out, "deleted") {
 		g.t.Fatal("unable to delete git bare repository " + repoName)
 	}
 }

--- a/test/e2e/cmd_invoke_test.go
+++ b/test/e2e/cmd_invoke_test.go
@@ -59,9 +59,9 @@ func TestInvoke(t *testing.T) {
 
 	run(t, bin, prefix, "create", "--language=go", "--template=cloudevents", cwd)
 	set(t, "handle.go", TestInvokeFunctionImpl)
-	run(t, bin, prefix, "deploy", "--builder=pack", "--registry", GetRegistry())
+	run(t, bin, prefix, "deploy", "--verbose", "--builder=pack", "--registry", GetRegistry())
 	infoOut := run(t, bin, prefix, "info", "--output", "plain")
-	run(t, bin, prefix, "invoke", "--verbose=true", "--content-type=text/plain", "--source=func:set", "--data=TEST")
+	run(t, bin, prefix, "invoke", "--verbose", "--content-type=text/plain", "--source=func:set", "--data=TEST")
 
 	// Resolve target service URL from info command stdout
 	targetUrl := "http://testinvoke.default.127.0.0.1.sslip.io"

--- a/test/oncluster/scenario_basic_test.go
+++ b/test/oncluster/scenario_basic_test.go
@@ -38,7 +38,7 @@ func TestBasicUpload(t *testing.T) {
 
 		// Assert "first revision" is returned
 		result := knFunc.Exec("invoke", "-p", funcPath)
-		assert.Assert(t, strings.Contains(result.Stdout, "first revision"), "Func body does not contain 'first revision'")
+		assert.Assert(t, strings.Contains(result.Out, "first revision"), "Func body does not contain 'first revision'")
 
 		previousServiceRevision := e2e.GetCurrentServiceRevision(t, funcName)
 
@@ -54,7 +54,7 @@ func TestBasicUpload(t *testing.T) {
 
 		// -- Assertions --
 		result = knFunc.Exec("invoke", "-p", funcPath)
-		assert.Assert(t, strings.Contains(result.Stdout, "new revision"), "Func body does not contain 'new revision'")
+		assert.Assert(t, strings.Contains(result.Out, "new revision"), "Func body does not contain 'new revision'")
 		AssertThatTektonPipelineRunSucceed(t, funcName)
 	}()
 
@@ -94,7 +94,7 @@ func TestBasicGit(t *testing.T) {
 
 		// Assert "first revision" is returned
 		result := knFunc.Exec("invoke", "-p", funcPath)
-		assert.Assert(t, strings.Contains(result.Stdout, "first revision"), "Func body does not contain 'first revision'")
+		assert.Assert(t, strings.Contains(result.Out, "first revision"), "Func body does not contain 'first revision'")
 
 		previousServiceRevision := e2e.GetCurrentServiceRevision(t, funcName)
 
@@ -113,7 +113,7 @@ func TestBasicGit(t *testing.T) {
 
 		// -- Assertions --
 		result = knFunc.Exec("invoke", "-p", funcPath)
-		assert.Assert(t, strings.Contains(result.Stdout, "new revision"), "Func body does not contain 'new revision'")
+		assert.Assert(t, strings.Contains(result.Out, "new revision"), "Func body does not contain 'new revision'")
 		AssertThatTektonPipelineRunSucceed(t, funcName)
 
 	}()

--- a/test/oncluster/scenario_context-dir_test.go
+++ b/test/oncluster/scenario_context-dir_test.go
@@ -54,7 +54,7 @@ func TestContextDirFunc(t *testing.T) {
 
 		// -- Assertions --
 		result := knFunc.Exec("invoke", "-p", funcPath)
-		assert.Assert(t, strings.Contains(result.Stdout, "hello dir"), "Func body does not contain 'hello dir'")
+		assert.Assert(t, strings.Contains(result.Out, "hello dir"), "Func body does not contain 'hello dir'")
 		AssertThatTektonPipelineRunSucceed(t, funcName)
 
 	}()

--- a/test/oncluster/scenario_from-cli_test.go
+++ b/test/oncluster/scenario_from-cli_test.go
@@ -57,7 +57,7 @@ func TestFromCliDefaultBranch(t *testing.T) {
 
 	// ## ASSERTIONS
 	result := knFunc.Exec("invoke", "-p", funcPath)
-	assert.Assert(t, strings.Contains(result.Stdout, "Hello"), "Func body does not contain 'Hello'")
+	assert.Assert(t, strings.Contains(result.Out, "Hello"), "Func body does not contain 'Hello'")
 	AssertThatTektonPipelineRunSucceed(t, funcName)
 
 }
@@ -99,7 +99,7 @@ func TestFromCliFeatureBranch(t *testing.T) {
 
 	// ## ASSERTIONS
 	result := knFunc.Exec("invoke", "-p", funcPath)
-	assert.Assert(t, strings.Contains(result.Stdout, "hello branch"), "Func body does not contain 'hello branch'")
+	assert.Assert(t, strings.Contains(result.Out, "hello branch"), "Func body does not contain 'hello branch'")
 	AssertThatTektonPipelineRunSucceed(t, funcName)
 
 }
@@ -137,7 +137,7 @@ func TestFromCliContextDirFunc(t *testing.T) {
 
 	// -- Assertions --
 	result := knFunc.Exec("invoke", "-p", funcPath)
-	assert.Assert(t, strings.Contains(result.Stdout, "hello dir"), "Func body does not contain 'hello dir'")
+	assert.Assert(t, strings.Contains(result.Out, "hello dir"), "Func body does not contain 'hello dir'")
 	AssertThatTektonPipelineRunSucceed(t, funcName)
 
 }

--- a/test/oncluster/scenario_revision_test.go
+++ b/test/oncluster/scenario_revision_test.go
@@ -78,7 +78,7 @@ func TestFromCommitHash(t *testing.T) {
 		sh.Exec("git add index.js")
 		sh.Exec(`git commit -m "version 2"`)
 		sh.Exec("git push origin main")
-		commitHash := strings.TrimSpace(gitRevParse.Stdout)
+		commitHash := strings.TrimSpace(gitRevParse.Out)
 		UpdateFuncGit(t, funcProjectPath, fn.Git{URL: clusterCloneUrl, Revision: commitHash})
 
 		t.Logf("Revision Check: commit hash resolved to [%v]", commitHash)
@@ -119,7 +119,7 @@ func GitRevisionCheck(
 
 	// -- Assertions --
 	result := knFunc.Exec("invoke", "-p", funcPath)
-	if !assertBodyFn(result.Stdout) {
+	if !assertBodyFn(result.Out) {
 		t.Error("Func Body does not contains expected expression")
 	}
 	AssertThatTektonPipelineRunSucceed(t, funcName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: E2E tests show all logs

When a test fails, a combined log is dumped rather than just the command's standard error buffer, and when a test is configured to dump logs on success, the combined buffer is dumped.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement
