### PR TITLE
src: add missing 'omitempty' annotations

### DIFF
--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -56,7 +56,7 @@ type Function struct {
 
 	// Registry at which to store interstitial containers, in the form
 	// [registry]/[user].
-	Registry string `yaml:"registry"`
+	Registry string `yaml:"registry,omitempty"`
 
 	// Optional full OCI image tag in form:
 	//   [registry]/[namespace]/[name]:[tag]
@@ -67,7 +67,7 @@ type Function struct {
 	//   alice/my.function.name
 	// If Image is provided, it overrides the default of concatenating
 	// "Registry+Name:latest" to derive the Image.
-	Image string `yaml:"image"`
+	Image string `yaml:"image,omitempty"`
 
 	// SHA256 hash of the latest image that has been built
 	ImageDigest string `yaml:"imageDigest,omitempty"`

--- a/schema/func_yaml-schema.json
+++ b/schema/func_yaml-schema.json
@@ -122,8 +122,6 @@
 		"Function": {
 			"required": [
 				"specVersion",
-				"registry",
-				"image",
 				"created"
 			],
 			"properties": {


### PR DESCRIPTION
- :broom: image and registry missing `omitempty`

The default func.yaml should be as empty as possible, as it is intended as a way to specify overrides to in-code defaults.
By pre-populating the func.yaml with empty strings, it is ambiguous as to the intent:  eg.  Are you requesting I explicitly set the regitry and image to nothing, or do you not care what I set it too? 

In other words, the initial funciton created by `func craete` should have a registry and image `nil`, indicating the user prefers to use whatever is default, not explicitly setting to emtpy string.

This was mostly fixed in PR #1630.  I think these two were just missed.

/kind cleanup