### PR TITLE
src: remove datestamp from binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,11 @@ BIN_WINDOWS ?= $(BIN)_windows_amd64.exe
 # hash and the version tag of the current commit (semver) if it exists.
 # If the current commit does not have a semver tag, 'tip' is used, unless there
 # is a TAG environment variable. Precedence is git tag, environment variable, 'tip'
-DATE    := $(shell date -u +"%Y%m%dT%H%M%SZ")
 HASH    := $(shell git rev-parse --short HEAD 2>/dev/null)
 VTAG    := $(shell git tag --points-at HEAD | head -1)
 VTAG    := $(shell [ -z $(VTAG) ] && echo $(ETAG) || echo $(VTAG))
 VERS    ?= $(shell [ -z $(VTAG) ] && echo 'tip' || echo $(VTAG) )
-LDFLAGS := "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.hash=$(HASH)"
+LDFLAGS := "-X main.vers=$(VERS) -X main.hash=$(HASH)"
 
 # All Code prerequisites, including generated files, etc.
 CODE := $(shell find . -name '*.go') generate/zz_filesystem_generated.go go.mod schema/func_yaml-schema.json

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -48,7 +48,6 @@ DESCRIPTION
 type Environment struct {
 	Version     string
 	GitRevision string
-	BuildDate   string
 	SpecVersion string
 	SocatImage  string
 	TarImage    string
@@ -109,7 +108,6 @@ func runEnvironment(cmd *cobra.Command, newClient ClientFactory, v *Version) (er
 	environment := Environment{
 		Version:     v.String(),
 		GitRevision: v.Hash,
-		BuildDate:   v.Date,
 		SpecVersion: functions.LastSpecVersion(),
 		SocatImage:  k8s.SocatImage,
 		TarImage:    k8s.TarImage,

--- a/cmd/func/main.go
+++ b/cmd/func/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Statically-populated build metadata set by `make build`.
-var date, vers, hash string
+var vers, hash string
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -33,7 +33,6 @@ func main() {
 	cfg := cmd.RootCommandConfig{
 		Name: "func",
 		Version: cmd.Version{
-			Date: date,
 			Vers: vers,
 			Hash: hash,
 		}}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
@@ -319,8 +318,6 @@ func cwd() (cwd string) {
 }
 
 type Version struct {
-	// Date of compilation
-	Date string
 	// Version tag of the git commit, or 'tip' if no tag.
 	Vers string
 	// Hash of the currently active git commit on build.
@@ -351,14 +348,13 @@ func (v Version) String() string {
 }
 
 // StringVerbose returns the verbose version of the version stringification.
-// The format returned is [semver]-[hash]-[date] where the special value
+// The format returned is [semver]-[hash] where the special value
 // 'v0.0.0' and 'source' are used when version is not available and/or the
 // libray has been built from source, respectively.
 func (v Version) StringVerbose() string {
 	var (
 		vers = v.Vers
 		hash = v.Hash
-		date = v.Date
 	)
 	if vers == "" {
 		vers = "v0.0.0"
@@ -366,10 +362,7 @@ func (v Version) StringVerbose() string {
 	if hash == "" {
 		hash = "source"
 	}
-	if date == "" {
-		date = time.Now().Format(time.RFC3339)
-	}
-	funcVersion := fmt.Sprintf("%s-%s-%s", vers, hash, date)
+	funcVersion := fmt.Sprintf("%s-%s", vers, hash)
 	return fmt.Sprintf("Version: %s\n"+
 		"SocatImage: %s\n"+
 		"TarImage: %s", funcVersion,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -170,7 +170,7 @@ func TestVerbose(t *testing.T) {
 		{
 			name:   "verbose as version's flag",
 			args:   []string{"version", "-v"},
-			want:   "Version: v0.42.0-cafe-1970-01-01",
+			want:   "Version: v0.42.0-cafe",
 			wantLF: 3,
 		},
 		{
@@ -189,7 +189,6 @@ func TestVerbose(t *testing.T) {
 			cmd := NewRootCmd(RootCommandConfig{
 				Name: "func",
 				Version: Version{
-					Date: "1970-01-01",
 					Vers: "v0.42.0",
 					Hash: "cafe",
 				}})

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -26,7 +26,8 @@ DESCRIPTION
 	o Print the functions version
 	  $ {{rootCmdUse}} version
 
-	o Print the functions version along with date and associated git commit hash.
+	o Print the functions version along with source git commit hash and other
+	  metadata.
 	  $ {{rootCmdUse}} version -v
 
 `,

--- a/docs/reference/func_version.md
+++ b/docs/reference/func_version.md
@@ -18,7 +18,8 @@ DESCRIPTION
 	o Print the functions version
 	  $ func version
 
-	o Print the functions version along with date and associated git commit hash.
+	o Print the functions version along with source git commit hash and other
+	  metadata.
 	  $ func version -v
 
 


### PR DESCRIPTION
- :broom: removes version from `func version --verbose`

In an effort to move one step closer to reproducible builds, build timestamp is removed from the CLI version subcommand.