### PR TITLE
[release-1.10] src: interstitial commit version (#1817)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,9 @@ DATE    := $(shell date -u +"%Y%m%dT%H%M%SZ")
 HASH    := $(shell git rev-parse --short HEAD 2>/dev/null)
 VTAG    := $(shell git tag --points-at HEAD | head -1)
 VTAG    := $(shell [ -z $(VTAG) ] && echo $(ETAG) || echo $(VTAG))
-VERS    ?= $(shell [ -z $(VTAG) ] && echo 'tip' || echo $(VTAG) )
-LDFLAGS := "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.hash=$(HASH)"
+VERS    ?= $(shell git describe --tags --match 'v*')
+KVER    ?= $(shell git describe --tags --match 'knative-*')
+LDFLAGS := "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.kver=$(KVER) -X main.hash=$(HASH)"
 
 # All Code prerequisites, including generated files, etc.
 CODE := $(shell find . -name '*.go') generate/zz_filesystem_generated.go go.mod schema/func_yaml-schema.json

--- a/cmd/func/main.go
+++ b/cmd/func/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Statically-populated build metadata set by `make build`.
-var date, vers, hash string
+var vers, kver, hash string
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -33,8 +33,8 @@ func main() {
 	cfg := cmd.RootCommandConfig{
 		Name: "func",
 		Version: cmd.Version{
-			Date: date,
 			Vers: vers,
+			Kver: kver,
 			Hash: hash,
 		}}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
+	"github.com/Masterminds/semver"
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -328,61 +328,52 @@ func cwd() (cwd string) {
 	return cwd
 }
 
+// Version information populated on build.
 type Version struct {
 	// Date of compilation
 	Date string
 	// Version tag of the git commit, or 'tip' if no tag.
 	Vers string
+	// Kver is the version of knative in which func was most recently
+	// If the build is not tagged as being released with a specific Knative
+	// build, this is the most recent version of knative along with a suffix
+	// consisting of the number of commits which have been added since it was
+	// included in Knative.
+	Kver string
 	// Hash of the currently active git commit on build.
 	Hash string
 	// Verbose printing enabled for the string representation.
 	Verbose bool
 }
 
-// Return the stringification of the Version struct, which takes into account
-// the verbosity setting.
+// Return the stringification of the Version struct.
 func (v Version) String() string {
 	if v.Verbose {
 		return v.StringVerbose()
 	}
-
-	// Ensure that the value returned is parseable as a semver, with the special
-	// value v0.0.0 as the default indicating there is no version information
-	// available.
-	if strings.HasPrefix(v.Vers, "v") {
-		// TODO: this is the naive approach, perhaps consider actually parse it
-		// using the semver lib
-		return v.Vers
-	}
-
-	// Any non-semver value is invalid, and thus indistinguishable from a
-	// nonexistent version value, so the default zero value of v0.0.0 is used.
-	return "v0.0.0"
+	_ = semver.MustParse(v.Vers)
+	return v.Vers
 }
 
-// StringVerbose returns the verbose version of the version stringification.
-// The format returned is [semver]-[hash]-[date] where the special value
-// 'v0.0.0' and 'source' are used when version is not available and/or the
-// libray has been built from source, respectively.
+// StringVerbose returns the version along with extended version metadata.
 func (v Version) StringVerbose() string {
 	var (
 		vers = v.Vers
+		kver = v.Kver
 		hash = v.Hash
-		date = v.Date
 	)
-	if vers == "" {
-		vers = "v0.0.0"
+	if strings.HasPrefix(kver, "knative-") {
+		kver = strings.Split(kver, "-")[1]
 	}
-	if hash == "" {
-		hash = "source"
-	}
-	if date == "" {
-		date = time.Now().Format(time.RFC3339)
-	}
-	funcVersion := fmt.Sprintf("%s-%s-%s", vers, hash, date)
-	return fmt.Sprintf("Version: %s\n"+
-		"SocatImage: %s\n"+
-		"TarImage: %s", funcVersion,
+	return fmt.Sprintf(
+		"Version: %s\n"+
+			"Knative: %s\n"+
+			"Commit: %s\n"+
+			"SocatImage: %s\n"+
+			"TarImage: %s\n",
+		vers,
+		kver,
+		hash,
 		k8s.SocatImage,
 		k8s.TarImage)
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -170,8 +170,8 @@ func TestVerbose(t *testing.T) {
 		{
 			name:   "verbose as version's flag",
 			args:   []string{"version", "-v"},
-			want:   "Version: v0.42.0-cafe-1970-01-01",
-			wantLF: 3,
+			want:   "Version: v0.42.0",
+			wantLF: 6,
 		},
 		{
 			name:   "no verbose",
@@ -192,6 +192,7 @@ func TestVerbose(t *testing.T) {
 					Date: "1970-01-01",
 					Vers: "v0.42.0",
 					Hash: "cafe",
+					Kver: "v1.10.0",
 				}})
 
 			cmd.SetArgs(tt.args)


### PR DESCRIPTION
This is a backport of #1817 to the 1.10 release branch.

The Knative version is now included in version command verbose output

Building an unreleased version no longer returns v0.0.0, but instead the value provided by `git describe --tags` which is the most recent tagged release with a suffix consisting of the number of commits since that release and the short hash.

Verbose output now always includes the current commit on a dedicated line.

```release-note
Improved version output
```
