### PR TITLE
chore: improve error message when no func on path

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -32,7 +32,7 @@ func (s standardLoaderSaver) Load(path string) (fn.Function, error) {
 		return fn.Function{}, fmt.Errorf("failed to create new function (path: %q): %w", path, err)
 	}
 	if !f.Initialized() {
-		return fn.Function{}, fmt.Errorf("the given path '%v' does not contain an initialized function", path)
+		return fn.Function{}, fmt.Errorf("the given path '%v' does not contain an initialized function", f.Root)
 	}
 	return f, nil
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -80,7 +80,7 @@ func runDelete(cmd *cobra.Command, args []string, newClient ClientFactory) (err 
 
 		// Check if the function has been initialized
 		if !function.Initialized() {
-			return fmt.Errorf("the given path '%v' does not contain an initialized function", cfg.Path)
+			return fmt.Errorf("the given path '%v' does not contain an initialized function", function.Root)
 		}
 
 		// If not provided, use the function's extant namespace

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -74,7 +74,7 @@ func runDescribe(cmd *cobra.Command, args []string, newClient ClientFactory) (er
 			return
 		}
 		if !f.Initialized() {
-			return fmt.Errorf("the given path '%v' does not contain an initialized function.", cfg.Path)
+			return fmt.Errorf("the given path '%v' does not contain an initialized function.", f.Root)
 		}
 		// Use Function's Namespace with precedence
 		//

--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -145,7 +145,7 @@ func runInvoke(cmd *cobra.Command, args []string, newClient ClientFactory) (err 
 		return
 	}
 	if !f.Initialized() {
-		return fmt.Errorf("'%v' does not contain an initialized function", cfg.Path)
+		return fmt.Errorf("'%v' does not contain an initialized function", f.Root)
 	}
 
 	// Client instance from env vars, flags, args and user prompts (if --confirm)


### PR DESCRIPTION
# Changes

- :broom: More clear error message when path does not contain initialized function.
