### PR TITLE
feat: platform build options

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -263,7 +263,6 @@ func runDeploy(cmd *cobra.Command, newClient ClientFactory) (err error) {
 	} else if f.Build.Builder == builders.S2I {
 		builder = s2i.NewBuilder(
 			s2i.WithName(builders.S2I),
-			s2i.WithPlatform(cfg.Platform),
 			s2i.WithVerbose(cfg.Verbose))
 	} else {
 		return builders.ErrUnknownBuilder{Name: f.Build.Builder, Known: KnownBuilders()}
@@ -283,8 +282,13 @@ func runDeploy(cmd *cobra.Command, newClient ClientFactory) (err error) {
 		}
 	} else {
 		if shouldBuild(cfg.Build, f, client) { // --build or "auto" with FS changes
-			if f, err = client.Build(cmd.Context(), f); err != nil {
-				return
+			buildOptions, err := cfg.buildOptions()
+			if err != nil {
+				return err
+			}
+
+			if f, err = client.Build(cmd.Context(), f, buildOptions...); err != nil {
+				return err
 			}
 		}
 		if cfg.Push {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -179,7 +179,6 @@ func runRun(cmd *cobra.Command, args []string, newClient ClientFactory) (err err
 	} else if f.Build.Builder == builders.S2I {
 		o = append(o, fn.WithBuilder(s2i.NewBuilder(
 			s2i.WithName(builders.S2I),
-			s2i.WithPlatform(cfg.Platform),
 			s2i.WithVerbose(cfg.Verbose))))
 	}
 	if cfg.Container {
@@ -194,8 +193,12 @@ func runRun(cmd *cobra.Command, args []string, newClient ClientFactory) (err err
 	// If requesting to run via the container, build the container if it is
 	// either out-of-date or a build was explicitly requested.
 	if cfg.Container && shouldBuild(cfg.Build, f, client) {
-		if f, err = client.Build(cmd.Context(), f); err != nil {
-			return
+		buildOptions, err := cfg.buildOptions()
+		if err != nil {
+			return err
+		}
+		if f, err = client.Build(cmd.Context(), f, buildOptions...); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/builders/buildpacks/builder.go
+++ b/pkg/builders/buildpacks/builder.go
@@ -3,6 +3,7 @@ package buildpacks
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"runtime"
@@ -112,7 +113,11 @@ func WithTimestamp(v bool) Option {
 var DefaultLifecycleImage = "quay.io/boson/lifecycle@sha256:f53fea9ec9188b92cab0b8a298ff852d76a6c2aaf56f968a08637e13de0e0c59"
 
 // Build the Function at path.
-func (b *Builder) Build(ctx context.Context, f fn.Function) (err error) {
+func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platform) (err error) {
+	if len(platforms) != 0 {
+		return errors.New("the pack builder does not support specifying target platforms directly.")
+	}
+
 	// Builder image from the function if defined, default otherwise.
 	image, err := BuilderImage(f, b.name)
 	if err != nil {

--- a/pkg/builders/buildpacks/builder_test.go
+++ b/pkg/builders/buildpacks/builder_test.go
@@ -56,7 +56,7 @@ func TestBuild_BuilderImageDefault(t *testing.T) {
 		return nil
 	}
 
-	if err := b.Build(context.Background(), f); err != nil {
+	if err := b.Build(context.Background(), f, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -80,7 +80,7 @@ func TestBuild_BuildpacksDefault(t *testing.T) {
 		return nil
 	}
 
-	if err := b.Build(context.Background(), f); err != nil {
+	if err := b.Build(context.Background(), f, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -111,7 +111,7 @@ func TestBuild_BuilderImageConfigurable(t *testing.T) {
 		return nil
 	}
 
-	if err := b.Build(context.Background(), f); err != nil {
+	if err := b.Build(context.Background(), f, nil); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -143,7 +143,7 @@ func TestBuild_Envs(t *testing.T) {
 		t.Fatal("build envs not added to builder options")
 		return nil
 	}
-	if err := b.Build(context.Background(), f); err != nil {
+	if err := b.Build(context.Background(), f, nil); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/builders/s2i/builder_test.go
+++ b/pkg/builders/s2i/builder_test.go
@@ -110,7 +110,7 @@ func Test_BuilderImageDefault(t *testing.T) {
 
 	// Invoke Build, which runs function Builder logic before invoking the
 	// mock impl above.
-	if err := b.Build(context.Background(), f); err != nil {
+	if err := b.Build(context.Background(), f, nil); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -145,7 +145,7 @@ func Test_BuilderImageConfigurable(t *testing.T) {
 
 	// Invoke Build, which runs function Builder logic before invoking the
 	// mock impl above.
-	if err := b.Build(context.Background(), f); err != nil {
+	if err := b.Build(context.Background(), f, nil); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -162,7 +162,8 @@ func Test_BuilderVerbose(t *testing.T) {
 				}
 				return &api.Result{Messages: []string{"message"}}, nil
 			}}
-		if err := s2i.NewBuilder(s2i.WithVerbose(verbose), s2i.WithImpl(i), s2i.WithDockerClient(c)).Build(context.Background(), fn.Function{Runtime: "node"}); err != nil {
+		if err := s2i.NewBuilder(s2i.WithVerbose(verbose), s2i.WithImpl(i), s2i.WithDockerClient(c)).
+			Build(context.Background(), fn.Function{Runtime: "node"}, nil); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -199,7 +200,7 @@ func Test_BuildEnvs(t *testing.T) {
 		t.Fatal("build envs not added to builder impl config")
 		return
 	}
-	if err := b.Build(context.Background(), f); err != nil {
+	if err := b.Build(context.Background(), f, nil); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -268,7 +269,7 @@ func TestS2IScriptURL(t *testing.T) {
 			}
 
 			b := s2i.NewBuilder(s2i.WithName(builders.S2I), s2i.WithImpl(impl), s2i.WithDockerClient(cli))
-			err = b.Build(context.Background(), f)
+			err = b.Build(context.Background(), f, nil)
 			if err != nil {
 				t.Error(err)
 			}
@@ -367,7 +368,7 @@ func TestBuildContextUpload(t *testing.T) {
 		Runtime: "node",
 	}
 	b := s2i.NewBuilder(s2i.WithImpl(impl), s2i.WithDockerClient(cli))
-	err := b.Build(context.Background(), f)
+	err := b.Build(context.Background(), f, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -388,7 +389,7 @@ func TestBuildFail(t *testing.T) {
 		},
 	}
 	b := s2i.NewBuilder(s2i.WithImpl(impl), s2i.WithDockerClient(cli))
-	err := b.Build(context.Background(), fn.Function{Runtime: "node"})
+	err := b.Build(context.Background(), fn.Function{Runtime: "node"}, nil)
 	if err == nil || !strings.Contains(err.Error(), "Error: this is expected") {
 		t.Error("didn't get expected error")
 	}

--- a/pkg/functions/client_test.go
+++ b/pkg/functions/client_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -36,6 +37,12 @@ const (
 	// TestRuntime is currently Go, the "reference implementation" and is
 	// used for verifying functionality that should be runtime agnostic.
 	TestRuntime = "go"
+)
+
+var (
+	// TestPlatforms to use when a multi-architecture build is not necessary
+	// for testing.
+	TestPlatforms = []fn.Platform{{OS: runtime.GOOS, Architecture: runtime.GOARCH}}
 )
 
 // TestClient_New function completes without error using defaults and zero values.

--- a/pkg/mock/builder.go
+++ b/pkg/mock/builder.go
@@ -17,7 +17,7 @@ func NewBuilder() *Builder {
 	}
 }
 
-func (i *Builder) Build(ctx context.Context, f fn.Function) error {
+func (i *Builder) Build(ctx context.Context, f fn.Function, _ []fn.Platform) error {
 	i.BuildInvoked = true
 	return i.BuildFn(f)
 }

--- a/pkg/oci/containerize.go
+++ b/pkg/oci/containerize.go
@@ -78,7 +78,7 @@ func containerize(cfg *buildConfig) (err error) {
 	// Create an image for each platform consisting of the shared data layer
 	// and an os/platform specific layer.
 	imageDescs := []v1.Descriptor{}
-	for _, p := range defaultPlatforms { // TODO: Configurable additions.
+	for _, p := range cfg.platforms {
 		imageDesc, err := newImage(cfg, dataDesc, dataLayer, p, cfg.verbose)
 		if err != nil {
 			return err
@@ -205,6 +205,7 @@ func newDescriptor(layer v1.Layer) (desc v1.Descriptor, err error) {
 // newImage creates an image for the given platform.
 // The image consists of the shared data layer which is provided
 func newImage(cfg *buildConfig, dataDesc v1.Descriptor, dataLayer v1.Layer, p v1.Platform, verbose bool) (imageDesc v1.Descriptor, err error) {
+
 	b, err := newLanguageLayerBuilder(cfg)
 	if err != nil {
 		return

--- a/pkg/oci/containerize_go.go
+++ b/pkg/oci/containerize_go.go
@@ -82,7 +82,6 @@ func isFirstBuild(cfg *buildConfig, current v1.Platform) bool {
 	return current.OS == first.OS &&
 		current.Architecture == first.Architecture &&
 		current.Variant == first.Variant
-
 }
 
 func pauseBuildUntilReleased(cfg *buildConfig, p v1.Platform) {


### PR DESCRIPTION
- :gift: adds platform build options

Plumbs through the platform CLI flag to the individual builders by creating a client-level functional option for `.Build`, and modifies the builder interface to accept an optional set of requested target platforms.

/kind enhancement

 \* Functional options are primarily useful for providing a simplified public API which can expand over time while remaining backwards-compatible.  The Builder interface is used to structure the functions codebase internally, so the complexity of the options pattern is not necessary and a simple argument will suffice.
