### PR TITLE
chore: fixup release.sh script

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -29,7 +29,7 @@ function build_release() {
 
   ARTIFACTS_TO_PUBLISH="func_darwin_amd64 func_darwin_arm64 func_linux_amd64 func_linux_arm64 func_linux_ppc64le func_linux_s390x func_windows_amd64.exe"
   ARTIFACTS_TO_PUBLISH="${ARTIFACTS_TO_PUBLISH} ${PIPELINE_ARTIFACTS}"
-  sha256sum ${ARTIFACTS_TO_PUBLISH} > checksums.txt
+  sha256sum "${ARTIFACTS_TO_PUBLISH}" > checksums.txt
   ARTIFACTS_TO_PUBLISH="${ARTIFACTS_TO_PUBLISH} checksums.txt"
   echo "🧮     Checksum:"
   cat checksums.txt

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -21,7 +21,7 @@ VALIDATION_TESTS="make test"
 
 source $(dirname $0)/../vendor/knative.dev/hack/release.sh
 
-PIPELINE_ARTIFACTS="pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml"
+PIPELINE_ARTIFACTS="pkg/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml"
 
 function build_release() {
   echo "🚧 🐧 Building cross platform binaries: Linux 🐧 (amd64 / arm64 / ppc64le / s390x), MacOS 🍏, and Windows 🎠"


### PR DESCRIPTION
After the repository reorg, the hack/release.sh script is no longer pointing at the correct task yamls.

Fixes: https://github.com/knative/func/issues/1651

/kind chore