### PR TITLE
feat: enable host-based build and push on build cmd

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -14,6 +14,7 @@ import (
 	"knative.dev/func/pkg/builders/s2i"
 	"knative.dev/func/pkg/config"
 	fn "knative.dev/func/pkg/functions"
+	"knative.dev/func/pkg/oci"
 )
 
 func NewBuildCmd(newClient ClientFactory) *cobra.Command {
@@ -156,8 +157,9 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 
 	// TODO: this logic is duplicated with runDeploy.  Shouild be in buildConfig
 	// constructor.
-	// Checks if there is a difference between defined registry and its value used as a prefix in the image tag
-	// In case of a mismatch a new image tag is created and used for build
+	// Checks if there is a difference between defined registry and its value
+	// used as a prefix in the image tag In case of a mismatch a new image tag is
+	// created and used for build.
 	// Do not react if image tag has been changed outside configuration
 	if f.Registry != "" && !cmd.Flags().Changed("image") && strings.Index(f.Image, "/") > 0 && !strings.HasPrefix(f.Image, f.Registry) {
 		prfx := f.Registry
@@ -171,23 +173,14 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 	}
 
 	// Client
-	// Concrete implementations (ex builder) vary based on final effective config
-	o := []fn.Option{fn.WithRegistry(cfg.Registry)}
-	if f.Build.Builder == builders.Pack {
-		o = append(o, fn.WithBuilder(pack.NewBuilder(
-			pack.WithName(builders.Pack),
-			pack.WithTimestamp(cfg.WithTimestamp),
-			pack.WithVerbose(cfg.Verbose))))
-	} else if f.Build.Builder == builders.S2I {
-		o = append(o, fn.WithBuilder(s2i.NewBuilder(
-			s2i.WithName(builders.S2I),
-			s2i.WithVerbose(cfg.Verbose))))
+	clientOptions, err := cfg.clientOptions()
+	if err != nil {
+		return
 	}
-
-	client, done := newClient(ClientConfig{Verbose: cfg.Verbose}, o...)
+	client, done := newClient(ClientConfig{Verbose: cfg.Verbose}, clientOptions...)
 	defer done()
 
-	// Build and (optionally) push
+	// Build
 	buildOptions, err := cfg.buildOptions()
 	if err != nil {
 		return
@@ -234,26 +227,6 @@ type buildConfig struct {
 	// Build with the current timestamp as the created time for docker image.
 	// This is only useful for buildpacks builder.
 	WithTimestamp bool
-}
-
-func (c buildConfig) buildOptions() (oo []fn.BuildOption, err error) {
-	oo = []fn.BuildOption{}
-
-	// Platforms
-	//
-	// TODO: upgrade --platform to a multi-value field.  The individual builder
-	// implementations are responsible for bubbling an error if they do
-	// not support this.  Pack  supports none, S2I supports one, host builder
-	// supports multi.
-	if c.Platform != "" {
-		parts := strings.Split(c.Platform, "/")
-		if len(parts) != 2 {
-			return oo, fmt.Errorf("the value for --patform must be in the form [OS]/[Architecture].  eg \"linux/amd64\"")
-		}
-		oo = append(oo, fn.BuildWithPlatforms([]fn.Platform{{OS: parts[0], Architecture: parts[1]}}))
-	}
-
-	return
 }
 
 // newBuildConfig gathers options into a single build request.
@@ -365,6 +338,65 @@ func (c buildConfig) Validate() (err error) {
 	if c.Platform != "" && c.Builder != builders.S2I {
 		err = errors.New("Only S2I builds currently support specifying platform")
 		return
+	}
+
+	return
+}
+
+// clientOptions returns options suitable for instantiating a client based on
+// the current state of the build config object.
+// This will be unnecessary and refactored away when the host-based OCI
+// builder and pusher are the default implementations and the Pack and S2I
+// constructors simplified.
+//
+// TODO: Platform is currently only used by the S2I builder.  This should be
+// a multi-valued argument which passes through to the "host" builder (which
+// supports multi-arch/platform images), and throw an error if either trying
+// to specify a platform for buildpacks, or trying to specify more than one
+// for S2I.
+//
+// TODO: As a further optimization, it might be ideal to only build the
+// image necessary for the target cluster, since the end product of  a function
+// deployment is not the contiainer, but rather the running service.
+func (c buildConfig) clientOptions() ([]fn.Option, error) {
+	o := []fn.Option{fn.WithRegistry(c.Registry)}
+	if c.Builder == builders.Host {
+		o = append(o,
+			fn.WithBuilder(oci.NewBuilder(builders.Host, c.Verbose)),
+			fn.WithPusher(oci.NewPusher(false, c.Verbose)))
+	} else if c.Builder == builders.Pack {
+		o = append(o,
+			fn.WithBuilder(pack.NewBuilder(
+				pack.WithName(builders.Pack),
+				pack.WithTimestamp(c.WithTimestamp),
+				pack.WithVerbose(c.Verbose))))
+	} else if c.Builder == builders.S2I {
+		o = append(o,
+			fn.WithBuilder(s2i.NewBuilder(
+				s2i.WithName(builders.S2I),
+				s2i.WithVerbose(c.Verbose))))
+	} else {
+		return o, builders.ErrUnknownBuilder{Name: c.Builder, Known: KnownBuilders()}
+	}
+	return o, nil
+}
+
+// buildOptions returns options for use with the client.Build request
+func (c buildConfig) buildOptions() (oo []fn.BuildOption, err error) {
+	oo = []fn.BuildOption{}
+
+	// Platforms
+	//
+	// TODO: upgrade --platform to a multi-value field.  The individual builder
+	// implementations are responsible for bubbling an error if they do
+	// not support this.  Pack  supports none, S2I supports one, host builder
+	// supports multi.
+	if c.Platform != "" {
+		parts := strings.Split(c.Platform, "/")
+		if len(parts) != 2 {
+			return oo, fmt.Errorf("the value for --patform must be in the form [OS]/[Architecture].  eg \"linux/amd64\"")
+		}
+		oo = append(oo, fn.BuildWithPlatforms([]fn.Platform{{OS: parts[0], Architecture: parts[1]}}))
 	}
 
 	return

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -1516,9 +1516,9 @@ func TestDeploy_UnsetFlag(t *testing.T) {
 }
 
 // Test_ValidateBuilder tests that the bulder validation accepts the
-// accepts === the set of known builders.
+// the set of known builders, and spot-checks an error is thrown for unknown.
 func Test_ValidateBuilder(t *testing.T) {
-	for _, name := range builders.All() {
+	for _, name := range KnownBuilders() {
 		if err := ValidateBuilder(name); err != nil {
 			t.Fatalf("expected builder '%v' to be valid, but got error: %v", name, err)
 		}

--- a/cmd/invoke_test.go
+++ b/cmd/invoke_test.go
@@ -47,10 +47,10 @@ func TestInvoke(t *testing.T) {
 				fmt.Fprintf(os.Stderr, "error serving: %v", err)
 			}
 		}()
-		_, port, _ := net.SplitHostPort(l.Addr().String())
+		host, port, _ := net.SplitHostPort(l.Addr().String())
 		errs := make(chan error, 10)
 		stop := func() error { _ = s.Close(); return nil }
-		return fn.NewJob(f, "127.0.0.1", port, errs, stop, false)
+		return fn.NewJob(f, host, port, errs, stop, false)
 	}
 
 	// Run the mock http service function interloper

--- a/pkg/builders/builders.go
+++ b/pkg/builders/builders.go
@@ -13,6 +13,7 @@ import (
 )
 
 const (
+	Host    = "host"
 	Pack    = "pack"
 	S2I     = "s2i"
 	Default = Pack
@@ -22,7 +23,7 @@ const (
 type Known []string
 
 func All() Known {
-	return Known([]string{Pack, S2I})
+	return Known([]string{Host, Pack, S2I})
 }
 
 func (k Known) String() string {

--- a/pkg/scaffolding/detectors_test.go
+++ b/pkg/scaffolding/detectors_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package scaffolding
 
 import (

--- a/pkg/scaffolding/testdata/go/scaffolding/instanced-http/main.go
+++ b/pkg/scaffolding/testdata/go/scaffolding/instanced-http/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :gift: enables `--builder=host`

Enables host-based builds on the `build`. `deploy` and `run` commands, including pushing.  It is not enabled, and is instead placed behind a feature-flag "FUNC_ENABLE_HOST_BUILDER"

/kind enhancement