### PR TITLE
fix: func deploy with explicity `--build=false` bypass isBuilt check

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -284,7 +284,7 @@ func runDeploy(cmd *cobra.Command, newClient ClientFactory) (err error) {
 				return
 			}
 		}
-		if err = client.Deploy(cmd.Context(), f.Root); err != nil {
+		if err = client.Deploy(cmd.Context(), f.Root, fn.WithDeploySkipBuildCheck(cfg.Build == "false")); err != nil {
 			return
 		}
 		if f, err = fn.NewFunction(f.Root); err != nil { // TODO: remove when client API uses 'f'


### PR DESCRIPTION
# Changes

- :bug: Fix error on build command `Error: not built` on situation where image is built but user explicity specifies `--build=false`

**Use cases it covers**
- On Cluster builds which image is build and deployed on different steps and build stamp is not generated
- Local builds when a user builds a function, then run locally (i.e `mvn quarkus:dev`) or user modifes a non func related file (i.e. README.md)

/kind bug

Fixes #1535 
