### PR TITLE
Pass image with digest to the deploy task

### DIFF
--- a/pkg/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
@@ -68,7 +68,7 @@ spec:
       default: empty-dir
 
   results:
-    - name: APP_IMAGE_DIGEST
+    - name: IMAGE_DIGEST
       description: The digest of the built `APP_IMAGE`.
 
   stepTemplate:
@@ -189,13 +189,13 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -e
-        cat /layers/report.toml | grep "digest" | cut -d'"' -f2 | cut -d'"' -f2 | tr -d '\n' | tee $(results.APP_IMAGE_DIGEST.path)
+        cat /layers/report.toml | grep "digest" | cut -d'"' -f2 | cut -d'"' -f2 | tr -d '\n' | tee $(results.IMAGE_DIGEST.path)
 
         ############################################
         ##### Added part for Knative Functions #####
         ############################################
 
-        digest=$(cat $(results.APP_IMAGE_DIGEST.path))
+        digest=$(cat $(results.IMAGE_DIGEST.path))
 
         func_file="$(workspaces.source.path)/func.yaml"
         if [ "$(params.SOURCE_SUBPATH)" != "" ]; then

--- a/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
@@ -26,5 +26,4 @@ spec:
     - name: func-deploy
       image: "ghcr.io/knative/func/func:latest"
       script: |
-        export FUNC_IMAGE="$(params.image)"
-        func deploy --verbose --build=false --push=false --path=$(params.path) --remote=false
+        func deploy --verbose --build=false --push=false --path=$(params.path) --remote=false --image="$(params.image)"

--- a/pkg/pipelines/tekton/resources.go
+++ b/pkg/pipelines/tekton/resources.go
@@ -79,7 +79,7 @@ func generatePipeline(f fn.Function, labels map[string]string) *pplnv1beta1.Pipe
 	}
 
 	var taskBuild pplnv1beta1.PipelineTask
-	
+
 	var tasks []pplnv1beta1.PipelineTask
 	var buildPreReq []string
 

--- a/pkg/pipelines/tekton/resources.go
+++ b/pkg/pipelines/tekton/resources.go
@@ -79,10 +79,7 @@ func generatePipeline(f fn.Function, labels map[string]string) *pplnv1beta1.Pipe
 	}
 
 	var taskBuild pplnv1beta1.PipelineTask
-
-	// Deploy step that uses an image produced by S2I builds needs explicit reference to the image
-	referenceImageFromPreviousTaskResults := false
-
+	
 	var tasks []pplnv1beta1.PipelineTask
 	var buildPreReq []string
 
@@ -104,11 +101,10 @@ func generatePipeline(f fn.Function, labels map[string]string) *pplnv1beta1.Pipe
 			Default: pplnv1beta1.NewArrayOrString("image:///usr/libexec/s2i")})
 
 		taskBuild = taskS2iBuild(buildPreReq)
-		referenceImageFromPreviousTaskResults = true
 	}
 
 	// ----- Pipeline definition
-	tasks = append(tasks, taskBuild, taskDeploy(taskNameBuild, referenceImageFromPreviousTaskResults))
+	tasks = append(tasks, taskBuild, taskDeploy(taskNameBuild))
 
 	return &pplnv1beta1.Pipeline{
 		ObjectMeta: v1.ObjectMeta{

--- a/pkg/pipelines/tekton/tasks.go
+++ b/pkg/pipelines/tekton/tasks.go
@@ -98,14 +98,12 @@ func taskS2iBuild(runAfter []string) pplnv1beta1.PipelineTask {
 
 }
 
-func taskDeploy(runAfter string, referenceImageFromPreviousTaskResults bool) pplnv1beta1.PipelineTask {
+func taskDeploy(runAfter string) pplnv1beta1.PipelineTask {
 
 	params := []pplnv1beta1.Param{{Name: "path", Value: *pplnv1beta1.NewArrayOrString("$(workspaces.source.path)/$(params.contextDir)")}}
 
-	// Deploy step that uses an image produced by S2I builds needs explicit reference to the image
-	if referenceImageFromPreviousTaskResults {
-		params = append(params, pplnv1beta1.Param{Name: "image", Value: *pplnv1beta1.NewArrayOrString(fmt.Sprintf("$(params.imageName)@$(tasks.%s.results.IMAGE_DIGEST)", runAfter))})
-	}
+	// Deploy step that uses an image produced by builds needs explicit reference to the image
+	params = append(params, pplnv1beta1.Param{Name: "image", Value: *pplnv1beta1.NewArrayOrString(fmt.Sprintf("$(params.imageName)@$(tasks.%s.results.IMAGE_DIGEST)", runAfter))})
 
 	return pplnv1beta1.PipelineTask{
 		Name: taskNameDeploy,

--- a/pkg/pipelines/tekton/templates_pack.go
+++ b/pkg/pipelines/tekton/templates_pack.go
@@ -81,6 +81,8 @@ spec:
       params:
         - name: path
           value: $(workspaces.source.path)/$(params.contextDir)
+        - name: image
+          value: $(params.imageName)@$(tasks.build.results.APP_IMAGE_DIGEST)
       runAfter:
         - build
       taskRef:

--- a/pkg/pipelines/tekton/templates_pack.go
+++ b/pkg/pipelines/tekton/templates_pack.go
@@ -82,7 +82,7 @@ spec:
         - name: path
           value: $(workspaces.source.path)/$(params.contextDir)
         - name: image
-          value: $(params.imageName)@$(tasks.build.results.APP_IMAGE_DIGEST)
+          value: $(params.imageName)@$(tasks.build.results.IMAGE_DIGEST)
       runAfter:
         - build
       taskRef:


### PR DESCRIPTION
# Changes

- The `pack` build task result `IMAGE_DIGEST` is passed to the deploy task. Before this was done only for the `s2i` build.
- The deploy task explicitly sets the `--image` flag.

```release-notes
- On-cluster build: The `pack` build task result `IMAGE_DIGEST` is passed to the deploy task.
- On-cluster build: The deploy task explicitly sets the `--image` flag.
```