### PR TITLE
chore: update docs from changes to deploy/run

### DIFF
--- a/docs/reference/func_build.md
+++ b/docs/reference/func_build.md
@@ -11,6 +11,7 @@ NAME
 SYNOPSIS
 	func build [-r|--registry] [--builder] [--builder-image] [--push]
 	             [--platform] [-p|--path] [-c|--confirm] [-v|--verbose]
+               [--build-timestamp]
 
 DESCRIPTION
 
@@ -55,6 +56,7 @@ func build
 ### Options
 
 ```
+      --build-timestamp        Use the actual time as the created time for the docker image. This is only useful for buildpacks builder.
   -b, --builder string         Builder to use when creating the function's container. Currently supported builders are "pack" and "s2i". ($FUNC_BUILDER) (default "pack")
       --builder-image string   Specify a custom builder image for use by the builder other than its default. ($FUNC_BUILDER_IMAGE)
   -c, --confirm                Prompt to confirm options interactively ($FUNC_CONFIRM)

--- a/docs/reference/func_deploy.md
+++ b/docs/reference/func_deploy.md
@@ -10,9 +10,9 @@ NAME
 
 SYNOPSIS
 	func deploy [-R|--remote] [-r|--registry] [-i|--image] [-n|--namespace]
-	             [-e|env] [-g|--git-url] [-t|git-branch] [-d|--git-dir]
+	             [-e|--env] [-g|--git-url] [-t|--git-branch] [-d|--git-dir]
 	             [-b|--build] [--builder] [--builder-image] [-p|--push]
-	             [--platform] [-c|--confirm] [-v|--verbose]
+	             [--platform] [-c|--confirm] [-v|--verbose] [--build-timestamp]
 
 DESCRIPTION
 
@@ -104,6 +104,7 @@ func deploy
 
 ```
       --build string[="true"]   Build the function. [auto|true|false]. ($FUNC_BUILD) (default "auto")
+      --build-timestamp         Use the actual time as the created time for the docker image. This is only useful for buildpacks builder.
   -b, --builder string          Builder to use when creating the function's container. Currently supported builders are "pack" and "s2i". (default "pack")
       --builder-image string    Specify a custom builder image for use by the builder other than its default. ($FUNC_BUILDER_IMAGE)
   -c, --confirm                 Prompt to confirm options interactively ($FUNC_CONFIRM)

--- a/docs/reference/func_run.md
+++ b/docs/reference/func_run.md
@@ -4,58 +4,67 @@ Run the function locally
 
 ### Synopsis
 
-Run the function locally
 
-Runs the function locally in the current directory or in the directory
-specified by --path flag.
+NAME
+	func run - Run a function locally
 
-Building
-By default the function will be built if never built, or if changes are detected
-to the function's source.  Use --build to override this behavior.
-Also a builder strategy (pack, s2i) can be chosen using the --builder option.
-Default builder is pack.
+SYNOPSIS
+	func run [-t|--container] [-r|--registry] [-i|--image] [-e|--env]
+	             [--build] [-b|--builder] [--builder-image] [-c|--confirm]
+	             [-v|--verbose]
 
+DESCRIPTION
+	Run the function locally.
+
+	Values provided for flags are not persisted to the function's metadata.
+
+	Containerized Runs
+	  The --container flag indicates that the function's container shuould be
+	  run rather than running the source code directly.  This may require that
+	  the function's container first be rebuilt.  Building the container on or
+	  off can be altered using the --build flag.  The default value --build=auto
+	  indicates the system should automatically build the container only if
+	  necessary.
+
+	Process Scaffolding
+	  This is an Experimental Feature currently available only to Go projects.
+	  When running a function with --container=false (host-based runs), the
+	  function is first wrapped code which presents it as a process.
+	  This "scaffolding" is transient, written for each build or run, and should
+	  in most cases be transparent to a function author.  However, to customize,
+	  or even completely replace this scafolding code, see the 'scaffold'
+	  subcommand.
+
+EXAMPLES
+
+	o Run the function locally from within its container.
+	  $ func run
+
+	o Run the function locally from within its container, forcing a rebuild
+	  of the container even if no filesysem changes are detected
+	  $ func run --build
+
+	o Run the function locally on the host with no containerization (Go only).
+	  $ func run --container=false
 
 
 ```
 func run
-```
-
-### Examples
-
-```
-
-# Run the function locally, building if necessary
-func run
-
-# Run the function locally, building if necessary, with --builder option
-func run --builder s2i
-
-# Run the function, forcing a rebuild of the image.
-#   This is useful when the function's image was manually deleted, necessitating
-#   A rebuild even when no changes have been made the function's source.
-func run --build
-
-# Run the function, forcing a rebuild of the image with --builder option.
-func run --build --builder s2i
-
-# Run the function's existing image, disabling auto-build.
-#   This is useful when filesystem changes have been made, but one wishes to
-#   run the previously built image without rebuilding.
-func run --build=false
-
-
 ```
 
 ### Options
 
 ```
-  -b, --build string[="true"]   Build the function. [auto|true|false]. (default "auto")
-      --builder string          Builder to use when creating the function's container. Currently supported builders are "pack" and "s2i". ($FUNC_BUILDER) (default "pack")
+      --build string[="true"]   Build the function. [auto|true|false]. ($FUNC_BUILD) (default "auto")
+  -b, --builder string          Builder to use when creating the function's container. Currently supported builders are "pack" and "s2i". (default "pack")
+      --builder-image string    Specify a custom builder image for use by the builder other than its default. ($FUNC_BUILDER_IMAGE)
+  -c, --confirm                 Prompt to confirm options interactively ($FUNC_CONFIRM)
+  -t, --container               Run the function in a container. ($FUNC_CONTAINER) (default true)
   -e, --env stringArray         Environment variable to set in the form NAME=VALUE. You may provide this flag multiple times for setting multiple environment variables. To unset, specify the environment variable name followed by a "-" (e.g., NAME-).
   -h, --help                    help for run
+  -i, --image string            Full image name in the form [registry]/[namespace]/[name]:[tag]. This option takes precedence over --registry. Specifying tag is optional. ($FUNC_IMAGE)
   -p, --path string             Path to the function.  Default is current directory ($FUNC_PATH)
-  -r, --registry string         Registry + namespace part of the image if building, ex 'quay.io/myuser' ($FUNC_REGISTRY)
+  -r, --registry string         Container registry + registry namespace. (ex 'ghcr.io/myuser').  The full image name is automatically determined using this along with function name. ($FUNC_REGISTRY)
   -v, --verbose                 Print verbose logs ($FUNC_VERBOSE)
 ```
 


### PR DESCRIPTION
The docs were overlooked in the changes to deploy and run in https://github.com/knative/func/pull/1693. This commit just updates the docs so they are consistent with the binary.
