### PR TITLE
Fix appending SHA256 hash to image reference in ImageWithDigest

### DIFF
--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -472,6 +472,12 @@ func (f Function) ImageWithDigest() string {
 		return f.Image
 	}
 
+	// Return image with new Digest if image already contains SHA256 Digest
+	shaIndex := strings.Index(f.Image, "@sha256:")
+	if shaIndex > 0 {
+		return f.Image[:shaIndex] + "@" + f.ImageDigest
+	}
+
 	lastSlashIdx := strings.LastIndexAny(f.Image, "/")
 	imageAsBytes := []byte(f.Image)
 

--- a/pkg/functions/function_unit_test.go
+++ b/pkg/functions/function_unit_test.go
@@ -105,6 +105,16 @@ func TestFunction_ImageWithDigest(t *testing.T) {
 			fields: fields{Image: "bar:latest", ImageDigest: "42"},
 			want:   "bar@42",
 		},
+		{
+			name:   "Full path with port and SHA256 Digest",
+			fields: fields{Image: "image-registry.openshift-image-registry.svc.cluster.local:50000/default/bar@sha256:42", ImageDigest: "sha256:42"},
+			want:   "image-registry.openshift-image-registry.svc.cluster.local:50000/default/bar@sha256:42",
+		},
+		{
+			name:   "Full path with port and SHA256 Digest with empty ImageDigest",
+			fields: fields{Image: "image-registry.openshift-image-registry.svc.cluster.local:50000/default/bar@sha256:42", ImageDigest: ""},
+			want:   "image-registry.openshift-image-registry.svc.cluster.local:50000/default/bar@sha256:42",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Fix appending SHA256 hash to image reference in ImageWithDigest


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1768

<!-- Please include the 'why' behind your changes if no issue exists -->

