### PR TITLE
chore: coverage for e2e tests

### DIFF
--- a/.github/workflows/test-e2e-oncluster-runtime.yaml
+++ b/.github/workflows/test-e2e-oncluster-runtime.yaml
@@ -7,7 +7,7 @@ jobs:
     name: On Cluster RT Test
     strategy:
       matrix:
-        go: [1.18.x]
+        go: [1.20.x]
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -29,4 +29,8 @@ jobs:
       - name: E2E On Cluster Test (Runtimes)
         env:
           TEST_TAGS: runtime
-        run: make && make test-e2e-on-cluster
+        run: make test-e2e-on-cluster
+      - uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.txt
+          flags: e2e-test-oncluster-runtime

--- a/.github/workflows/test-e2e-oncluster.yaml
+++ b/.github/workflows/test-e2e-oncluster.yaml
@@ -7,7 +7,7 @@ jobs:
     name: On Cluster Test
     strategy:
       matrix:
-        go: [1.18.x]
+        go: [1.20.x]
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -29,4 +29,8 @@ jobs:
       - name: E2E On Cluster Test
         env:
           E2E_RUNTIMES: ""
-        run: make && make test-e2e-on-cluster
+        run: make test-e2e-on-cluster
+      - uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.txt
+          flags: e2e-test-oncluster

--- a/.github/workflows/test-e2e-runtime.yaml
+++ b/.github/workflows/test-e2e-runtime.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.20.x
       - name: Install Binaries
         run: ./hack/binaries.sh
       - name: Allocate Cluster
@@ -28,3 +28,7 @@ jobs:
         run: make
       - name: E2E runtime for ${{ matrix.runtime }}
         run: make test-e2e-runtime runtime=${{ matrix.runtime }}
+      - uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.txt
+          flags: e2e-test-runtime-${{ matrix.runtime }}

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -7,7 +7,7 @@ jobs:
     name: E2E Test
     strategy:
       matrix:
-        go: [1.18.x]
+        go: [1.20.x]
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -22,4 +22,8 @@ jobs:
       - name: Local Registry
         run: ./hack/registry.sh
       - name: E2E Test
-        run: make && make test-e2e
+        run: make test-e2e
+      - uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.txt
+          flags: e2e-test

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /templates/typescript/http/build
 /coverage.out
 /coverage.txt
+/.coverage
 /bin
 /target
 

--- a/Makefile
+++ b/Makefile
@@ -144,14 +144,19 @@ test-typescript: ## Test Typescript templates
 test-integration: ## Run integration tests using an available cluster.
 	go test -tags integration -timeout 30m --coverprofile=coverage.txt ./... -v
 
-test-e2e: ## Run end-to-end tests using an available cluster.
+.PHONY: func-instrumented
+
+func-instrumented: ## Func binary that is instrumented for e2e tests
+	env CGO_ENABLED=1 go build -ldflags $(LDFLAGS) -race -cover -o func ./cmd/func
+
+test-e2e: func-instrumented ## Run end-to-end tests using an available cluster.
 	./test/e2e_lifecycle_tests.sh node
 	./test/e2e_extended_tests.sh
 
-test-e2e-runtime: ## Run end-to-end lifecycle tests using an available cluster for a single runtime.
+test-e2e-runtime: func-instrumented ## Run end-to-end lifecycle tests using an available cluster for a single runtime.
 	./test/e2e_lifecycle_tests.sh $(runtime)
 
-test-e2e-on-cluster: ## Run end-to-end on-cluster build tests using an available cluster.
+test-e2e-on-cluster: func-instrumented ## Run end-to-end on-cluster build tests using an available cluster.
 	./test/e2e_oncluster_tests.sh
 
 ######################

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ test-integration: ## Run integration tests using an available cluster.
 .PHONY: func-instrumented
 
 func-instrumented: ## Func binary that is instrumented for e2e tests
-	env CGO_ENABLED=1 go build -ldflags $(LDFLAGS) -race -cover -o func ./cmd/func
+	env CGO_ENABLED=1 go build -ldflags $(LDFLAGS) -cover -o func ./cmd/func
 
 test-e2e: func-instrumented ## Run end-to-end tests using an available cluster.
 	./test/e2e_lifecycle_tests.sh node

--- a/test/e2e_extended_tests.sh
+++ b/test/e2e_extended_tests.sh
@@ -31,9 +31,10 @@ set -o pipefail
 
 use_kn_func=${E2E_USE_KN_FUNC:-}
 
-curdir=$(pwd)
-cd $(dirname $0)
-cd ../
+pushd "$(dirname "$0")/.."
+mkdir -p .coverage
+GOCOVERDIR="$(pwd)/.coverage"
+export GOCOVERDIR
 
 # Make sure 'func' binary is built in case KN FUNC was not required for testing
 if [[ ! -f func && "$use_kn_func" != "true" ]]; then
@@ -47,5 +48,6 @@ go clean -testcache
 go test -v -test.v -tags="e2e" ./test/e2e/
 ret=$?
 
-cd $curdir
+go tool covdata textfmt -i=./.coverage -o coverage.txt
+popd
 exit $ret

--- a/test/e2e_lifecycle_tests.sh
+++ b/test/e2e_lifecycle_tests.sh
@@ -37,9 +37,10 @@ set -o pipefail
 runtime=${1:-}
 use_kn_func=${E2E_USE_KN_FUNC:-}
 
-curdir=$(pwd)
-cd $(dirname $0)
-cd ../
+pushd "$(dirname "$0")/.."
+mkdir -p .coverage
+GOCOVERDIR="$(pwd)/.coverage"
+export GOCOVERDIR
 
 # Make sure 'func' binary is built in case KN FUNC was not required for testing
 if [[ ! -f func && "$use_kn_func" != "true" ]]; then
@@ -57,5 +58,6 @@ go clean -testcache
 go test -v -test.v -test.timeout=45m -tags="e2elc" ./test/e2e/
 ret=$?
 
-cd $curdir
+go tool covdata textfmt -i=./.coverage -o coverage.txt
+popd
 exit $ret

--- a/test/e2e_oncluster_tests.sh
+++ b/test/e2e_oncluster_tests.sh
@@ -35,9 +35,10 @@ set -o pipefail
 runtime=${1:-}
 use_kn_func=${E2E_USE_KN_FUNC:-}
 
-curdir=$(pwd)
-cd $(dirname $0)
-cd ../
+pushd "$(dirname "$0")/.."
+mkdir -p .coverage
+GOCOVERDIR="$(pwd)/.coverage"
+export GOCOVERDIR
 
 REGISTRY_PROJ=knfunc$(head -c 128 </dev/urandom | LC_CTYPE=C tr -dc 'a-z0-9' | fold -w 8 | head -n 1)
 export E2E_REGISTRY_URL=${E2E_REGISTRY_URL:-ttl.sh/$REGISTRY_PROJ}
@@ -54,5 +55,6 @@ go clean -testcache
 go test -v -test.v -test.timeout=90m -tags="${TEST_TAGS:-oncluster}" ./test/oncluster/
 ret=$?
 
-cd $curdir
+go tool covdata textfmt -i=./.coverage -o coverage.txt
+popd
 exit $ret


### PR DESCRIPTION
# Changes

- :gift: Coverage for the end to end tests. With Go 1.20+ it is possible to instrument final binary to gather coverage.

