### PR TITLE
fix: missing map initializations

### DIFF
--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -150,6 +150,12 @@ func NewFunctionWith(defaults Function) Function {
 	if defaults.Template == "" {
 		defaults.Template = DefaultTemplate
 	}
+	if defaults.Build.BuilderImages == nil {
+		defaults.Build.BuilderImages = make(map[string]string)
+	}
+	if defaults.Deploy.Annotations == nil {
+		defaults.Deploy.Annotations = make(map[string]string)
+	}
 	return defaults
 }
 


### PR DESCRIPTION

- :bug: both function constructors now ensure maps are initialized

The helper Function constructor which uses a passed function as defaults, `NewFunctionWith` was missing map initialization.  This could lead to nil pointer exceptions as it is used by `client.Init`.

/kind bug