### PR TITLE
fix: PaC not working with dot git suffixed URLs

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -61,5 +61,7 @@ func RepoOwnerAndNameFromUrl(url string) (string, string, error) {
 	repoOwner := repoArr[0]
 	repoName := repoArr[1]
 
+	repoName = strings.TrimSuffix(repoName, ".git")
+
 	return repoOwner, repoName, nil
 }

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -18,6 +18,13 @@ func TestGetRepoOwnerFromGHURL(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			name:      "correct with dot git suffix",
+			url:       "https://gh/foo/bar.git",
+			wantOwner: "foo",
+			wantName:  "bar",
+			wantErr:   false,
+		},
+		{
 			name:      "correct with capital letters",
 			url:       "https://gh/FOO/bar",
 			wantOwner: "foo",


### PR DESCRIPTION
# Changes


- :bug: Fix PaC not working with `.git` suffixed URLs.

/kind bug

fixes #1707

```release-note
fix: PaC not working with dot git suffixed URLs
```

