### PR TITLE
fix: bad connection handling for in cluster dialer

### DIFF
--- a/pkg/k8s/dialer_test.go
+++ b/pkg/k8s/dialer_test.go
@@ -167,16 +167,8 @@ func TestDialUnreachable(t *testing.T) {
 	t.Cleanup(func() {
 		dialer.Close()
 	})
-
-	transport := &http.Transport{
-		DialContext: dialer.DialContext,
-	}
-
-	var client = http.Client{
-		Transport: transport,
-	}
-
-	_, err = client.Get("http://does-not.exists.svc")
+	
+	_, err = dialer.DialContext(ctx, "tcp", "does-not.exists.svc:80")
 	if err == nil {
 		t.Error("error was expected but got nil")
 		return

--- a/pkg/k8s/dialer_test.go
+++ b/pkg/k8s/dialer_test.go
@@ -167,13 +167,22 @@ func TestDialUnreachable(t *testing.T) {
 	t.Cleanup(func() {
 		dialer.Close()
 	})
-	
+
 	_, err = dialer.DialContext(ctx, "tcp", "does-not.exists.svc:80")
 	if err == nil {
 		t.Error("error was expected but got nil")
 		return
 	}
-	if !strings.Contains(err.Error(), "not resolve") {
-		t.Errorf("error %q doesn't containe expected sub-string: ", err.Error())
+	if !strings.Contains(err.Error(), "no such host") {
+		t.Errorf("error %q doesn't containe expected substring: ", err.Error())
+	}
+
+	_, err = dialer.DialContext(ctx, "tcp", "localhost:80")
+	if err == nil {
+		t.Error("error was expected but got nil")
+		return
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("error %q doesn't containe expected substring: ", err.Error())
 	}
 }

--- a/pkg/k8s/dialer_test.go
+++ b/pkg/k8s/dialer_test.go
@@ -174,7 +174,7 @@ func TestDialUnreachable(t *testing.T) {
 		return
 	}
 	if !strings.Contains(err.Error(), "no such host") {
-		t.Errorf("error %q doesn't containe expected substring: ", err.Error())
+		t.Errorf("error %q doesn't contain expected substring: ", err.Error())
 	}
 
 	_, err = dialer.DialContext(ctx, "tcp", "localhost:80")
@@ -183,6 +183,6 @@ func TestDialUnreachable(t *testing.T) {
 		return
 	}
 	if !strings.Contains(err.Error(), "connection refused") {
-		t.Errorf("error %q doesn't containe expected substring: ", err.Error())
+		t.Errorf("error %q doesn't contain expected substring: ", err.Error())
 	}
 }


### PR DESCRIPTION
# Changes

- :bug: Fix bad connection handling for `in cluster dialer` which caused confusing error messages (although  functionality was not affected). Connections were closed from wrong end of io.Pipe
which resulted in confusing error logs.
- :gift: Better error handling:
  - `ContextDial()` returns some errors immediately instead of deferring them on `Read/Write` operation on returned connection.
  -  `ContextDial()` tries to parse `socat`'s stderr and translate it to `Go`'s `net.OpError` instead of just creating error with whole stderr embedded in it.

/kind bug

resolves: #1792

```release-note
fix: connection handling for `in cluster dialer` causing confusing error messages #1792
```

