### PR TITLE
Cluster integration tests cleanup

### DIFF
--- a/pkg/http/transport.go
+++ b/pkg/http/transport.go
@@ -56,7 +56,7 @@ func WithInsecureSkipVerify(insecureSkipVerify bool) Option {
 // This is useful for accessing cluster internal services (pushing a CloudEvent into Knative broker).
 func NewRoundTripper(opts ...Option) RoundTripCloser {
 	o := options{
-		inClusterDialer:    k8s.NewLazyInitInClusterDialer(),
+		inClusterDialer:    k8s.NewLazyInitInClusterDialer(k8s.GetClientConfig()),
 		insecureSkipVerify: false,
 	}
 	for _, option := range opts {

--- a/pkg/k8s/dialer_test.go
+++ b/pkg/k8s/dialer_test.go
@@ -40,8 +40,11 @@ func TestDialInClusterService(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	pp := metaV1.DeletePropagationForeground
 	creatOpts := metaV1.CreateOptions{}
-	deleteOpts := metaV1.DeleteOptions{}
+	deleteOpts := metaV1.DeleteOptions{
+		PropagationPolicy: &pp,
+	}
 
 	testingNS, _, err := clientConfig.Namespace()
 	if err != nil {

--- a/pkg/k8s/dialer_test.go
+++ b/pkg/k8s/dialer_test.go
@@ -20,6 +20,7 @@ import (
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes"
 	"knative.dev/func/pkg/k8s"
 )
 
@@ -27,7 +28,14 @@ func TestDialInClusterService(t *testing.T) {
 	var err error
 	var ctx = context.Background()
 
-	cliSet, err := k8s.NewKubernetesClientset()
+	clientConfig := k8s.GetClientConfig()
+
+	rc, err := clientConfig.ClientConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cliSet, err := kubernetes.NewForConfig(rc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +138,7 @@ func TestDialInClusterService(t *testing.T) {
 	// wait for service to start
 	time.Sleep(time.Second * 5)
 
-	dialer := k8s.NewLazyInitInClusterDialer()
+	dialer := k8s.NewLazyInitInClusterDialer(clientConfig)
 	t.Cleanup(func() {
 		dialer.Close()
 	})
@@ -181,7 +189,7 @@ func TestDialInClusterService(t *testing.T) {
 func TestDialUnreachable(t *testing.T) {
 	var ctx = context.Background()
 
-	dialer, err := k8s.NewInClusterDialer(ctx)
+	dialer, err := k8s.NewInClusterDialer(ctx, k8s.GetClientConfig())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/k8s/dialer_test.go
+++ b/pkg/k8s/dialer_test.go
@@ -51,11 +51,12 @@ func TestDialInClusterService(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	rnd := rand.String(5)
 	one := int32(1)
 	labels := map[string]string{"app.kubernetes.io/name": "helloworld"}
 	deployment := &appsV1.Deployment{
 		ObjectMeta: metaV1.ObjectMeta{
-			Name:   "helloworld-" + rand.String(5),
+			Name:   "helloworld-" + rnd,
 			Labels: labels,
 		},
 		Spec: appsV1.DeploymentSpec{
@@ -103,7 +104,7 @@ func TestDialInClusterService(t *testing.T) {
 
 	svc := &coreV1.Service{
 		ObjectMeta: metaV1.ObjectMeta{
-			Name: "helloworld",
+			Name: "helloworld-" + rnd,
 		},
 		Spec: coreV1.ServiceSpec{
 			Ports: []coreV1.ServicePort{

--- a/pkg/k8s/dialer_test.go
+++ b/pkg/k8s/dialer_test.go
@@ -43,21 +43,10 @@ func TestDialInClusterService(t *testing.T) {
 	creatOpts := metaV1.CreateOptions{}
 	deleteOpts := metaV1.DeleteOptions{}
 
-	testingNS := &coreV1.Namespace{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name: "dialer-test-ns-" + rand.String(5),
-		},
-		Spec: coreV1.NamespaceSpec{},
-	}
-
-	_, err = cliSet.CoreV1().Namespaces().Create(ctx, testingNS, creatOpts)
+	testingNS, _, err := clientConfig.Namespace()
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		cliSet.CoreV1().Namespaces().Delete(ctx, testingNS.Name, deleteOpts)
-	})
-	t.Log("created namespace: ", testingNS.Name)
 
 	one := int32(1)
 	labels := map[string]string{"app.kubernetes.io/name": "helloworld"}
@@ -100,12 +89,12 @@ func TestDialInClusterService(t *testing.T) {
 		},
 	}
 
-	_, err = cliSet.AppsV1().Deployments(testingNS.Name).Create(ctx, deployment, creatOpts)
+	_, err = cliSet.AppsV1().Deployments(testingNS).Create(ctx, deployment, creatOpts)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		_ = cliSet.AppsV1().Deployments(testingNS.Name).Delete(ctx, deployment.Name, deleteOpts)
+		_ = cliSet.AppsV1().Deployments(testingNS).Delete(ctx, deployment.Name, deleteOpts)
 	})
 	t.Log("created deployment:", deployment.Name)
 
@@ -126,12 +115,12 @@ func TestDialInClusterService(t *testing.T) {
 		},
 	}
 
-	svc, err = cliSet.CoreV1().Services(testingNS.Name).Create(ctx, svc, creatOpts)
+	svc, err = cliSet.CoreV1().Services(testingNS).Create(ctx, svc, creatOpts)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		_ = cliSet.CoreV1().Services(testingNS.Name).Delete(ctx, svc.Name, deleteOpts)
+		_ = cliSet.CoreV1().Services(testingNS).Delete(ctx, svc.Name, deleteOpts)
 	})
 	t.Log("created svc:", svc.Name)
 

--- a/pkg/k8s/persistent_volumes_test.go
+++ b/pkg/k8s/persistent_volumes_test.go
@@ -30,7 +30,8 @@ func TestUploadToVolume(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testingPVCName := "testing-pvc-" + rand.String(5)
+	rnd := rand.String(5)
+	testingPVCName := "testing-pvc-" + rnd
 
 	err = k8s.CreatePersistentVolumeClaim(ctx, testingPVCName, testingNS,
 		nil, nil,
@@ -64,7 +65,7 @@ func TestUploadToVolume(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testingPodName := "testing-pod-" + rand.String(5)
+	testingPodName := "testing-pod-" + rnd
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/k8s/persistent_volumes_test.go
+++ b/pkg/k8s/persistent_volumes_test.go
@@ -17,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/rand"
-
 	"knative.dev/func/pkg/k8s"
 )
 
@@ -26,28 +25,10 @@ func TestUploadToVolume(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	t.Cleanup(cancel)
 
-	cliSet, err := k8s.NewKubernetesClientset()
+	cliSet, testingNS, err := k8s.NewClientAndResolvedNamespace("")
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	testingNS := "volume-uploader-test-ns-" + rand.String(5)
-
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: testingNS,
-		},
-		Spec: corev1.NamespaceSpec{},
-	}
-
-	_, err = cliSet.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		cliSet.CoreV1().Namespaces().Delete(ctx, testingNS, metav1.DeleteOptions{})
-	})
-	t.Log("created namespace: ", testingNS)
 
 	testingPVCName := "testing-pvc-" + rand.String(5)
 


### PR DESCRIPTION
# Changes


- :broom: General improvements for `TestUploadToVolume()` and `TestDialInClusterService()`:
   * Better allocation and cleanup of testing resources. All resources names are randomized and the resources are deleted after test.
   * `TestUploadToVolume()` now uses `Deployment` instead of plain `Pod` for the testing service.
   * `TestUploadToVolume()` and `TestDialInClusterService()` are not running in new namespace, instead they are run in current default namespace. Rationale: not all cluster users can create a namespace, this change ensures the tests can be run with non-admin cluster users.
   
- :broom: Refactor `NewInClusterDialer()` now takes `clientcmd.ClientConfig` as parameter, this removed deplendency on global `kubectl` configuration allowing test parallelization.