### PR TITLE
src: Envs type

### DIFF
--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -393,7 +393,7 @@ func TestDeploy_Envs(t *testing.T) {
 		{Name: ptr("ENV1"), Value: ptr("VAL1")},
 		{Name: ptr("ENV2"), Value: ptr("VAL2")},
 	}
-	if !reflect.DeepEqual(f.Run.Envs, expected) {
+	if !reflect.DeepEqual(f.Run.Envs, fn.Envs(expected)) {
 		t.Fatalf("Expected envs '%v', got '%v'", expected, f.Run.Envs)
 	}
 
@@ -412,7 +412,7 @@ func TestDeploy_Envs(t *testing.T) {
 		{Name: ptr("ENV2"), Value: ptr("VAL2")},
 		{Name: ptr("ENV3"), Value: ptr("VAL3")},
 	}
-	if !reflect.DeepEqual(f.Run.Envs, expected) {
+	if !reflect.DeepEqual(f.Run.Envs, fn.Envs(expected)) {
 		t.Fatalf("Expected envs '%v', got '%v'", expected, f.Run.Envs)
 	}
 
@@ -429,7 +429,7 @@ func TestDeploy_Envs(t *testing.T) {
 		{Name: ptr("ENV2"), Value: ptr("VAL2")},
 		{Name: ptr("ENV3"), Value: ptr("VAL3")},
 	}
-	if !reflect.DeepEqual(f.Run.Envs, expected) {
+	if !reflect.DeepEqual(f.Run.Envs, fn.Envs(expected)) {
 		t.Fatalf("Expected envs '%v', got '%v'", expected, f.Run.Envs)
 	}
 

--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -117,7 +117,7 @@ type BuildSpec struct {
 	Builder string `yaml:"builder,omitempty" jsonschema:"enum=pack,enum=s2i"`
 
 	// Build Env variables to be set
-	BuildEnvs []Env `yaml:"buildEnvs,omitempty"`
+	BuildEnvs Envs `yaml:"buildEnvs,omitempty"`
 
 	// PVCSize specifies the size of persistent volume claim used to store function
 	// when using deployment and remote build process (only relevant when Remote is true).
@@ -130,7 +130,7 @@ type RunSpec struct {
 	Volumes []Volume `yaml:"volumes,omitempty"`
 
 	// Env variables to be set
-	Envs []Env `yaml:"envs,omitempty"`
+	Envs Envs `yaml:"envs,omitempty"`
 }
 
 // DeploySpec

--- a/pkg/functions/function_envs.go
+++ b/pkg/functions/function_envs.go
@@ -7,6 +7,34 @@ import (
 	"knative.dev/func/pkg/utils"
 )
 
+type Envs []Env
+
+// String returns Envs as a space-separated set of environment variable
+// declarations in the form "KEY=VALUE K2=V2"
+func (ee Envs) String() string {
+	return strings.Join(ee.Slice(), " ")
+}
+
+// Slice returns Envs as a []strings in format NAME=VALUE
+// Note that Env structs with a nil pointer for name are ignored because
+// "=VALUE" is an invalid environment variable declaration.
+func (ee Envs) Slice() []string {
+	// TODO: removing pointers from the Env slice type (and the others)
+	// would probably be worth the effort.
+	s := []string{}
+	for _, e := range ee {
+		if e.Name == nil {
+			continue
+		}
+		if e.Value == nil {
+			s = append(s, *e.Name+"=")
+			continue
+		}
+		s = append(s, *e.Name+"="+*e.Value)
+	}
+	return s
+}
+
 type Env struct {
 	Name  *string `yaml:"name,omitempty" jsonschema:"pattern=^[-._a-zA-Z][-._a-zA-Z0-9]*$"`
 	Value *string `yaml:"value,omitempty"`

--- a/pkg/functions/repository_test.go
+++ b/pkg/functions/repository_test.go
@@ -119,7 +119,7 @@ func TestRepository_Inheritance(t *testing.T) {
 		},
 	}
 
-	if diff := cmp.Diff(envs, fB.Build.BuildEnvs); diff != "" {
+	if diff := cmp.Diff(fn.Envs(envs), fB.Build.BuildEnvs); diff != "" {
 		t.Fatalf("Unexpected difference between repository's manifest.yaml buildEnvs and function BuildEnvs (-want, +got): %v", diff)
 	}
 

--- a/pkg/functions/templates_test.go
+++ b/pkg/functions/templates_test.go
@@ -409,7 +409,7 @@ func TestTemplates_RuntimeManifestBuildEnvs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if diff := cmp.Diff(envs, f.Build.BuildEnvs); diff != "" {
+	if diff := cmp.Diff(fn.Envs(envs), f.Build.BuildEnvs); diff != "" {
 		t.Fatalf("Unexpected difference between runtime's manifest.yaml buildEnvs and function BuildEnvs (-want, +got): %v", diff)
 	}
 }
@@ -456,7 +456,7 @@ func TestTemplates_ManifestBuildEnvs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if diff := cmp.Diff(envs, f.Build.BuildEnvs); diff != "" {
+	if diff := cmp.Diff(fn.Envs(envs), f.Build.BuildEnvs); diff != "" {
 		t.Fatalf("Unexpected difference between template's manifest.yaml buildEnvs and function BuildEnvs (-want, +got): %v", diff)
 	}
 }
@@ -503,7 +503,7 @@ func TestTemplates_RepositoryManifestBuildEnvs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if diff := cmp.Diff(envs, f.Build.BuildEnvs); diff != "" {
+	if diff := cmp.Diff(fn.Envs(envs), f.Build.BuildEnvs); diff != "" {
 		t.Fatalf("Unexpected difference between repository's manifest.yaml buildEnvs and function BuildEnvs (-want, +got): %v", diff)
 	}
 }


### PR DESCRIPTION
- :broom: simplify usage of []Env using a type serialization helpers

Creates a type for []Env with a String and Slice method for presenting a set of environment variables in common formats.

/kind cleanup