### PR TITLE
adding support for .funcignore file

### DIFF
--- a/pkg/builders/buildpacks/builder_test.go
+++ b/pkg/builders/buildpacks/builder_test.go
@@ -131,7 +131,7 @@ func TestBuild_BuilderImageExclude(t *testing.T) {
 	)
 	funcIgnoreContent := []byte(`#testing comments
 hello.txt`)
-	expected := []string{"#testing comments", "hello.txt"}
+	expected := []string{"hello.txt"}
 
 	tempdir := t.TempDir()
 	f.Root = tempdir
@@ -146,10 +146,7 @@ hello.txt`)
 		if len(opts.ProjectDescriptor.Build.Exclude) != 2 {
 			t.Fatalf("expected 2 lines of exclusions , got %v", len(opts.ProjectDescriptor.Build.Exclude))
 		}
-		if opts.ProjectDescriptor.Build.Exclude[0] != expected[0] {
-			t.Fatalf("expected a comment line %v, got '%v'", expected[0], opts.ProjectDescriptor.Build.Exclude[0])
-		}
-		if opts.ProjectDescriptor.Build.Exclude[1] != expected[1] {
+		if opts.ProjectDescriptor.Build.Exclude[1] != expected[0] {
 			t.Fatalf("expected excluded file to be '%v', got '%v'", expected[1], opts.ProjectDescriptor.Build.Exclude[1])
 		}
 		return nil

--- a/pkg/builders/s2i/builder.go
+++ b/pkg/builders/s2i/builder.go
@@ -151,6 +151,25 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 	}
 	defer os.RemoveAll(tmp)
 
+	funcignore, err := os.Open(filepath.Join(f.Root, ".funcignore"))
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("error opening funcignore file: %w", err)
+	}
+	defer funcignore.Close()
+
+	s2iignore, err := os.Create(filepath.Join(f.Root, ".s2iignore"))
+	if err != nil {
+		return fmt.Errorf("error creating funcignore file: %w", err)
+
+	}
+	defer s2iignore.Close()
+	defer os.Remove(s2iignore.Name())
+
+	_, err = io.Copy(s2iignore, funcignore)
+	if err != nil {
+		return fmt.Errorf("error copying funcignore file: %w", err)
+
+	}
 	cfg.AsDockerfile = filepath.Join(tmp, "Dockerfile")
 
 	var client = b.cli

--- a/pkg/builders/s2i/builder.go
+++ b/pkg/builders/s2i/builder.go
@@ -151,25 +151,29 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 	}
 	defer os.RemoveAll(tmp)
 
-	funcignore, err := os.Open(filepath.Join(f.Root, ".funcignore"))
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("error opening funcignore file: %w", err)
+	funcignorePath := filepath.Join(f.Root, ".funcignore")
+	if _, err := os.Stat(funcignorePath); err == nil {
+		funcignore, err := os.Open(filepath.Join(f.Root, ".funcignore"))
+		if err != nil {
+			return fmt.Errorf("error opening funcignore file: %w", err)
+		}
+		defer funcignore.Close()
+
+		s2iignore, err := os.Create(filepath.Join(f.Root, ".s2iignore"))
+		if err != nil {
+			return fmt.Errorf("error creating funcignore file: %w", err)
+
+		}
+		defer s2iignore.Close()
+		defer os.Remove(s2iignore.Name())
+
+		_, err = io.Copy(s2iignore, funcignore)
+		if err != nil {
+			return fmt.Errorf("error copying funcignore file: %w", err)
+
+		}
 	}
-	defer funcignore.Close()
 
-	s2iignore, err := os.Create(filepath.Join(f.Root, ".s2iignore"))
-	if err != nil {
-		return fmt.Errorf("error creating funcignore file: %w", err)
-
-	}
-	defer s2iignore.Close()
-	defer os.Remove(s2iignore.Name())
-
-	_, err = io.Copy(s2iignore, funcignore)
-	if err != nil {
-		return fmt.Errorf("error copying funcignore file: %w", err)
-
-	}
 	cfg.AsDockerfile = filepath.Join(tmp, "Dockerfile")
 
 	var client = b.cli

--- a/pkg/builders/s2i/builder_test.go
+++ b/pkg/builders/s2i/builder_test.go
@@ -169,12 +169,13 @@ hello.txt
 		t.Fatal(err)
 	}
 
-	// create a test file that should be ignored
-	_, err = os.Create(filepath.Join(f.Root, "hello.txt"))
+	// creating test files which should be ignored
+	err = os.WriteFile(filepath.Join(f.Root, "hello.txt"), []byte(""), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = os.Create(filepath.Join(f.Root, "#testingComments.txt"))
+
+	err = os.WriteFile(filepath.Join(f.Root, "#testingComments.txt"), []byte(""), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/builders/s2i/builder_test.go
+++ b/pkg/builders/s2i/builder_test.go
@@ -154,11 +154,14 @@ func Test_BuilderImageConfigurable(t *testing.T) {
 // image
 func Test_BuildImageWithFuncIgnore(t *testing.T) {
 
-	funcIgnoreContent := []byte("hello.txt")
+	funcIgnoreContent := []byte(`#testing comments
+hello.txt
+`)
 	f := fn.Function{
 		Runtime: "node",
-		Root:    ".",
 	}
+	tempdir := t.TempDir()
+	f.Root = tempdir
 	//create a .funcignore file containing the details of the files to be ignored
 	err := os.WriteFile(filepath.Join(f.Root, ".funcignore"), funcIgnoreContent, 0644)
 	if err != nil {
@@ -170,17 +173,6 @@ func Test_BuildImageWithFuncIgnore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	defer func() {
-		err = os.Remove(filepath.Join(filepath.Dir(f.Root), ".funcignore"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = os.Remove(filepath.Join(filepath.Dir(f.Root), "hello.txt"))
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
 
 	cli := mockDocker{
 		build: func(ctx context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error) {

--- a/pkg/builders/s2i/builder_test.go
+++ b/pkg/builders/s2i/builder_test.go
@@ -154,7 +154,8 @@ func Test_BuilderImageConfigurable(t *testing.T) {
 // image
 func Test_BuildImageWithFuncIgnore(t *testing.T) {
 
-	funcIgnoreContent := []byte(`#testing comments
+	funcIgnoreContent := []byte(`#testing Comments
+#testingComments.txt
 hello.txt
 `)
 	f := fn.Function{
@@ -170,6 +171,10 @@ hello.txt
 
 	// create a test file that should be ignored
 	_, err = os.Create(filepath.Join(f.Root, "hello.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = os.Create(filepath.Join(f.Root, "#testingComments.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,6 +195,11 @@ hello.txt
 				if filepath.Base(hdr.Name) == "hello.txt" {
 					return types.ImageBuildResponse{}, fmt.Errorf("test failed, found ignonered file %s:", filepath.Base(hdr.Name))
 				}
+				// If we find the undesired file, return an error
+				if filepath.Base(hdr.Name) == "#tesingComments.txt" {
+					return types.ImageBuildResponse{}, fmt.Errorf("test failed, found ignonered file %s:", filepath.Base(hdr.Name))
+				}
+
 			}
 			return types.ImageBuildResponse{
 				Body:   io.NopCloser(strings.NewReader(`{"stream": "OK!"}`)),

--- a/pkg/builders/s2i/builder_test.go
+++ b/pkg/builders/s2i/builder_test.go
@@ -150,6 +150,67 @@ func Test_BuilderImageConfigurable(t *testing.T) {
 	}
 }
 
+// Test_BuildImageWithFuncIgnore ensures that ignored files are not added to the func
+// image
+func Test_BuildImageWithFuncIgnore(t *testing.T) {
+
+	funcIgnoreContent := []byte("hello.txt")
+	f := fn.Function{
+		Runtime: "node",
+		Root:    ".",
+	}
+	//create a .funcignore file containing the details of the files to be ignored
+	err := os.WriteFile(filepath.Join(f.Root, ".funcignore"), funcIgnoreContent, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create a test file that should be ignored
+	_, err = os.Create(filepath.Join(f.Root, "hello.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err = os.Remove(filepath.Join(filepath.Dir(f.Root), ".funcignore"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = os.Remove(filepath.Join(filepath.Dir(f.Root), "hello.txt"))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	cli := mockDocker{
+		build: func(ctx context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error) {
+			tr := tar.NewReader(context)
+			for {
+				hdr, err := tr.Next()
+				if err != nil {
+					if errors.Is(err, io.EOF) {
+						break
+					}
+					return types.ImageBuildResponse{}, err
+				}
+
+				// If we find the undesired file, return an error
+				if filepath.Base(hdr.Name) == "hello.txt" {
+					return types.ImageBuildResponse{}, fmt.Errorf("test failed, found ignonered file %s:", filepath.Base(hdr.Name))
+				}
+			}
+			return types.ImageBuildResponse{
+				Body:   io.NopCloser(strings.NewReader(`{"stream": "OK!"}`)),
+				OSType: "linux",
+			}, nil
+		},
+	}
+	b := s2i.NewBuilder(s2i.WithName(builders.S2I), s2i.WithDockerClient(cli))
+	if err := b.Build(context.Background(), f, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // Test_Verbose ensures that the verbosity flag is propagated to the
 // S2I builder implementation.
 func Test_BuilderVerbose(t *testing.T) {

--- a/pkg/functions/client.go
+++ b/pkg/functions/client.go
@@ -1102,7 +1102,7 @@ func ensureFuncIgnore(root string) error {
 	_, err = file.WriteString(`
 # Function use the .funcignore file to exclude data which should not
 # be tracked in the image build. To instruct the system not to track
-# files in the image build, add the regex pattern or file information to  
+# files in the image build, add the regex pattern or file information to
 # this file.
 `)
 	if err != nil {

--- a/pkg/functions/client.go
+++ b/pkg/functions/client.go
@@ -1100,10 +1100,10 @@ func ensureFuncIgnore(root string) error {
 
 	// Write the desired string to the file
 	_, err = file.WriteString(`
-# Function use the .funcignore file to exclude data which should not
-# be tracked in the image build. To instruct the system not to track
-# files in the image build, add the regex pattern or file information to
-# this file.
+# Use the .funcignore file to exclude files which should not be
+# tracked in the image build. To instruct the system not to track
+# files in the image build, add the regex pattern or file information
+# to this file.
 `)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes
added the support for funcignore file for excluding the data which don't need to be added to image build

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1463 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
