### PR TITLE
feat: common command aliases

### DIFF
--- a/cmd/config_envs.go
+++ b/cmd/config_envs.go
@@ -27,7 +27,8 @@ func NewConfigEnvsCmd(loadSaver functionLoaderSaver) *cobra.Command {
 Prints configured Environment variable for a function project present in
 the current directory or from the directory specified with --path.
 `,
-		SuggestFor: []string{"ensv", "env"},
+		Aliases:    []string{"env"},
+		SuggestFor: []string{"ensv"},
 		PreRunE:    bindEnv("path", "output"),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			function, err := initConfigCommand(loadSaver)
@@ -138,7 +139,8 @@ func NewConfigEnvsRemoveCmd() *cobra.Command {
 Interactive prompt to remove Environment variables from the function project
 in the current directory or from the directory specified with --path.
 `,
-		SuggestFor: []string{"rm", "del", "delete", "rmeove"},
+		Aliases:    []string{"rm"},
+		SuggestFor: []string{"del", "delete", "rmeove"},
 		PreRunE:    bindEnv("path"),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			function, err := initConfigCommand(defaultLoaderSaver)

--- a/cmd/config_labels.go
+++ b/cmd/config_labels.go
@@ -21,7 +21,8 @@ func NewConfigLabelsCmd(loaderSaver functionLoaderSaver) *cobra.Command {
 Prints configured labels for a function project present in
 the current directory or from the directory specified with --path.
 `,
-		SuggestFor: []string{"albels", "abels", "label"},
+		Aliases:    []string{"label"},
+		SuggestFor: []string{"albels", "abels"},
 		PreRunE:    bindEnv("path"),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			function, err := initConfigCommand(loaderSaver)
@@ -66,6 +67,7 @@ the local machine.
 Interactive prompt to remove labels from the function project in the current
 directory or from the directory specified with --path.
 `,
+		Aliases:    []string{"rm"},
 		SuggestFor: []string{"del", "delete", "rmeove"},
 		PreRunE:    bindEnv("path"),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/config_volumes.go
+++ b/cmd/config_volumes.go
@@ -21,7 +21,8 @@ func NewConfigVolumesCmd() *cobra.Command {
 Prints configured Volume mounts for a function project present in
 the current directory or from the directory specified with --path.
 `,
-		SuggestFor: []string{"volums", "volume", "vols"},
+		Aliases:    []string{"volume"},
+		SuggestFor: []string{"vol", "volums", "vols"},
 		PreRunE:    bindEnv("path"),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			function, err := initConfigCommand(defaultLoaderSaver)
@@ -81,6 +82,7 @@ func NewConfigVolumesRemoveCmd() *cobra.Command {
 Interactive prompt to remove Volume mounts from the function project
 in the current directory or from the directory specified with --path.
 `,
+		Aliases:    []string{"rm"},
 		SuggestFor: []string{"del", "delete", "rmeove"},
 		PreRunE:    bindEnv("path"),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -172,8 +172,9 @@ EXAMPLES
 
 func NewRepositoryListCmd(newClient ClientFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Short: "List repositories",
-		Use:   "list",
+		Short:   "List repositories",
+		Use:     "list",
+		Aliases: []string{"ls"},
 	}
 
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
@@ -209,6 +210,7 @@ func NewRepositoryRenameCmd(newClient ClientFactory) *cobra.Command {
 	cmd := &cobra.Command{
 		Short:   "Rename a repository",
 		Use:     "rename <old> <new>",
+		Aliases: []string{"mv"},
 		PreRunE: bindEnv("confirm"),
 	}
 


### PR DESCRIPTION


- :gift: commands which refer to sets ignore plurality
- :gift: aliases added for linux command synonyms

Ensures commands which have subcommands to operate on individual members (list, add, remove etc) have singular and plural as aliases.

Ensures consistent usage of linux-command-style aliases for list,remove and rename operations: "ls", "rm", "mv"

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement


```release-note
Commands such as `envs` can be referred to by their singular form `env` and vice-versa.
Commands with well-known command synonyms were added as aliases, such as`labels delete <name>` now supports `labels rm <name>`
```