### PR TITLE
src: errors cleanup

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -150,7 +150,7 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 		return
 	}
 	if !f.Initialized() {
-		return fn.NewUninitializedError(f.Root)
+		return fn.NewErrNotInitialized(f.Root)
 	}
 	f = cfg.Configure(f) // Updates f at path to include build request values
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -32,7 +32,7 @@ func (s standardLoaderSaver) Load(path string) (fn.Function, error) {
 		return fn.Function{}, fmt.Errorf("failed to create new function (path: %q): %w", path, err)
 	}
 	if !f.Initialized() {
-		return fn.Function{}, fn.NewUninitializedError(f.Root)
+		return fn.Function{}, fn.NewErrNotInitialized(f.Root)
 	}
 	return f, nil
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -81,7 +81,7 @@ func runDelete(cmd *cobra.Command, args []string, newClient ClientFactory) (err 
 
 		// Check if the function has been initialized
 		if !function.Initialized() {
-			return fn.NewUninitializedError(function.Root)
+			return fn.NewErrNotInitialized(function.Root)
 		}
 
 		// If not provided, use the function's extant namespace

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -228,7 +228,7 @@ func runDeploy(cmd *cobra.Command, newClient ClientFactory) (err error) {
 		return
 	}
 	if !f.Initialized() {
-		return fn.NewUninitializedError(f.Root)
+		return fn.NewErrNotInitialized(f.Root)
 	}
 	if f, err = cfg.Configure(f); err != nil { // Updates f with deploy cfg
 		return

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -74,7 +74,7 @@ func runDescribe(cmd *cobra.Command, args []string, newClient ClientFactory) (er
 			return
 		}
 		if !f.Initialized() {
-			return fn.NewUninitializedError(f.Root)
+			return fn.NewErrNotInitialized(f.Root)
 		}
 		// Use Function's Namespace with precedence
 		//

--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -149,7 +149,7 @@ func runInvoke(cmd *cobra.Command, args []string, newClient ClientFactory) (err 
 		return err
 	}
 	if !f.Initialized() {
-		return fn.NewUninitializedError(f.Root)
+		return fn.NewErrNotInitialized(f.Root)
 	}
 
 	// Client instance from env vars, flags, args and user prompts (if --confirm)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -147,7 +147,7 @@ func runRun(cmd *cobra.Command, args []string, newClient ClientFactory) (err err
 		return
 	}
 	if !f.Initialized() {
-		return fn.NewUninitializedError(f.Root)
+		return fn.NewErrNotInitialized(f.Root)
 	}
 	if f, err = cfg.Configure(f); err != nil { // Updates f with deploy cfg
 		return

--- a/pkg/functions/errors.go
+++ b/pkg/functions/errors.go
@@ -1,0 +1,64 @@
+package functions
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrEnvironmentNotFound       = errors.New("environment not found")
+	ErrMismatchedName            = errors.New("name passed the function source")
+	ErrNameRequired              = errors.New("name required")
+	ErrNotBuilt                  = errors.New("not built")
+	ErrNotRunning                = errors.New("function not running")
+	ErrRepositoriesNotDefined    = errors.New("custom template repositories location not specified")
+	ErrRepositoryNotFound        = errors.New("repository not found")
+	ErrRootRequired              = errors.New("function root path is required")
+	ErrRunTimeout                = errors.New("timeout waiting for function to report ready")
+	ErrRuntimeNotFound           = errors.New("language runtime not found")
+	ErrRuntimeRequired           = errors.New("language runtime required")
+	ErrTemplateMissingRepository = errors.New("template name missing repository prefix")
+	ErrTemplateNotFound          = errors.New("template not found")
+	ErrTemplatesNotFound         = errors.New("templates path (runtimes) not found")
+
+	// TODO: change the wording of this error to not be CLI-specific;
+	// eg "registry required".  Then catch the error in the CLI and add the
+	// cli-specific usage hints there
+	ErrRegistryRequired = errors.New("registry required to build function, please set with `--registry` or the FUNC_REGISTRY environment variable")
+)
+
+// ErrNotInitialized indicates that a function is uninitialized
+type ErrNotInitialized struct {
+	Path string
+}
+
+func NewErrNotInitialized(path string) error {
+	return &ErrNotInitialized{Path: path}
+}
+
+func (e ErrNotInitialized) Error() string {
+	if e.Path == "" {
+		return "function is not initialized"
+	}
+	return fmt.Sprintf("'%s' does not contain an initialized function", e.Path)
+}
+
+// ErrRuntimeNotRecognized indicates a runtime which is not in the set of
+// those known.
+type ErrRuntimeNotRecognized struct {
+	Runtime string
+}
+
+func (e ErrRuntimeNotRecognized) Error() string {
+	return fmt.Sprintf("the %q runtime is not recognized", e.Runtime)
+}
+
+// ErrRunnerNotImplemented indicates the feature is not available for the
+// requested runtime.
+type ErrRunnerNotImplemented struct {
+	Runtime string
+}
+
+func (e ErrRunnerNotImplemented) Error() string {
+	return fmt.Sprintf("the %q runtime may only be run containerized.", e.Runtime)
+}

--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -160,18 +160,6 @@ type BuildConfig struct {
 	BuilderImages map[string]string `yaml:"builderImages,omitempty"`
 }
 
-type UninitializedError struct {
-	Path string
-}
-
-func (e *UninitializedError) Error() string {
-	return fmt.Sprintf("'%s' does not contain an initialized function", e.Path)
-}
-
-func NewUninitializedError(path string) error {
-	return &UninitializedError{Path: path}
-}
-
 // NewFunctionWith defaults as provided.
 func NewFunctionWith(defaults Function) Function {
 	// Deprecatded:  these defaults should be used directly from their

--- a/pkg/functions/instances.go
+++ b/pkg/functions/instances.go
@@ -11,14 +11,6 @@ const (
 	EnvironmentRemote = "remote"
 )
 
-var (
-	ErrNotInitialized      = errors.New("function is not initialized")
-	ErrNotRunning          = errors.New("function not running")
-	ErrRootRequired        = errors.New("function root path is required")
-	ErrEnvironmentNotFound = errors.New("environment not found")
-	ErrMismatchedName      = errors.New("name passed does not match name of the function at root")
-)
-
 // InstanceRefs manager
 //
 // InstanceRefs are point-in-time snapshots of a function's runtime state in
@@ -61,7 +53,7 @@ func (s *InstanceRefs) Local(ctx context.Context, f Function) (Instance, error) 
 		return i, ErrRootRequired
 	}
 	if !f.Initialized() {
-		return i, ErrNotInitialized
+		return i, ErrNotInitialized{f.Root}
 	}
 	ports := jobPorts(f)
 	if len(ports) == 0 {

--- a/pkg/functions/runner_test.go
+++ b/pkg/functions/runner_test.go
@@ -1,62 +1,44 @@
 //go:build !integration
 // +build !integration
 
-package functions_test
+package functions
 
 import (
 	"context"
-	"fmt"
-	"net/http"
+	"errors"
 	"testing"
-
-	fn "knative.dev/func/pkg/functions"
-	"knative.dev/func/pkg/oci"
-	. "knative.dev/func/pkg/testing"
 )
 
-// TestRunner ensures that the default internal runner correctly executes
-// a scaffolded function.
-func TestRunner(t *testing.T) {
-	// This integration test explicitly requires the "host" builder due to its
-	// lack of a dependency on a container runtime, and the other builders not
-	// taking advantage of Scaffolding (expected by this runner).
-	// See E2E tests for testing of running functions built using Pack or S2I and
-	// which are dependent on Podman or Docker.
-	// Currently only a Go function is tested because other runtimes do not yet
-	// have scaffolding.
-
-	root, cleanup := Mktemp(t)
-	defer cleanup()
-	ctx, cancel := context.WithCancel(context.Background())
-	client := fn.New(fn.WithBuilder(oci.NewBuilder("", true)), fn.WithVerbose(true))
-
-	// Initialize
-	f, err := client.Init(fn.Function{Root: root, Runtime: "go", Registry: TestRegistry})
-	if err != nil {
-		t.Fatal(err)
+// TestGetRunFuncErrors ensures that known runtimes which do not yet
+// have their runner implemented return a "not yet available" message, as
+// distinct from unrecognized runtimes which state as much.
+func TestGetRunFuncErrors(t *testing.T) {
+	tests := []struct {
+		Runtime    string
+		ExpectedIs error
+		ExpectedAs any
+	}{
+		{"", ErrRuntimeRequired, nil},
+		{"go", nil, nil},
+		{"python", nil, &ErrRunnerNotImplemented{}},
+		{"rust", nil, &ErrRunnerNotImplemented{}},
+		{"node", nil, &ErrRunnerNotImplemented{}},
+		{"typescript", nil, &ErrRunnerNotImplemented{}},
+		{"quarkus", nil, &ErrRunnerNotImplemented{}},
+		{"java", nil, &ErrRunnerNotImplemented{}},
+		{"other", nil, &ErrRuntimeNotRecognized{}},
 	}
+	for _, test := range tests {
+		t.Run(test.Runtime, func(t *testing.T) {
 
-	// Build
-	if f, err = client.Build(ctx, f); err != nil {
-		t.Fatal(err)
+			ctx := context.Background()
+			job := Job{Function: Function{Runtime: test.Runtime}}
+			_, err := getRunFunc(ctx, &job)
+
+			if test.ExpectedAs != nil && !errors.As(err, test.ExpectedAs) {
+				t.Fatalf("did not receive expected error type for %v runtime.", test.Runtime)
+			}
+			t.Logf("ok: %v", err)
+		})
 	}
-
-	// Run
-	job, err := client.Run(ctx, f)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Invoke
-	resp, err := http.Get(fmt.Sprintf("http://%s:%s", job.Host, job.Port))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		t.Fatalf("unexpected response code: %v", resp.StatusCode)
-	}
-
-	cancel()
 }

--- a/pkg/functions/templates.go
+++ b/pkg/functions/templates.go
@@ -2,20 +2,9 @@ package functions
 
 import (
 	"context"
-	"errors"
 	"strings"
 
 	"knative.dev/func/pkg/utils"
-)
-
-var (
-	ErrRepositoryNotFound        = errors.New("repository not found")
-	ErrRepositoriesNotDefined    = errors.New("custom template repositories location not specified")
-	ErrTemplatesNotFound         = errors.New("templates path (runtimes) not found")
-	ErrRuntimeNotFound           = errors.New("language runtime not found")
-	ErrRuntimeRequired           = errors.New("language runtime required")
-	ErrTemplateNotFound          = errors.New("template not found")
-	ErrTemplateMissingRepository = errors.New("template name missing repository prefix")
 )
 
 // Templates Manager


### PR DESCRIPTION
- :broom: cleans up and tests errors
- :broom: cleans up comments

Moves errors into their own file, updates to using typed error responses in a few more places, cleans a few comments and adds a test.

/kind cleanup