### PR TITLE
reduce default build platforms

### DIFF
--- a/pkg/oci/builder.go
+++ b/pkg/oci/builder.go
@@ -23,10 +23,7 @@ var path = filepath.Join
 var defaultPlatforms = []v1.Platform{
 	{OS: "linux", Architecture: "amd64"},
 	{OS: "linux", Architecture: "arm64"},
-	// {OS: "linux", Architecture: "arm", Variant: "v6"},
 	{OS: "linux", Architecture: "arm", Variant: "v7"},
-	{OS: "darwin", Architecture: "amd64"},
-	{OS: "darwin", Architecture: "arm64"},
 }
 
 var defaultIgnored = []string{ // TODO: implement and use .funcignore


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :broom: Reduce default platforms to likely base set

Removes cross-compiles use during testing to a base set most likely to be those of the target cluster.

Note that when the `environment` reporting is complete, we could further reduce this set to only that of the target cluster.

/kind cleanup