### PR TITLE
fix: building resets image digest

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -430,9 +430,12 @@ func (c deployConfig) Configure(f fn.Function) (fn.Function, error) {
 	// ImageDigest
 	// Parsed off f.Image if provided.  Deploying adds the ability to specify a
 	// digest on the associated image (not available on build as nonsensical).
-	f.ImageDigest, err = imageDigest(f.Image)
+	newDigest, err := imageDigest(f.Image)
 	if err != nil {
 		return f, err
+	}
+	if newDigest != "" {
+		f.ImageDigest = newDigest
 	}
 
 	// Envs


### PR DESCRIPTION
- :bug: fix builds sometimes not caching

Fixes a bug where the image digest was being cleared on a subsequent deploy, resulting in incorrect metadata and a build stamp which was always out-of-date (effectively disabling cached builds).

/kind bug