### PR TITLE
fix: use full builder for Rust

### DIFF
--- a/pkg/builders/buildpacks/builder.go
+++ b/pkg/builders/buildpacks/builder.go
@@ -31,7 +31,7 @@ var (
 		"go":         "gcr.io/paketo-buildpacks/builder:base",
 		"python":     "gcr.io/paketo-buildpacks/builder:base",
 		"quarkus":    "gcr.io/paketo-buildpacks/builder:base",
-		"rust":       "gcr.io/paketo-buildpacks/builder:base",
+		"rust":       "gcr.io/paketo-buildpacks/builder:full-cf",
 		"springboot": "gcr.io/paketo-buildpacks/builder:base",
 	}
 


### PR DESCRIPTION
# Changes

- :broom: Use `full` builder for Rust. This is need to make some libs work (e.g. openssl).
