### PR TITLE
chore(ci): update java version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
           go-version: "1.18"
       - uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '17'
       - name: Unit Test
         run:  make test
       - name: Template Unit Tests


### PR DESCRIPTION
Signed-off-by: Lance Ball <lball@redhat.com>

Updates Java to version 17 in CI