### PR TITLE
fix: PVCSize resets to default with futureproofing

### DIFF
--- a/docs/reference/func_deploy.md
+++ b/docs/reference/func_deploy.md
@@ -128,7 +128,7 @@ func deploy
   -p, --path string             Path to the function.  Default is current directory ($FUNC_PATH)
       --platform string         Optionally specify a specific platform to build for (e.g. linux/amd64). ($FUNC_PLATFORM)
   -u, --push                    Push the function image to registry before deploying. ($FUNC_PUSH) (default true)
-      --pvc-size string         Configure the PVC size used by a pipeline during remote build. (default "256Mi")
+      --pvc-size string         When triggering a remote deployment, set a custom volume size to allocate for the build operation ($FUNC_PVC_SIZE)
   -r, --registry string         Container registry + registry namespace. (ex 'ghcr.io/myuser').  The full image name is automatically determined using this along with function name. ($FUNC_REGISTRY)
       --remote                  Trigger a remote deployment. Default is to deploy and build from the local system ($FUNC_REMOTE)
   -v, --verbose                 Print verbose logs ($FUNC_VERBOSE)

--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -22,9 +22,6 @@ const (
 	// RunDataDir holds transient runtime metadata
 	// By default it is excluded from source control.
 	RunDataDir = ".func"
-
-	// DefaultPersistentVolumeClaimSize represents default size of PVC created for a Pipeline
-	DefaultPersistentVolumeClaimSize string = "256Mi"
 )
 
 // Function
@@ -177,6 +174,10 @@ func NewUninitializedError(path string) error {
 
 // NewFunctionWith defaults as provided.
 func NewFunctionWith(defaults Function) Function {
+	// Deprecatded:  these defaults should be used directly from their
+	// in-code static defaults, config, etc. A function struct is used to hold
+	// overrides (eg. use PVCSize X instead of the default), and to record the
+	// results of operations (eg. the function was deployed with image Y).
 	if defaults.SpecVersion == "" {
 		defaults.SpecVersion = LastSpecVersion()
 	}
@@ -185,9 +186,6 @@ func NewFunctionWith(defaults Function) Function {
 	}
 	if defaults.Build.BuilderImages == nil {
 		defaults.Build.BuilderImages = make(map[string]string)
-	}
-	if defaults.Build.PVCSize == "" {
-		defaults.Build.PVCSize = DefaultPersistentVolumeClaimSize
 	}
 	if defaults.Deploy.Annotations == nil {
 		defaults.Deploy.Annotations = make(map[string]string)

--- a/pkg/pipelines/tekton/pipeplines_provider_test.go
+++ b/pkg/pipelines/tekton/pipeplines_provider_test.go
@@ -96,7 +96,7 @@ func Test_createPipelinePersistentVolumeClaim(t *testing.T) {
 				f:         fn.Function{},
 				namespace: "test-ns",
 				labels:    nil,
-				size:      fn.DefaultPersistentVolumeClaimSize,
+				size:      DefaultPersistentVolumeClaimSize.String(),
 			},
 			mock: func(ctx context.Context, name, namespaceOverride string, labels map[string]string, annotations map[string]string, accessMode corev1.PersistentVolumeAccessMode, resourceRequest resource.Quantity) (err error) {
 				return errors.New("creation of pvc failed")
@@ -110,7 +110,7 @@ func Test_createPipelinePersistentVolumeClaim(t *testing.T) {
 				f:         fn.Function{},
 				namespace: "test-ns",
 				labels:    nil,
-				size:      fn.DefaultPersistentVolumeClaimSize,
+				size:      DefaultPersistentVolumeClaimSize.String(),
 			},
 			mock: func(ctx context.Context, name, namespaceOverride string, labels map[string]string, annotations map[string]string, accessMode corev1.PersistentVolumeAccessMode, resourceRequest resource.Quantity) (err error) {
 				return &apiErrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonAlreadyExists}}


### PR DESCRIPTION
Refactors PVCSize to treat the Function member as a custom setting, and the in-code constant as the default.

- :bug: Fixes a bug where the PVCSize would reset to the default on deploy
- :gift: Allows the default to be changed by future func version, only pinning the value if explicitly requested by the user.

/kind bug

```release-note
- Fixes a bug where volume size for remote builds was sometimes not respected
```