### PR TITLE
feat: track go template sumfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 /func
 /func_*
 /cmd/func.yaml
-/templates/go/cloudevents/go.sum
-/templates/go/http/go.sum
 /templates/typescript/cloudevents/build
 /templates/typescript/http/build
 /coverage.out


### PR DESCRIPTION

- :broom:  enable tracking of Go sumfiles in templates

In order for Scaffolding to correctly associate the dependencies of the "embedded" function, we actually do need to track the initial sumfiles for the source function template.  This change should have no effect on "nonscaffolded" functions; and we probably should have been doing this anyway.

/kind cleanup