### PR TITLE
src: cleanup the run timeout loop and check

### DIFF
--- a/pkg/functions/errors.go
+++ b/pkg/functions/errors.go
@@ -3,6 +3,7 @@ package functions
 import (
 	"errors"
 	"fmt"
+	"time"
 )
 
 var (
@@ -14,7 +15,6 @@ var (
 	ErrRepositoriesNotDefined    = errors.New("custom template repositories location not specified")
 	ErrRepositoryNotFound        = errors.New("repository not found")
 	ErrRootRequired              = errors.New("function root path is required")
-	ErrRunTimeout                = errors.New("timeout waiting for function to report ready")
 	ErrRuntimeNotFound           = errors.New("language runtime not found")
 	ErrRuntimeRequired           = errors.New("language runtime required")
 	ErrTemplateMissingRepository = errors.New("template name missing repository prefix")
@@ -61,4 +61,12 @@ type ErrRunnerNotImplemented struct {
 
 func (e ErrRunnerNotImplemented) Error() string {
 	return fmt.Sprintf("the %q runtime may only be run containerized.", e.Runtime)
+}
+
+type ErrRunTimeout struct {
+	Timeout time.Duration
+}
+
+func (e ErrRunTimeout) Error() string {
+	return fmt.Sprintf("timed out waiting for function to be ready for %s", e.Timeout)
 }

--- a/pkg/functions/runner.go
+++ b/pkg/functions/runner.go
@@ -156,9 +156,10 @@ func waitFor(job *Job, timeout time.Duration) error {
 	if job.verbose {
 		fmt.Printf("Waiting for %v\n", url)
 	}
+	to := time.After(timeout)
 	for {
 		select {
-		case <-time.After(timeout):
+		case <-to:
 			return ErrRunTimeout{timeout}
 		case <-time.After(500 * time.Millisecond):
 			if checkReady(url, job.verbose) {


### PR DESCRIPTION
- :broom: cleans up the run timeout loop and error

Adds the timeout reached to a typed error on timeout, and factors out the liveness check to a function to avoid tail-stacking defer statements in the check loop.