### PR TITLE
added shorthand -R for --remote flag

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -176,7 +176,7 @@ EXAMPLES
 		"Git revision (branch) to be used when deploying via the Git repository ($FUNC_GIT_BRANCH)")
 	cmd.Flags().StringP("git-dir", "d", f.Build.Git.ContextDir,
 		"Directory in the Git repository containing the function (default is the root) ($FUNC_GIT_DIR)")
-	cmd.Flags().Bool("remote", f.Deploy.Remote,
+	cmd.Flags().BoolP("remote", "R", f.Deploy.Remote,
 		"Trigger a remote deployment. Default is to deploy and build from the local system ($FUNC_REMOTE)")
 	cmd.Flags().String("pvc-size", f.Build.PVCSize,
 		"When triggering a remote deployment, set a custom volume size to allocate for the build operation ($FUNC_PVC_SIZE)")

--- a/docs/reference/func_deploy.md
+++ b/docs/reference/func_deploy.md
@@ -130,7 +130,7 @@ func deploy
   -u, --push                    Push the function image to registry before deploying. ($FUNC_PUSH) (default true)
       --pvc-size string         When triggering a remote deployment, set a custom volume size to allocate for the build operation ($FUNC_PVC_SIZE)
   -r, --registry string         Container registry + registry namespace. (ex 'ghcr.io/myuser').  The full image name is automatically determined using this along with function name. ($FUNC_REGISTRY)
-      --remote                  Trigger a remote deployment. Default is to deploy and build from the local system ($FUNC_REMOTE)
+  -R, --remote                  Trigger a remote deployment. Default is to deploy and build from the local system ($FUNC_REMOTE)
   -v, --verbose                 Print verbose logs ($FUNC_VERBOSE)
 ```
 


### PR DESCRIPTION
# Changes
Added shorthand -R for `func deploy --remote` flag to allow `func deploy -R` to work according to the Synopsis
```
SYNOPSIS
	{{rootCmdUse}} deploy [-R|--remote] [-r|--registry] [-i|--image] [-n|--namespace]
	             [-e|--env] [-g|--git-url] [-t|--git-branch] [-d|--git-dir]
	             [-b|--build] [--builder] [--builder-image] [-p|--push]
	             [--platform] [-c|--confirm] [-v|--verbose] [--build-timestamp]
```


Fixes #1719

```release-notes
Adds `-R` shorthand for `--remote` flag in `func deploy`
```
