### PR TITLE
chore: move prompts to a separate package

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 
+	"knative.dev/func/cmd/prompt"
 	"knative.dev/func/pkg/builders/buildpacks"
 	"knative.dev/func/pkg/config"
 	"knative.dev/func/pkg/docker"
@@ -115,8 +116,8 @@ func newTransport(insecureSkipVerify bool) fnhttp.RoundTripCloser {
 // of features or configuration nuances of cluster variants.
 func newCredentialsProvider(configPath string, t http.RoundTripper) docker.CredentialsProvider {
 	options := []creds.Opt{
-		creds.WithPromptForCredentials(newPromptForCredentials(os.Stdin, os.Stdout, os.Stderr)),
-		creds.WithPromptForCredentialStore(newPromptForCredentialStore()),
+		creds.WithPromptForCredentials(prompt.NewPromptForCredentials(os.Stdin, os.Stdout, os.Stderr)),
+		creds.WithPromptForCredentialStore(prompt.NewPromptForCredentialStore()),
 		creds.WithTransport(t),
 		creds.WithAdditionalCredentialLoaders(openshift.GetDockerCredentialLoaders()...),
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,18 +1,13 @@
 package cmd
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 	"strings"
 
-	"golang.org/x/term"
-
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
 	"knative.dev/client/pkg/util"
@@ -21,8 +16,6 @@ import (
 	"knative.dev/func/pkg/builders/buildpacks"
 	"knative.dev/func/pkg/builders/s2i"
 	"knative.dev/func/pkg/config"
-	"knative.dev/func/pkg/docker"
-	"knative.dev/func/pkg/docker/creds"
 	fn "knative.dev/func/pkg/functions"
 	"knative.dev/func/pkg/k8s"
 )
@@ -354,124 +347,6 @@ func KnownBuilders() builders.Known {
 	// However, future third-party integrations may support less than, or more
 	// builders, and certain environmental considerations may alter this list.
 	return builders.All()
-}
-
-func newPromptForCredentials(in io.Reader, out, errOut io.Writer) func(registry string) (docker.Credentials, error) {
-	firstTime := true
-	return func(registry string) (docker.Credentials, error) {
-		var result docker.Credentials
-
-		if firstTime {
-			firstTime = false
-			fmt.Fprintf(out, "Please provide credentials for image registry (%s).\n", registry)
-		} else {
-			fmt.Fprintln(out, "Incorrect credentials, please try again.")
-		}
-
-		var qs = []*survey.Question{
-			{
-				Name: "username",
-				Prompt: &survey.Input{
-					Message: "Username:",
-				},
-				Validate: survey.Required,
-			},
-			{
-				Name: "password",
-				Prompt: &survey.Password{
-					Message: "Password:",
-				},
-				Validate: survey.Required,
-			},
-		}
-
-		var (
-			fr terminal.FileReader
-			ok bool
-		)
-
-		isTerm := false
-		if fr, ok = in.(terminal.FileReader); ok {
-			isTerm = term.IsTerminal(int(fr.Fd()))
-		}
-
-		if isTerm {
-			err := survey.Ask(qs, &result, survey.WithStdio(fr, out.(terminal.FileWriter), errOut))
-			if err != nil {
-				return docker.Credentials{}, err
-			}
-		} else {
-			reader := bufio.NewReader(in)
-
-			fmt.Fprintf(out, "Username: ")
-			u, err := reader.ReadString('\n')
-			if err != nil {
-				return docker.Credentials{}, err
-			}
-			u = strings.Trim(u, "\r\n")
-
-			fmt.Fprintf(out, "Password: ")
-			p, err := reader.ReadString('\n')
-			if err != nil {
-				return docker.Credentials{}, err
-			}
-			p = strings.Trim(p, "\r\n")
-
-			result = docker.Credentials{Username: u, Password: p}
-		}
-
-		return result, nil
-	}
-}
-
-func newPromptForCredentialStore() creds.ChooseCredentialHelperCallback {
-	return func(availableHelpers []string) (string, error) {
-		if len(availableHelpers) < 1 {
-			fmt.Fprintf(os.Stderr, `Credentials will not be saved.
-If you would like to save your credentials in the future,
-you can install docker credential helper https://github.com/docker/docker-credential-helpers.
-`)
-			return "", nil
-		}
-
-		isTerm := term.IsTerminal(int(os.Stdin.Fd()))
-
-		var resp string
-
-		if isTerm {
-			err := survey.AskOne(&survey.Select{
-				Message: "Choose credentials helper",
-				Options: append(availableHelpers, "None"),
-			}, &resp, survey.WithValidator(survey.Required))
-			if err != nil {
-				return "", err
-			}
-			if resp == "None" {
-				fmt.Fprintf(os.Stderr, "No helper selected. Credentials will not be saved.\n")
-				return "", nil
-			}
-		} else {
-			fmt.Fprintf(os.Stderr, "Available credential helpers:\n")
-			for _, helper := range availableHelpers {
-				fmt.Fprintf(os.Stderr, "%s\n", helper)
-			}
-			fmt.Fprintf(os.Stderr, "Choose credentials helper: ")
-
-			reader := bufio.NewReader(os.Stdin)
-
-			var err error
-			resp, err = reader.ReadString('\n')
-			if err != nil {
-				return "", err
-			}
-			resp = strings.Trim(resp, "\r\n")
-			if resp == "" {
-				fmt.Fprintf(os.Stderr, "No helper selected. Credentials will not be saved.\n")
-			}
-		}
-
-		return resp, nil
-	}
 }
 
 type deployConfig struct {

--- a/cmd/prompt/prompt.go
+++ b/cmd/prompt/prompt.go
@@ -1,0 +1,134 @@
+package prompt
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/terminal"
+	"golang.org/x/term"
+
+	"knative.dev/func/pkg/docker"
+	"knative.dev/func/pkg/docker/creds"
+)
+
+func NewPromptForCredentials(in io.Reader, out, errOut io.Writer) func(registry string) (docker.Credentials, error) {
+	firstTime := true
+	return func(registry string) (docker.Credentials, error) {
+		var result docker.Credentials
+
+		if firstTime {
+			firstTime = false
+			fmt.Fprintf(out, "Please provide credentials for image registry (%s).\n", registry)
+		} else {
+			fmt.Fprintln(out, "Incorrect credentials, please try again.")
+		}
+
+		var qs = []*survey.Question{
+			{
+				Name: "username",
+				Prompt: &survey.Input{
+					Message: "Username:",
+				},
+				Validate: survey.Required,
+			},
+			{
+				Name: "password",
+				Prompt: &survey.Password{
+					Message: "Password:",
+				},
+				Validate: survey.Required,
+			},
+		}
+
+		var (
+			fr terminal.FileReader
+			ok bool
+		)
+
+		isTerm := false
+		if fr, ok = in.(terminal.FileReader); ok {
+			isTerm = term.IsTerminal(int(fr.Fd()))
+		}
+
+		if isTerm {
+			err := survey.Ask(qs, &result, survey.WithStdio(fr, out.(terminal.FileWriter), errOut))
+			if err != nil {
+				return docker.Credentials{}, err
+			}
+		} else {
+			reader := bufio.NewReader(in)
+
+			fmt.Fprintf(out, "Username: ")
+			u, err := reader.ReadString('\n')
+			if err != nil {
+				return docker.Credentials{}, err
+			}
+			u = strings.Trim(u, "\r\n")
+
+			fmt.Fprintf(out, "Password: ")
+			p, err := reader.ReadString('\n')
+			if err != nil {
+				return docker.Credentials{}, err
+			}
+			p = strings.Trim(p, "\r\n")
+
+			result = docker.Credentials{Username: u, Password: p}
+		}
+
+		return result, nil
+	}
+}
+
+func NewPromptForCredentialStore() creds.ChooseCredentialHelperCallback {
+	return func(availableHelpers []string) (string, error) {
+		if len(availableHelpers) < 1 {
+			fmt.Fprintf(os.Stderr, `Credentials will not be saved.
+If you would like to save your credentials in the future,
+you can install docker credential helper https://github.com/docker/docker-credential-helpers.
+`)
+			return "", nil
+		}
+
+		isTerm := term.IsTerminal(int(os.Stdin.Fd()))
+
+		var resp string
+
+		if isTerm {
+			err := survey.AskOne(&survey.Select{
+				Message: "Choose credentials helper",
+				Options: append(availableHelpers, "None"),
+			}, &resp, survey.WithValidator(survey.Required))
+			if err != nil {
+				return "", err
+			}
+			if resp == "None" {
+				fmt.Fprintf(os.Stderr, "No helper selected. Credentials will not be saved.\n")
+				return "", nil
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "Available credential helpers:\n")
+			for _, helper := range availableHelpers {
+				fmt.Fprintf(os.Stderr, "%s\n", helper)
+			}
+			fmt.Fprintf(os.Stderr, "Choose credentials helper: ")
+
+			reader := bufio.NewReader(os.Stdin)
+
+			var err error
+			resp, err = reader.ReadString('\n')
+			if err != nil {
+				return "", err
+			}
+			resp = strings.Trim(resp, "\r\n")
+			if resp == "" {
+				fmt.Fprintf(os.Stderr, "No helper selected. Credentials will not be saved.\n")
+			}
+		}
+
+		return resp, nil
+	}
+}

--- a/cmd/prompt/prompt_test.go
+++ b/cmd/prompt/prompt_test.go
@@ -1,7 +1,7 @@
 //go:build linux
 // +build linux
 
-package cmd
+package prompt
 
 import (
 	"io"
@@ -14,7 +14,11 @@ import (
 	"knative.dev/func/pkg/docker"
 )
 
-func Test_newPromptForCredentials(t *testing.T) {
+const (
+	enter = "\r"
+)
+
+func Test_NewPromptForCredentials(t *testing.T) {
 	expectedCreds := docker.Credentials{
 		Username: "testuser",
 		Password: "testpwd",
@@ -59,7 +63,7 @@ func Test_newPromptForCredentials(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			credPrompt := newPromptForCredentials(tt.in, tt.out, tt.errOut)
+			credPrompt := NewPromptForCredentials(tt.in, tt.out, tt.errOut)
 			cred, err := credPrompt("example.com")
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

Code clean up. These prompts were in `cmd/deploy.go` making the file quite long and these haven't been used there at all.

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: move prompts to a separate package

