### PR TITLE
feat: job scaffolding

### DIFF
--- a/cmd/invoke_test.go
+++ b/cmd/invoke_test.go
@@ -48,8 +48,8 @@ func TestInvoke(t *testing.T) {
 		}()
 		_, port, _ := net.SplitHostPort(l.Addr().String())
 		errs := make(chan error, 10)
-		stop := func() { _ = s.Close() }
-		return fn.NewJob(f, port, errs, stop)
+		stop := func() error { _ = s.Close(); return nil }
+		return fn.NewJob(f, port, errs, stop, false)
 	}
 
 	// Run the mock http service function interloper
@@ -62,7 +62,7 @@ func TestInvoke(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(job.Stop)
+	t.Cleanup(func() { _ = job.Stop() })
 
 	// Test that the invoke command invokes
 	cmd := NewInvokeCmd(NewClient)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -206,7 +206,11 @@ func runRun(cmd *cobra.Command, args []string, newClient ClientFactory) (err err
 	if err != nil {
 		return
 	}
-	defer job.Stop()
+	defer func() {
+		if err = job.Stop(); err != nil {
+			fmt.Fprintf(cmd.OutOrStderr(), "Job stop error. %v", err)
+		}
+	}()
 
 	fmt.Fprintf(cmd.OutOrStderr(), "Running on host port %v\n", job.Port)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -216,6 +216,9 @@ func runRun(cmd *cobra.Command, args []string, newClient ClientFactory) (err err
 			err = cmd.Context().Err()
 		}
 	case err = <-job.Errors:
+		return
+		// Bubble up runtime errors on the optional channel used for async job
+		// such as docker containers.
 	}
 
 	// NOTE: we do not f.Write() here unlike deploy (and build).

--- a/pkg/docker/runner_int_test.go
+++ b/pkg/docker/runner_int_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package docker_test
 
 import (
@@ -49,6 +52,7 @@ func TestRun(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = j.Stop() })
+	time.Sleep(time.Second * 5)
 
 	var (
 		id  = "runner-test-id"

--- a/pkg/docker/runner_int_test.go
+++ b/pkg/docker/runner_int_test.go
@@ -45,7 +45,7 @@ func TestRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(j.Stop)
+	t.Cleanup(func() { _ = j.Stop() })
 	time.Sleep(time.Second * 5)
 
 	var (

--- a/pkg/functions/client_test.go
+++ b/pkg/functions/client_test.go
@@ -1297,8 +1297,8 @@ func TestClient_Invoke_HTTP(t *testing.T) {
 	runner.RunFn = func(ctx context.Context, f fn.Function) (*fn.Job, error) {
 		_, p, _ := net.SplitHostPort(l.Addr().String())
 		errs := make(chan error, 10)
-		stop := func() {}
-		return fn.NewJob(f, p, errs, stop)
+		stop := func() error { return nil }
+		return fn.NewJob(f, p, errs, stop, false)
 	}
 	client := fn.New(fn.WithRegistry(TestRegistry), fn.WithRunner(runner))
 
@@ -1313,7 +1313,7 @@ func TestClient_Invoke_HTTP(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(job.Stop)
+	t.Cleanup(func() { _ = job.Stop() })
 	// Invoke the function, which will use the mock Runner
 	h, r, err := client.Invoke(context.Background(), f.Root, "", message)
 	if err != nil {
@@ -1395,8 +1395,8 @@ func TestClient_Invoke_CloudEvent(t *testing.T) {
 	runner.RunFn = func(ctx context.Context, f fn.Function) (*fn.Job, error) {
 		_, p, _ := net.SplitHostPort(l.Addr().String())
 		errs := make(chan error, 10)
-		stop := func() {}
-		return fn.NewJob(f, p, errs, stop)
+		stop := func() error { return nil }
+		return fn.NewJob(f, p, errs, stop, false)
 	}
 	client := fn.New(fn.WithRegistry(TestRegistry), fn.WithRunner(runner))
 
@@ -1444,8 +1444,8 @@ func TestClient_Instances(t *testing.T) {
 	runner := mock.NewRunner()
 	runner.RunFn = func(_ context.Context, f fn.Function) (*fn.Job, error) {
 		errs := make(chan error, 10)
-		stop := func() {}
-		return fn.NewJob(f, "8080", errs, stop)
+		stop := func() error { return nil }
+		return fn.NewJob(f, "8080", errs, stop, false)
 	}
 
 	// Client with the mock runner

--- a/pkg/functions/client_test.go
+++ b/pkg/functions/client_test.go
@@ -485,7 +485,7 @@ func TestClient_Run(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer job.Stop()
+	defer func() { _ = job.Stop() }()
 
 	// Assert the runner was invoked, and with the expected root.
 	if !runner.RunInvoked {
@@ -1411,7 +1411,7 @@ func TestClient_Invoke_CloudEvent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer job.Stop()
+	defer func() { _ = job.Stop() }()
 
 	// Invoke the function, which will use the mock Runner
 	_, r, err := client.Invoke(context.Background(), f.Root, "", message)
@@ -1463,7 +1463,7 @@ func TestClient_Instances(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer job.Stop()
+	defer func() { _ = job.Stop() }()
 
 	// Get the local function instance info
 	instance, err := client.Instances().Local(context.Background(), f)

--- a/pkg/functions/job.go
+++ b/pkg/functions/job.go
@@ -38,7 +38,7 @@ func NewJob(f Function, port string, errs chan error, onStop func() error, verbo
 		return j, errors.New("initialized function required to create job")
 	}
 	if j.Port == "" {
-		return j, errors.New("port requred to create job")
+		return j, errors.New("port required to create job")
 	}
 	if j.Errors == nil {
 		j.Errors = make(chan error, 1)
@@ -93,7 +93,7 @@ func cleanupJobDirs(j *Job) error {
 		_ = ln.Close()
 		orphanedJobDir := filepath.Join(funcJobsDir(j.Function), d.Name())
 		if j.verbose {
-			fmt.Printf("No process listening on port %v.  Removing its job directoy\n", d.Name())
+			fmt.Printf("No process listening on port %v.  Removing its job directory\n", d.Name())
 			fmt.Printf("rm %v\n", orphanedJobDir)
 		}
 		return os.RemoveAll(orphanedJobDir)

--- a/pkg/functions/job.go
+++ b/pkg/functions/job.go
@@ -1,10 +1,15 @@
 package functions
 
 import (
+	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 )
+
+const runsDir = "runs"
 
 // Job represents a running function job (presumably started by this process'
 // Runner instance.
@@ -14,59 +19,86 @@ type Job struct {
 	Function Function
 	Port     string
 	Errors   chan error
-	onStop   func()
+	onStop   func() error
+	verbose  bool
 }
 
 // Create a new Job which represents a running function task by providing
 // the port on which it was started, a channel on which runtime errors can
 // be received, and a stop function.
-func NewJob(f Function, port string, errs chan error, onStop func()) (*Job, error) {
-	j := &Job{
+func NewJob(f Function, port string, errs chan error, onStop func() error, verbose bool) (j *Job, err error) {
+	j = &Job{
 		Function: f,
 		Port:     port,
 		Errors:   errs,
 		onStop:   onStop,
+		verbose:  verbose,
 	}
-	return j, j.save() // Everything is a file:  save instance data to disk.
+	if !f.Initialized() {
+		return j, errors.New("initialized function required to create job")
+	}
+	if j.Port == "" {
+		return j, errors.New("port requred to create job")
+	}
+	if j.Errors == nil {
+		j.Errors = make(chan error, 1)
+	}
+	if err = cleanupJobDirs(j); err != nil {
+		return
+	}
+	if j.verbose {
+		fmt.Printf("mkdir -p %v\n", j.Dir())
+	}
+	return j, os.MkdirAll(j.Dir(), os.ModePerm)
 }
 
 // Stop the Job, running the provided stop delegate and removing runtime
 // metadata from disk.
-func (j *Job) Stop() {
-	if j == nil {
-		return
+func (j *Job) Stop() error {
+	if j.verbose {
+		fmt.Printf("rm %v\n", j.Dir())
 	}
-	_ = j.remove() // Remove representation on disk
-	j.onStop()
+	if err := os.RemoveAll(j.Dir()); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: unable to remove run directory. %v", err)
+	}
+	return j.onStop()
 }
 
-func (j *Job) save() error {
-	instancesDir := filepath.Join(j.Function.Root, RunDataDir, "instances")
-	// job metadata is stored in <root>/.func/instances
-	if err := os.MkdirAll(instancesDir, os.ModePerm); err != nil {
-		return err
-	}
+// Directory within which all data about this current job is placed.
+// ${f.Root}/.func/runs/${j.Port}
+func (j *Job) Dir() string {
+	return filepath.Join(funcJobsDir(j.Function), j.Port)
+}
 
-	// create a file <root>/.func/instances/<port>
-	file, err := os.Create(filepath.Join(instancesDir, j.Port))
-	if err != nil {
-		return err
-	}
-	return file.Close()
+// Directory within which all runs (jobs) are held for the given function.
+// ${f.Root}/.func/runs/
+func funcJobsDir(f Function) string {
+	return filepath.Join(f.Root, RunDataDir, runsDir)
+}
 
-	// Store the effective port for use by other client instances, possibly
-	// in other processes, such as to run Invoke from other terminal in CLI apps.
-	/*
-		if err := writeFunc(f, "port", []byte(port)); err != nil {
-			return j, err
+// cleanupJobDirs removes any orphaned jobs' disk representation
+func cleanupJobDirs(j *Job) error {
+	dd, _ := os.ReadDir(funcJobsDir(j.Function))
+	for _, d := range dd {
+		if !d.IsDir() {
+			continue // ignore files in the directory (like a readme)
 		}
-		return j, nil
-	*/
-}
-
-func (j *Job) remove() error {
-	filename := filepath.Join(j.Function.Root, RunDataDir, "instances", j.Port)
-	return os.Remove(filename)
+		if _, err := strconv.Atoi(d.Name()); err != nil {
+			continue // ignore directories that aren't integers (ports)
+		}
+		ln, err := net.Listen("tcp", ":"+d.Name())
+		if err != nil {
+			continue // ignore if we can't bind to the port (running or invalid port)
+		}
+		_ = ln.Close()
+		orphanedJobDir := filepath.Join(funcJobsDir(j.Function), d.Name())
+		if j.verbose {
+			fmt.Printf("No process listening on port %v.  Removing its job directoy\n", d.Name())
+			fmt.Printf("rm %v\n", orphanedJobDir)
+		}
+		return os.RemoveAll(orphanedJobDir)
+	}
+	return nil
 }
 
 // jobPorts returns all the ports on which an instance of the given function is
@@ -77,19 +109,20 @@ func jobPorts(f Function) []string {
 	if f.Root == "" || !f.Initialized() {
 		return []string{}
 	}
-	instancesDir := filepath.Join(f.Root, RunDataDir, "instances")
-	if _, err := os.Stat(instancesDir); err != nil {
+	jobsDir := funcJobsDir(f)
+	if _, err := os.Stat(jobsDir); err != nil {
 		return []string{} // never started, so path does not exist
 	}
 
-	files, err := os.ReadDir(instancesDir)
+	files, err := os.ReadDir(jobsDir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error reading %v", instancesDir)
+		fmt.Fprintf(os.Stderr, "error reading %v", jobsDir)
 		return []string{}
 	}
 	ports := []string{}
 	for _, f := range files {
 		ports = append(ports, f.Name())
 	}
+	// TODO: validate it's a directory whose name parses as an integer?
 	return ports
 }

--- a/pkg/functions/job_test.go
+++ b/pkg/functions/job_test.go
@@ -1,0 +1,96 @@
+package functions
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "knative.dev/func/pkg/testing"
+)
+
+// TestJob_New ensures that creating a new Job creates the expected errors if
+// incomplete and the client registers the job as being available for the
+// function when created.
+//
+// This is ver much a unit test mostly confirming implementation details, the
+// more complete test is the integration test which invokes "run".  Presuming
+// this works for both containerized and noncontainerized funcitions, the
+// correctness of the Job implementation is inferred (with the possible
+// exception of not cleaning up after itself, which is an implementatoin best
+// left to unit tests here).
+func TestJob_New(t *testing.T) {
+	root, rm := Mktemp(t)
+	defer rm()
+	client := New()
+
+	// create a new function
+	f, err := client.Init(Function{Runtime: "go", Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert that an initialized function and port are required
+	onStop := func() error { return nil }
+	if _, err := NewJob(Function{}, "", nil, onStop, false); err == nil {
+		t.Fatal("expected NewJob to require an initialized functoin")
+	}
+	if _, err := NewJob(f, "", nil, onStop, false); err == nil {
+		t.Fatal("expected NewJob to require a port")
+	}
+
+	// Assert creating a Job with the required arguments succeeds.
+	_, err = NewJob(f, "8080", nil, onStop, false)
+	if err != nil {
+		t.Fatalf("creating job failed. %s", err)
+	}
+
+	// Assert that the client recognizes a job is running for the given function
+	// NOTE: the Instances API will be updated to return []Instance to reflect
+	// that the system supports multiple instances running simultaneously.
+	_, err = client.Instances().Local(context.Background(), f)
+	if err != nil {
+		if errors.Is(err, ErrNotRunning) {
+			t.Fatalf("client does not recognize job as running. %s", err)
+		} else {
+			t.Fatalf("unexpected error checking client for instance's existence. %s", err)
+		}
+	}
+
+}
+
+// TestJob_Stop ensures that stopping a local job results in the API no longer
+// recognizing it as running, and invokes the onStop function
+func TestJob_Stop(t *testing.T) {
+	root, rm := Mktemp(t)
+	defer rm()
+	client := New()
+
+	f, err := client.Init(Function{Runtime: "go", Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert that an initialized function and port are required
+	var onStopInvoked bool
+	onStop := func() error { onStopInvoked = true; return nil }
+
+	// Assert creating a Job with the required arguments succeeds.
+	j, err := NewJob(f, "8080", nil, onStop, false)
+	if err != nil {
+		t.Fatalf("creating job failed. %s", err)
+	}
+	_, err = client.Instances().Local(context.Background(), f)
+	if err != nil {
+		if errors.Is(err, ErrNotRunning) {
+			t.Fatalf("client does not recognize job as running. %s", err)
+		} else {
+			t.Fatalf("unexpected error checking client for instance's existence. %s", err)
+		}
+	}
+	if err := j.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	if !onStopInvoked {
+		t.Fatal("the job stopped but did not invoke the onStop handler")
+	}
+}

--- a/pkg/mock/runner.go
+++ b/pkg/mock/runner.go
@@ -20,8 +20,8 @@ func NewRunner() *Runner {
 	return &Runner{
 		RunFn: func(ctx context.Context, f fn.Function) (*fn.Job, error) {
 			errs := make(chan error, 1)
-			stop := func() {}
-			return fn.NewJob(f, "8080", errs, stop)
+			stop := func() error { return nil }
+			return fn.NewJob(f, "8080", errs, stop, false)
 		},
 	}
 }


### PR DESCRIPTION
- :gift: client Jobs support scaffolding (backwards compatibly)

- Local jobs use a directory rather than filename This sets up for upcoming scaffolding to use as a space for job scaffolding code.
- Places all jobs within a 'runs' directory in ./func rather than 'instances' to further differentiate between an instance and a local run task invoked via .Run
- Updates Jobs' stop handler to have an error return.
- Adds tests which ensure creating and stopping a job are reflected in the client's .Instances().Local() accessor.
- Adds verbose logging support to the Job implementation.
- Adds a cleanup task which will remove orphaned jobs by, in addition to previous logic, checking that there is no longer a process listening on the port indicated by the job.

/kind enhancement