### PR TITLE
src: improved version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,9 @@ BIN_WINDOWS ?= $(BIN)_windows_amd64.exe
 HASH    := $(shell git rev-parse --short HEAD 2>/dev/null)
 VTAG    := $(shell git tag --points-at HEAD | head -1)
 VTAG    := $(shell [ -z $(VTAG) ] && echo $(ETAG) || echo $(VTAG))
-VERS    ?= $(shell [ -z $(VTAG) ] && echo 'tip' || echo $(VTAG) )
-LDFLAGS := "-X main.vers=$(VERS) -X main.hash=$(HASH)"
+VERS    ?= $(shell git describe --tags --match 'v*')
+KVER    ?= $(shell git describe --tags --match 'knative-*')
+LDFLAGS := "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.kver=$(KVER) -X main.hash=$(HASH)"
 
 # All Code prerequisites, including generated files, etc.
 CODE := $(shell find . -name '*.go') generate/zz_filesystem_generated.go go.mod schema/func_yaml-schema.json

--- a/cmd/func/main.go
+++ b/cmd/func/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Statically-populated build metadata set by `make build`.
-var vers, hash string
+var vers, kver, hash string
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -34,6 +34,7 @@ func main() {
 		Name: "func",
 		Version: cmd.Version{
 			Vers: vers,
+			Kver: kver,
 			Hash: hash,
 		}}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -170,8 +170,8 @@ func TestVerbose(t *testing.T) {
 		{
 			name:   "verbose as version's flag",
 			args:   []string{"version", "-v"},
-			want:   "Version: v0.42.0-cafe",
-			wantLF: 3,
+			want:   "Version: v0.42.0",
+			wantLF: 6,
 		},
 		{
 			name:   "no verbose",
@@ -191,6 +191,7 @@ func TestVerbose(t *testing.T) {
 				Version: Version{
 					Vers: "v0.42.0",
 					Hash: "cafe",
+					Kver: "v1.10.0",
 				}})
 
 			cmd.SetArgs(tt.args)


### PR DESCRIPTION
- :gift: Knative version now included in func verbose output
- :bug: fixes bug where builds without an associated version number showed `v0.0.0`
- :broom: validates version passed by build is a valid semver

Ensures that `func version` remains consistent; always returning an ascending semver of the version, with the associated knative tag being part of the verbose version information.

Replaces the default v0.0.0 version tag when building from a non-tagged commit to the "human readable" form provided by "git describe".  This consists of the most recently tagged version along with a suffix which consists of the number of commits which have been added since the tagged version, and the hash.

The reasoning behind this change is that we must retain the ability to release versions independently of the knative releases, while at the same time communicating which knative release to for which this version is associated.  The primary version number is the version of this library, and of the binary itself.  At time of this writing, that is `v0.37.0`, and is the most contectually relevant.  The knative version to which this library and cli tool relates most closely is `v1.10`, and is included as metadata, and printed in verbose mode.

Here's how this will look in practice:

The most recent Knative version is v1.10, which was released with Functions v0.37.0.  Checking out v0.37.0 correctly displays the versions:
```shell
❯ git checkout v0.37.0 && make
❯ ./func version -v
Version: v0.37.0
Knative: v1.10.0
Commit: 61179d88
SocatImage: quay.io/boson/alpine-socat:1.7.4.3-r1-non-root
TarImage: quay.io/boson/alpine-socat:1.7.4.3-r1-non-root
```

When building from an unreleased commit, such as the current Function main branch (which is 37 commits ahead of what was released as v0.37.0 in Knative 1.10:
```shell
❯ git checkout main && make
❯ ./func version -v
Version: v0.37.0-77-gcabba3f9
Knative: v1.10.0
Commit: cabba3f9
SocatImage: quay.io/boson/alpine-socat:1.7.4.3-r1-non-root
TarImage: quay.io/boson/alpine-socat:1.7.4.3-r1-non-root
```

Please note that this only applies to builds triggered with `make build`.  Direct builds of the source code do not populate these values:
```shell
❯ go build ./cmd/func
❯ ./func version -v
Version:
Knative:
Commit:
SocatImage: quay.io/boson/alpine-socat:1.7.4.3-r1-non-root
TarImage: quay.io/boson/alpine-socat:1.7.4.3-r1-non-root