### PR TITLE
Use current (as in PR) func image in integration tests

### DIFF
--- a/.github/workflows/test-e2e-oncluster-runtime.yaml
+++ b/.github/workflows/test-e2e-oncluster-runtime.yaml
@@ -15,8 +15,11 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
+      - uses: imjasonh/setup-ko@v0.6
       - name: Install Binaries
         run: ./hack/binaries.sh
+      - name: Setup testing func image
+        run: ./hack/create-testing-func-image.sh
       - name: Allocate Cluster
         run: ./hack/allocate.sh
       - name: Deploy Tekton

--- a/.github/workflows/test-e2e-oncluster.yaml
+++ b/.github/workflows/test-e2e-oncluster.yaml
@@ -15,8 +15,11 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
+      - uses: imjasonh/setup-ko@v0.6
       - name: Install Binaries
         run: ./hack/binaries.sh
+      - name: Setup testing func image
+        run: ./hack/create-testing-func-image.sh
       - name: Allocate Cluster
         run: ./hack/allocate.sh
       - name: Deploy Tekton

--- a/hack/create-testing-func-image.sh
+++ b/hack/create-testing-func-image.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KO_DOCKER_REPO="ttl.sh/$(head -c 128 </dev/urandom | LC_CTYPE=C tr -dc 'a-z0-9' | fold -w 8 | head -n 1)"
+export KO_DOCKER_REPO
+
+REF_FILE=$(mktemp)
+
+ko build --image-refs "${REF_FILE}" --tags "30m" -B ./cmd/func
+
+yq -Y -i ".spec.steps[0].image = \"$(cat "${REF_FILE}")\"" \
+  pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml

--- a/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+++ b/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
@@ -13,18 +13,18 @@ spec:
   description: >-
     This Task performs a deploy operation using the Knative `func` CLI
   params:
-  - name: path
-    description: Path to the function project
-    default: ""
-  - name: image
-    description: Container image to be deployed
-    default: ""
+    - name: path
+      description: Path to the function project
+      default: ""
+    - name: image
+      description: Container image to be deployed
+      default: ""
   workspaces:
     - name: source
       description: The workspace containing the function project
   steps:
-  - name: func-deploy
-    image: "ghcr.io/knative/func/func:latest"
-    script: |
-      export FUNC_IMAGE="$(params.image)"
-      func deploy --verbose --build=false --push=false --path=$(params.path) --remote=false
+    - name: func-deploy
+      image: "ghcr.io/knative/func/func:latest"
+      script: |
+        export FUNC_IMAGE="$(params.image)"
+        func deploy --verbose --build=false --push=false --path=$(params.path) --remote=false


### PR DESCRIPTION
# Changes

- Use current (as in PR) version of `func` in Tekton task during integration testing.
Without this change the `func` from `main` is used and changes in PR are not tested for on cluster build.
