### PR TITLE
remove obsolete test build tags and removal of config tests on Windows

### DIFF
--- a/test/e2e/scenario_config-envs_test.go
+++ b/test/e2e/scenario_config-envs_test.go
@@ -1,5 +1,4 @@
-//go:build e2e
-// +build e2e
+//go:build e2e && !windows
 
 package e2e
 

--- a/test/e2e/scenario_config-labels_test.go
+++ b/test/e2e/scenario_config-labels_test.go
@@ -1,5 +1,4 @@
-//go:build e2e
-// +build e2e
+//go:build e2e && !windows
 
 package e2e
 

--- a/test/e2e/scenario_config-volumes_test.go
+++ b/test/e2e/scenario_config-volumes_test.go
@@ -1,5 +1,4 @@
-//go:build e2e
-// +build e2e
+//go:build e2e && !windows
 
 package e2e
 

--- a/test/e2e/scenario_extended_flow_test.go
+++ b/test/e2e/scenario_extended_flow_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/test/e2e/scenario_remote-repository_test.go
+++ b/test/e2e/scenario_remote-repository_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/test/e2e/scenario_runtime-cloudevents_test.go
+++ b/test/e2e/scenario_runtime-cloudevents_test.go
@@ -1,5 +1,4 @@
 //go:build e2elc
-// +build e2elc
 
 package e2e
 

--- a/test/e2e/scenario_runtime-http_test.go
+++ b/test/e2e/scenario_runtime-http_test.go
@@ -1,5 +1,4 @@
 //go:build e2elc
-// +build e2elc
 
 package e2e
 

--- a/test/oncluster/scenario_basic_test.go
+++ b/test/oncluster/scenario_basic_test.go
@@ -1,5 +1,4 @@
 //go:build oncluster
-// +build oncluster
 
 package oncluster
 

--- a/test/oncluster/scenario_context-dir_test.go
+++ b/test/oncluster/scenario_context-dir_test.go
@@ -1,5 +1,4 @@
 //go:build oncluster
-// +build oncluster
 
 package oncluster
 

--- a/test/oncluster/scenario_from-cli-local_test.go
+++ b/test/oncluster/scenario_from-cli-local_test.go
@@ -1,5 +1,4 @@
 //go:build oncluster
-// +build oncluster
 
 package oncluster
 

--- a/test/oncluster/scenario_from-cli_test.go
+++ b/test/oncluster/scenario_from-cli_test.go
@@ -1,5 +1,4 @@
 //go:build oncluster
-// +build oncluster
 
 package oncluster
 

--- a/test/oncluster/scenario_github_test.go
+++ b/test/oncluster/scenario_github_test.go
@@ -1,5 +1,4 @@
 //go:build oncluster
-// +build oncluster
 
 package oncluster
 

--- a/test/oncluster/scenario_revision_test.go
+++ b/test/oncluster/scenario_revision_test.go
@@ -1,5 +1,4 @@
 //go:build oncluster
-// +build oncluster
 
 package oncluster
 

--- a/test/oncluster/scenario_runtime_test.go
+++ b/test/oncluster/scenario_runtime_test.go
@@ -1,5 +1,4 @@
 //go:build oncluster || runtime
-// +build oncluster runtime
 
 package oncluster
 


### PR DESCRIPTION
# Changes

- :broom: Removed obsolete build tags from e2e tests
- :broom: Removed config e2e test for Windows platform