### PR TITLE
fix: node s2i build when node_modules present

### DIFF
--- a/pkg/builders/s2i/builder_test.go
+++ b/pkg/builders/s2i/builder_test.go
@@ -334,7 +334,7 @@ func TestBuildContextUpload(t *testing.T) {
 						return types.ImageBuildResponse{}, errors.New("bad content for a.txt")
 					}
 				default:
-					return types.ImageBuildResponse{}, errors.New("unexpected file")
+					return types.ImageBuildResponse{}, fmt.Errorf("unexpected file or directory: %q", hdr.Name)
 				}
 			}
 			return types.ImageBuildResponse{
@@ -351,6 +351,10 @@ func TestBuildContextUpload(t *testing.T) {
 				return nil, err
 			}
 			err = os.WriteFile(filepath.Join(filepath.Dir(config.AsDockerfile), "a.txt"), atxtContent, 0644)
+			if err != nil {
+				return nil, err
+			}
+			err = os.Mkdir(filepath.Join(filepath.Dir(config.AsDockerfile), "node_modules"), 0755)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
@@ -89,6 +89,9 @@ spec:
         fi
         sed -i "s|^registry:.*$|registry: $(params.REGISTRY)|" "$func_file"
         echo "Function image registry: $(params.REGISTRY)"
+        
+        s2iignore_file="$(dirname "$func_file")/.s2iignore"
+        [ -f "$s2iignore_file" ] || echo "node_modules" >> "$s2iignore_file"
 
       volumeMounts:
         - mountPath: /gen-source

--- a/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
@@ -89,7 +89,7 @@ spec:
         fi
         sed -i "s|^registry:.*$|registry: $(params.REGISTRY)|" "$func_file"
         echo "Function image registry: $(params.REGISTRY)"
-        
+
         s2iignore_file="$(dirname "$func_file")/.s2iignore"
         [ -f "$s2iignore_file" ] || echo "node_modules" >> "$s2iignore_file"
 

--- a/pkg/pipelines/tekton/pipeplines_provider.go
+++ b/pkg/pipelines/tekton/pipeplines_provider.go
@@ -252,9 +252,17 @@ func sourcesAsTarStream(f fn.Function) *io.PipeReader {
 					if err != nil {
 						return fmt.Errorf("cannot get relative path for symlink: %w", err)
 					}
-				}
-				if strings.HasPrefix(lnk, up) || lnk == ".." {
-					return fmt.Errorf("link %q points outside source root", p)
+					if strings.HasPrefix(lnk, up) || lnk == ".." {
+						return fmt.Errorf("link %q points outside source root", p)
+					}
+				} else {
+					t, err := filepath.Rel(f.Root, filepath.Join(filepath.Dir(p), lnk))
+					if err != nil {
+						return fmt.Errorf("cannot get relative path for symlink: %w", err)
+					}
+					if strings.HasPrefix(t, up) || t == ".." {
+						return fmt.Errorf("link %q points outside source root", p)
+					}
 				}
 			}
 


### PR DESCRIPTION
# Changes

- :bug: Fix NodeJS s2i build when `node_modules` is present on filesystem.
  This is workaround for two bug in another components:
    * The s2i CLI/library is not honoring the `--exclude` flag when used with the `--as-dockerfile` flag.
        https://github.com/openshift/source-to-image/issues/1104
    * The node s2i image is not working if project contains `node_modules` directory with NodeJS modules.
        https://github.com/sclorg/s2i-nodejs-container/issues/333
  
  If only one of the bugs above were fixed this PR wouldn't be necessary.

/kind bug

```release-note
fix: s2i build when node_modules present
```
