### PR TITLE
fix: host builder retry error

### DIFF
--- a/pkg/oci/containerize.go
+++ b/pkg/oci/containerize.go
@@ -28,7 +28,7 @@ var languageLayerBuilders = map[string]languageLayerBuilder{
 }
 
 func layerBuilderNotImplemented(cfg *buildConfig, _ v1.Platform) (d v1.Descriptor, l v1.Layer, err error) {
-	err = fmt.Errorf("%v functions are not yet supported by the host builder.", cfg.f.Runtime)
+	err = fmt.Errorf("%v functions are not yet supported by the host builder", cfg.f.Runtime)
 	return
 }
 

--- a/pkg/scaffolding/scaffold.go
+++ b/pkg/scaffolding/scaffold.go
@@ -86,7 +86,7 @@ func detectSignature(src, runtime, invoke string) (s Signature, err error) {
 	if static && instanced {
 		return s, fmt.Errorf("function may not implement both the static and instanced method signatures simultaneously")
 	} else if !static && !instanced {
-		return s, fmt.Errorf("function does not implement any known method signatures")
+		return s, fmt.Errorf("function does not implement any known method signatures or does not compile")
 	} else if instanced {
 		return toSignature(true, invoke), nil
 	} else {


### PR DESCRIPTION
- :bug: error retrying failed host builder builds

The host builder was not properly starting a clean build on retry of a failed build.

This is also the last known bug for the [Scaffolding Subsystem](https://github.com/knative/func/discussions/1589) MVP, closing the Issue-epic #1703

/kind bug
/closes #1703