### PR TITLE
chore: improve error messages for most commands

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -149,6 +149,9 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 	if f, err = fn.NewFunction(cfg.Path); err != nil {
 		return
 	}
+	if !f.Initialized() {
+		return fn.NewUninitializedError(f.Root)
+	}
 	f = cfg.Configure(f) // Updates f at path to include build request values
 
 	// TODO: this logic is duplicated with runDeploy.  Shouild be in buildConfig

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -32,7 +32,7 @@ func (s standardLoaderSaver) Load(path string) (fn.Function, error) {
 		return fn.Function{}, fmt.Errorf("failed to create new function (path: %q): %w", path, err)
 	}
 	if !f.Initialized() {
-		return fn.Function{}, fmt.Errorf("the given path '%v' does not contain an initialized function", f.Root)
+		return fn.Function{}, fn.NewUninitializedError(f.Root)
 	}
 	return f, nil
 }
@@ -165,7 +165,7 @@ func initConfigCommand(loader functionLoader) (fn.Function, error) {
 
 	function, err := loader.Load(config.Path)
 	if err != nil {
-		return fn.Function{}, fmt.Errorf("failed to load the function (path: %q): %w", config.Path, err)
+		return fn.Function{}, err
 	}
 
 	return function, nil

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -67,7 +67,7 @@ func runDelete(cmd *cobra.Command, args []string, newClient ClientFactory) (err 
 	if len(args) > 0 && args[0] != "" {
 		pathChanged := cmd.Flags().Changed("path")
 		if pathChanged {
-			return fmt.Errorf("Only one of --path and [NAME] should be provided")
+			return fmt.Errorf("only one of --path and [NAME] should be provided")
 		}
 		function = fn.Function{
 			Name: args[0],
@@ -80,7 +80,7 @@ func runDelete(cmd *cobra.Command, args []string, newClient ClientFactory) (err 
 
 		// Check if the function has been initialized
 		if !function.Initialized() {
-			return fmt.Errorf("the given path '%v' does not contain an initialized function", function.Root)
+			return fn.NewUninitializedError(function.Root)
 		}
 
 		// If not provided, use the function's extant namespace

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -227,6 +227,9 @@ func runDeploy(cmd *cobra.Command, newClient ClientFactory) (err error) {
 	if f, err = fn.NewFunction(cfg.Path); err != nil {
 		return
 	}
+	if !f.Initialized() {
+		return fn.NewUninitializedError(f.Root)
+	}
 	if f, err = cfg.Configure(f); err != nil { // Updates f with deploy cfg
 		return
 	}

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -74,7 +74,7 @@ func runDescribe(cmd *cobra.Command, args []string, newClient ClientFactory) (er
 			return
 		}
 		if !f.Initialized() {
-			return fmt.Errorf("the given path '%v' does not contain an initialized function.", f.Root)
+			return fn.NewUninitializedError(f.Root)
 		}
 		// Use Function's Namespace with precedence
 		//

--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -144,8 +144,12 @@ func runInvoke(cmd *cobra.Command, args []string, newClient ClientFactory) (err 
 	if err != nil {
 		return
 	}
+	if err = f.Validate(); err != nil {
+		fmt.Printf("error validating function at '%v'. %v\n", f.Root, err)
+		return err
+	}
 	if !f.Initialized() {
-		return fmt.Errorf("'%v' does not contain an initialized function", f.Root)
+		return fn.NewUninitializedError(f.Root)
 	}
 
 	// Client instance from env vars, flags, args and user prompts (if --confirm)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -146,6 +146,9 @@ func runRun(cmd *cobra.Command, args []string, newClient ClientFactory) (err err
 	if f, err = fn.NewFunction(cfg.Path); err != nil {
 		return
 	}
+	if !f.Initialized() {
+		return fn.NewUninitializedError(f.Root)
+	}
 	if f, err = cfg.Configure(f); err != nil { // Updates f with deploy cfg
 		return
 	}

--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -163,6 +163,18 @@ type BuildConfig struct {
 	BuilderImages map[string]string `yaml:"builderImages,omitempty"`
 }
 
+type UninitializedError struct {
+	Path string
+}
+
+func (e *UninitializedError) Error() string {
+	return fmt.Sprintf("'%s' does not contain an initialized function", e.Path)
+}
+
+func NewUninitializedError(path string) error {
+	return &UninitializedError{Path: path}
+}
+
 // NewFunctionWith defaults as provided.
 func NewFunctionWith(defaults Function) Function {
 	if defaults.SpecVersion == "" {


### PR DESCRIPTION
# Changes

- :broom: adds a new error type `UninitializedError` to minimize redundancy across commands, and applies it in all of the commands which need an initialized function to operate.

Fixes: https://github.com/knative/func/issues/1744

/kind cleanup
