### PR TITLE
feat: add common command aliases

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -30,7 +30,8 @@ No local files are deleted.
 # Undeploy the function 'myfunc' in namespace 'apps'
 {{rootCmdUse}} delete -n apps myfunc
 `,
-		SuggestFor:        []string{"remove", "rm", "del"},
+		SuggestFor:        []string{"remove", "del"},
+		Aliases:           []string{"rm"},
 		ValidArgsFunction: CompleteFunctionList,
 		PreRunE:           bindEnv("path", "confirm", "all", "namespace", "verbose"),
 		SilenceUsage:      true, // no usage dump on error

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -35,7 +35,8 @@ Lists all deployed functions in a given namespace.
 # List all functions in all namespaces with JSON output
 {{rootCmdUse}} list --all-namespaces --output json
 `,
-		SuggestFor: []string{"ls", "lsit"},
+		SuggestFor: []string{"lsit"},
+		Aliases:    []string{"ls"},
 		PreRunE:    bindEnv("all-namespaces", "output", "namespace", "verbose"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(cmd, args, newClient)


### PR DESCRIPTION
- :gift: add `ls` as an alias for `func list`
- :gift: add `rm` as an alias for `func remove`