### PR TITLE
fix: TCP+TLS docker daemon connection

### DIFF
--- a/pkg/docker/docker_client.go
+++ b/pkg/docker/docker_client.go
@@ -158,7 +158,11 @@ func newHttpClient() *http.Client {
 
 	var tlsOpts []func(*tls.Config)
 
-	tlsVerify, _ := strconv.ParseBool(tlsVerifyStr)
+	tlsVerify := true
+	if b, err := strconv.ParseBool(tlsVerifyStr); err == nil {
+		tlsVerify = b
+	}
+
 	if !tlsVerify {
 		tlsOpts = append(tlsOpts, func(t *tls.Config) {
 			t.InsecureSkipVerify = true


### PR DESCRIPTION
# Changes

- :bug: Fix TCP+TLS docker daemon connection. If the `DOCKER_TLS_VERIFY` environment variable is set then TLS should be applied to the TCP connection to the docker daemon.

```release-note
fix: TCP+TLS docker daemon connection
```
