### PR TITLE
src: refactor builder concurrency test

### DIFF
--- a/pkg/oci/containerize.go
+++ b/pkg/oci/containerize.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -19,27 +18,30 @@ import (
 // languageLayerBuilder builds the layer for the given language whuch may
 // be different from one platform to another.  For example, this is the
 // layer in the image which contains the Go cross-compiled binary.
-type languageLayerBuilder interface {
-	Build(*buildConfig, v1.Platform) (v1.Descriptor, v1.Layer, error)
+type languageLayerBuilder func(*buildConfig, v1.Platform) (v1.Descriptor, v1.Layer, error)
+
+var languageLayerBuilders = map[string]languageLayerBuilder{
+	"go":     buildGoLayer,
+	"python": layerBuilderNotImplemented,
+	"node":   layerBuilderNotImplemented,
+	"rust":   layerBuilderNotImplemented,
 }
 
-func newLanguageLayerBuilder(cfg *buildConfig) (l languageLayerBuilder, err error) {
-	switch cfg.f.Runtime {
-	case "go":
-		l = goLayerBuilder{}
-	case "python":
-		// Likely the next to be supported after Go
-		err = errors.New("functions written in Python are not yet supported by the host builder")
-	case "node":
-		// Likely the next to be supported after Python
-		err = errors.New("functions written in Node are not yet supported by the host builder")
-	case "rust":
-		// Likely the next to be supprted after Node
-		err = errors.New("functions written in Rust are not yet supported by the host builder")
-	default:
-		// Others are not likely to be supported in the near future without
-		// increased contributions.
+func layerBuilderNotImplemented(cfg *buildConfig, _ v1.Platform) (d v1.Descriptor, l v1.Layer, err error) {
+	err = fmt.Errorf("%v functions are not yet supported by the host builder.", cfg.f.Runtime)
+	return
+}
+
+func getLanguageLayerBuilder(cfg *buildConfig) (l languageLayerBuilder, err error) {
+	// use the custom implementation, if provided
+	if cfg.buildFn != nil {
+		return cfg.buildFn, nil
+	}
+	// otherwise lookup the build function
+	l, ok := languageLayerBuilders[cfg.f.Runtime]
+	if !ok {
 		err = fmt.Errorf("the language runtime '%v' is not a recognized language by the host builder", cfg.f.Runtime)
+		return
 	}
 	return
 }
@@ -205,14 +207,13 @@ func newDescriptor(layer v1.Layer) (desc v1.Descriptor, err error) {
 // newImage creates an image for the given platform.
 // The image consists of the shared data layer which is provided
 func newImage(cfg *buildConfig, dataDesc v1.Descriptor, dataLayer v1.Layer, p v1.Platform, verbose bool) (imageDesc v1.Descriptor, err error) {
-
-	b, err := newLanguageLayerBuilder(cfg)
+	buildFn, err := getLanguageLayerBuilder(cfg)
 	if err != nil {
 		return
 	}
 
 	// Write Exec Layer as Blob -> Layer
-	execDesc, execLayer, err := b.Build(cfg, p)
+	execDesc, execLayer, err := buildFn(cfg, p)
 	if err != nil {
 		return
 	}
@@ -288,6 +289,9 @@ func newConfig(cfg *buildConfig, p v1.Platform, layers ...v1.Layer) (desc v1.Des
 	}
 	var diff v1.Hash
 	for _, v := range layers {
+		if v == nil {
+			continue
+		}
 		if diff, err = v.DiffID(); err != nil {
 			return
 		}


### PR DESCRIPTION
- :broom: refactor build concurrency test

Expands the builder to include an optional notification channel such that temporary test tooling can be removed entirely from the builder core and logic kept in the test only.

/kind cleanup