### PR TITLE
chore(release): add tekton artifacts to release

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -21,11 +21,14 @@ VALIDATION_TESTS="make test"
 
 source $(dirname $0)/../vendor/knative.dev/hack/release.sh
 
+PIPELINE_ARTIFACTS="pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml"
+
 function build_release() {
   echo "🚧 🐧 Building cross platform binaries: Linux 🐧 (amd64 / arm64 / ppc64le / s390x), MacOS 🍏, and Windows 🎠"
   ETAG=${TAG} make cross-platform
 
   ARTIFACTS_TO_PUBLISH="func_darwin_amd64 func_darwin_arm64 func_linux_amd64 func_linux_arm64 func_linux_ppc64le func_linux_s390x func_windows_amd64.exe"
+  ARTIFACTS_TO_PUBLISH="${ARTIFACTS_TO_PUBLISH} ${PIPELINE_ARTIFACTS}"
   sha256sum ${ARTIFACTS_TO_PUBLISH} > checksums.txt
   ARTIFACTS_TO_PUBLISH="${ARTIFACTS_TO_PUBLISH} checksums.txt"
   echo "🧮     Checksum:"


### PR DESCRIPTION
# Changes

Adds the Tekton tasks for buildpacks, s2i and deployment to the release artifacts.

Note that the `checksums.txt` file will contain references to the full path of the files. I don't think this is a problem, but something to be look out for in case there is an issue.

/kind chore

**Release Note**
```release-note
Adds Tekton Tasks to release artifacts.
```
Fixes: https://github.com/knative/func/issues/1550
Related: https://github.com/knative/func/issues/1333