### PR TITLE
test: cleanup on e2e github test

### DIFF
--- a/test/common/config.go
+++ b/test/common/config.go
@@ -33,12 +33,12 @@ func GetRegistry() string {
 
 // GetFuncBinaryPath should return the Path of 'func' binary under test
 func GetFuncBinaryPath() string {
-	return getOsEnvOrDefault("E2E_FUNC_BIN_PATH", "")
+	return GetOsEnvOrDefault("E2E_FUNC_BIN_PATH", "")
 }
 
 // GetRuntime returns the runtime that should be tested.
 func GetRuntime() string {
-	return getOsEnvOrDefault("E2E_RUNTIME", "node")
+	return GetOsEnvOrDefault("E2E_RUNTIME", "node")
 }
 
 // IsUseKnFunc indicates that tests should be run against "kn func" instead of "func" binary
@@ -46,7 +46,7 @@ func IsUseKnFunc() bool {
 	return strings.EqualFold(os.Getenv("E2E_USE_KN_FUNC"), "true")
 }
 
-func getOsEnvOrDefault(env string, dflt string) string {
+func GetOsEnvOrDefault(env string, dflt string) string {
 	e := os.Getenv(env)
 	if e == "" {
 		return dflt

--- a/test/oncluster/scenario_github_test.go
+++ b/test/oncluster/scenario_github_test.go
@@ -4,7 +4,6 @@
 package oncluster
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -20,7 +19,7 @@ Test scenario covered here:
 Notes:
  * The function used as input for this scenario is stored in this repository at /test/oncluster/testdata/simplefunc
 
- * On a CI Pull Request action (env CI="true") the branch used on the on-cluster test is the pull request reference.
+ * On a CI Pull Request action the branch used on the on-cluster test is the pull request reference.
    The equivalent deploy func command would look like this:
 
    func deploy --remote \
@@ -33,15 +32,11 @@ Notes:
 */
 
 func resolveGitVars() (gitRepoUrl string, gitRef string) {
-	var githubRepository = "knative/func"
-	gitRef = "main"
-	if os.Getenv("CI") == "true" {
-		// On a GitHub Action (Pull Request)
-		// https://docs.github.com/en/actions/learn-github-actions/variables
-		githubRepository, _ = os.LookupEnv("GITHUB_REPOSITORY")
-		gitRef, _ = os.LookupEnv("GITHUB_REF")
-	}
-	gitRepoUrl = "https://github.com/" + githubRepository + ".git"
+	// On a GitHub Action (Pull Request) these variables will be set
+	// https://docs.github.com/en/actions/learn-github-actions/variables
+	gitRepo := common.GetOsEnvOrDefault("GITHUB_REPOSITORY", "knative/func")
+	gitRef = common.GetOsEnvOrDefault("GITHUB_REF", "main")
+	gitRepoUrl = "https://github.com/" + gitRepo + ".git"
 	return
 }
 


### PR DESCRIPTION
# Changes

- :broom: No longer using CI env to detect github action for oncluster test. This var is also used by other CI systems (i.e Jenkins) and thus causing the test to fail when executed on other CI systems.

/kind cleanup
