### PR TITLE
fix: build stamp computation

### DIFF
--- a/pkg/functions/client.go
+++ b/pkg/functions/client.go
@@ -617,12 +617,20 @@ func ensureRuntimeDir(f Function) error {
 		return err
 	}
 
+	_, err := os.Stat(".gitignore")
+	if err == nil {
+		return nil
+	}
+	if !os.IsNotExist(err) {
+		return err
+	}
+
 	gitignore := `
 # Functions use the .func directory for local runtime data which should
 # generally not be tracked in source control:
 /.func
 `
-	return os.WriteFile(filepath.Join(f.Root, ".gitignore"), []byte(gitignore), os.ModePerm)
+	return os.WriteFile(filepath.Join(f.Root, ".gitignore"), []byte(gitignore), 0644)
 
 }
 


### PR DESCRIPTION
# Changes

- :bug: Fix build stamp computation.
About the same time that `buildStamp` was computed `.gitignore` was (unnecessary) modified.
This caused timestamp mismatch so function appeared to be not built.
Reason: sometimes (randomly) the `buildStamp` was computed before the `.gitignore` was modified.

/kind bug

```release-note
fix: build stamp computation
```
