### PR TITLE
adding default builders

### DIFF
--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
 
+	"knative.dev/func/pkg/builders/s2i"
 	"knative.dev/func/pkg/config"
 	"knative.dev/func/pkg/functions"
 	"knative.dev/func/pkg/k8s"
@@ -46,16 +47,17 @@ DESCRIPTION
 }
 
 type Environment struct {
-	Version     string
-	GitRevision string
-	SpecVersion string
-	SocatImage  string
-	TarImage    string
-	Languages   []string
-	Templates   map[string][]string
-	Environment []string
-	Cluster     string
-	Defaults    config.Global
+	Version         string
+	GitRevision     string
+	SpecVersion     string
+	SocatImage      string
+	TarImage        string
+	Languages       []string
+	DefaultBuilders map[string]string
+	Templates       map[string][]string
+	Environment     []string
+	Cluster         string
+	Defaults        config.Global
 }
 
 func runEnvironment(cmd *cobra.Command, newClient ClientFactory, v *Version) (err error) {
@@ -106,16 +108,17 @@ func runEnvironment(cmd *cobra.Command, newClient ClientFactory, v *Version) (er
 	}
 
 	environment := Environment{
-		Version:     v.String(),
-		GitRevision: v.Hash,
-		SpecVersion: functions.LastSpecVersion(),
-		SocatImage:  k8s.SocatImage,
-		TarImage:    k8s.TarImage,
-		Languages:   r,
-		Templates:   t,
-		Environment: envs,
-		Cluster:     host,
-		Defaults:    defaults,
+		Version:         v.String(),
+		GitRevision:     v.Hash,
+		SpecVersion:     functions.LastSpecVersion(),
+		SocatImage:      k8s.SocatImage,
+		TarImage:        k8s.TarImage,
+		Languages:       r,
+		DefaultBuilders: s2i.DefaultBuilderImages,
+		Templates:       t,
+		Environment:     envs,
+		Cluster:         host,
+		Defaults:        defaults,
 	}
 
 	if s, err := json.MarshalIndent(environment, "", "  "); err != nil {

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -8,12 +8,16 @@ import (
 
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 
+	"knative.dev/func/pkg/builders/buildpacks"
 	"knative.dev/func/pkg/builders/s2i"
 	"knative.dev/func/pkg/config"
 	"knative.dev/func/pkg/functions"
 	"knative.dev/func/pkg/k8s"
 )
+
+var EnvFormat string = "json"
 
 func NewEnvironmentCmd(newClient ClientFactory, version *Version) *cobra.Command {
 	cmd := &cobra.Command{
@@ -21,10 +25,11 @@ func NewEnvironmentCmd(newClient ClientFactory, version *Version) *cobra.Command
 		Short: "Display function execution environment information",
 		Long: `
 NAME
-	{{rootCmdUse}} environment
+	{{rootCmdUse}} environment - display function execution environment information
 
 SYNOPSIS
-	{{rootCmdUse}} environment - display function execution environment information
+	{{rootCmdUse}} environment [-e|--env-format] [-v|--verbose]
+
 
 DESCRIPTION
 	Display information about the function execution environment, including
@@ -32,6 +37,7 @@ DESCRIPTION
 	available runtimes, and available templates.
 `,
 		SuggestFor: []string{"env", "environemtn", "enviroment", "enviornment", "enviroment"},
+		PreRunE:    bindEnv("verbose", "env-format"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runEnvironment(cmd, newClient, version)
 		},
@@ -41,23 +47,24 @@ DESCRIPTION
 		fmt.Fprintf(cmd.OutOrStdout(), "error loading config at '%v'. %v\n", config.File(), err)
 	}
 
+	cmd.Flags().StringP("env-format", "e", EnvFormat, "Format of output environment informatio, 'json' or 'yaml'. ($FUNC_ENV_FORMAT)")
 	addVerboseFlag(cmd, cfg.Verbose)
 
 	return cmd
 }
 
 type Environment struct {
-	Version         string
-	GitRevision     string
-	SpecVersion     string
-	SocatImage      string
-	TarImage        string
-	Languages       []string
-	DefaultBuilders map[string]string
-	Templates       map[string][]string
-	Environment     []string
-	Cluster         string
-	Defaults        config.Global
+	Version              string
+	GitRevision          string
+	SpecVersion          string
+	SocatImage           string
+	TarImage             string
+	Languages            []string
+	DefaultImageBuilders map[string]map[string]string
+	Templates            map[string][]string
+	Environment          []string
+	Cluster              string
+	Defaults             config.Global
 }
 
 func runEnvironment(cmd *cobra.Command, newClient ClientFactory, v *Version) (err error) {
@@ -107,25 +114,38 @@ func runEnvironment(cmd *cobra.Command, newClient ClientFactory, v *Version) (er
 		host = cc.Host
 	}
 
+	//Get default image builders
+	builderimagesdefault := make(map[string]map[string]string)
+	builderimagesdefault["s2i"] = s2i.DefaultBuilderImages
+	builderimagesdefault["buildpacks"] = buildpacks.DefaultBuilderImages
+
 	environment := Environment{
-		Version:         v.String(),
-		GitRevision:     v.Hash,
-		SpecVersion:     functions.LastSpecVersion(),
-		SocatImage:      k8s.SocatImage,
-		TarImage:        k8s.TarImage,
-		Languages:       r,
-		DefaultBuilders: s2i.DefaultBuilderImages,
-		Templates:       t,
-		Environment:     envs,
-		Cluster:         host,
-		Defaults:        defaults,
+		Version:              v.String(),
+		GitRevision:          v.Hash,
+		SpecVersion:          functions.LastSpecVersion(),
+		SocatImage:           k8s.SocatImage,
+		TarImage:             k8s.TarImage,
+		Languages:            r,
+		DefaultImageBuilders: builderimagesdefault,
+		Templates:            t,
+		Environment:          envs,
+		Cluster:              host,
+		Defaults:             defaults,
 	}
 
-	if s, err := json.MarshalIndent(environment, "", "  "); err != nil {
-		return err
-	} else {
-		fmt.Fprintln(cmd.OutOrStdout(), string(s))
+	var s []byte
+	switch cfg.Format {
+	case "json":
+		s, err = json.MarshalIndent(environment, "", "  ")
+	case "yaml":
+		s, err = yaml.Marshal(&environment)
+	default:
+		err = fmt.Errorf("unsupported format: %s", cfg.Format)
 	}
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), string(s))
 
 	return nil
 }
@@ -152,12 +172,13 @@ func getTemplates(client *functions.Client, runtimes []string) (map[string][]str
 
 type environmentConfig struct {
 	Verbose bool
-	// TODO: add format (e.g. JSON/YAML)
+	Format  string
 }
 
 func newEnvironmentConfig() (cfg environmentConfig, err error) {
 	cfg = environmentConfig{
 		Verbose: viper.GetBool("verbose"),
+		Format:  viper.GetString("env-format"),
 	}
 
 	return

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -47,7 +47,7 @@ DESCRIPTION
 		fmt.Fprintf(cmd.OutOrStdout(), "error loading config at '%v'. %v\n", config.File(), err)
 	}
 
-	cmd.Flags().StringP("env-format", "e", EnvFormat, "Format of output environment informatio, 'json' or 'yaml'. ($FUNC_ENV_FORMAT)")
+	cmd.Flags().StringP("env-format", "e", EnvFormat, "Format of output environment information, 'json' or 'yaml'. ($FUNC_ENV_FORMAT)")
 	addVerboseFlag(cmd, cfg.Verbose)
 
 	return cmd

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -17,7 +17,7 @@ import (
 	"knative.dev/func/pkg/k8s"
 )
 
-var EnvFormat string = "json"
+var format string = "json"
 
 func NewEnvironmentCmd(newClient ClientFactory, version *Version) *cobra.Command {
 	cmd := &cobra.Command{
@@ -37,7 +37,7 @@ DESCRIPTION
 	available runtimes, and available templates.
 `,
 		SuggestFor: []string{"env", "environemtn", "enviroment", "enviornment", "enviroment"},
-		PreRunE:    bindEnv("verbose", "env-format"),
+		PreRunE:    bindEnv("verbose", "format"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runEnvironment(cmd, newClient, version)
 		},
@@ -47,7 +47,7 @@ DESCRIPTION
 		fmt.Fprintf(cmd.OutOrStdout(), "error loading config at '%v'. %v\n", config.File(), err)
 	}
 
-	cmd.Flags().StringP("env-format", "e", EnvFormat, "Format of output environment information, 'json' or 'yaml'. ($FUNC_ENV_FORMAT)")
+	cmd.Flags().StringP("format", "f", format, "Format of output environment information, 'json' or 'yaml'. ($FUNC_FORMAT)")
 	addVerboseFlag(cmd, cfg.Verbose)
 
 	return cmd
@@ -178,7 +178,7 @@ type environmentConfig struct {
 func newEnvironmentConfig() (cfg environmentConfig, err error) {
 	cfg = environmentConfig{
 		Verbose: viper.GetBool("verbose"),
-		Format:  viper.GetString("env-format"),
+		Format:  viper.GetString("format"),
 	}
 
 	return

--- a/docs/reference/func_config_git_set.md
+++ b/docs/reference/func_config_git_set.md
@@ -26,7 +26,7 @@ func config git set
       --gh-webhook-secret string   GitHub Webhook Secret used for payload validation. If not specified, it will be generated automatically.
   -t, --git-branch string          Git revision (branch) to be used when deploying via the Git repository ($FUNC_GIT_BRANCH)
   -d, --git-dir string             Directory in the Git repository containing the function (default is the root) ($FUNC_GIT_DIR)
-      --git-provider string        The type of the Git platform provider to setup webhook. This value is usually automatically generated from input URL, use this parameter to override this setting. Currently supported providers are "github".
+      --git-provider string        The type of the Git platform provider to setup webhook. This value is usually automatically generated from input URL, use this parameter to override this setting. Currently supported providers are "github" and "gitlab".
   -g, --git-url string             Repository url containing the function to build ($FUNC_GIT_URL)
   -h, --help                       help for set
   -i, --image string               Full image name in the form [registry]/[namespace]/[name]:[tag]@[digest]. This option takes precedence over --registry. Specifying digest is optional, but if it is given, 'build' and 'push' phases are disabled. ($FUNC_IMAGE)

--- a/docs/reference/func_environment.md
+++ b/docs/reference/func_environment.md
@@ -6,10 +6,11 @@ Display function execution environment information
 
 
 NAME
-	func environment
+	func environment - display function execution environment information
 
 SYNOPSIS
-	func environment - display function execution environment information
+	func environment [-e|--env-format] [-v|--verbose]
+
 
 DESCRIPTION
 	Display information about the function execution environment, including
@@ -24,8 +25,9 @@ func environment
 ### Options
 
 ```
-  -h, --help      help for environment
-  -v, --verbose   Print verbose logs ($FUNC_VERBOSE)
+  -f, --format string   Format of output environment information, 'json' or 'yaml'. ($FUNC_FORMAT) (default "json")
+  -h, --help            help for environment
+  -v, --verbose         Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/pkg/builders/buildpacks/builder.go
+++ b/pkg/builders/buildpacks/builder.go
@@ -23,16 +23,19 @@ import (
 // DefaultName when no WithName option is provided to NewBuilder
 const DefaultName = builders.Pack
 
+var DefaultBaseBuilder = "gcr.io/paketo-buildpacks/builder:base"
+var DefaultRustBuilder = "gcr.io/paketo-buildpacks/builder:full-cf"
+
 var (
 	DefaultBuilderImages = map[string]string{
-		"node":       "gcr.io/paketo-buildpacks/builder:base",
-		"nodejs":     "gcr.io/paketo-buildpacks/builder:base",
-		"typescript": "gcr.io/paketo-buildpacks/builder:base",
-		"go":         "gcr.io/paketo-buildpacks/builder:base",
-		"python":     "gcr.io/paketo-buildpacks/builder:base",
-		"quarkus":    "gcr.io/paketo-buildpacks/builder:base",
-		"rust":       "gcr.io/paketo-buildpacks/builder:full-cf",
-		"springboot": "gcr.io/paketo-buildpacks/builder:base",
+		"node":       DefaultBaseBuilder,
+		"nodejs":     DefaultBaseBuilder,
+		"typescript": DefaultBaseBuilder,
+		"go":         DefaultBaseBuilder,
+		"python":     DefaultBaseBuilder,
+		"quarkus":    DefaultBaseBuilder,
+		"rust":       DefaultRustBuilder,
+		"springboot": DefaultBaseBuilder,
 	}
 
 	// Ensure that all entries in this list are terminated with a trailing "/"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Added the default builders variables for listing through func environment command


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1788

```release-notes
Adds default builders for s2i and buildpacks to `func environment`
```

