### PR TITLE
fix: remove path bacause of bug in paring logic

### DIFF
--- a/pkg/docker/docker_client.go
+++ b/pkg/docker/docker_client.go
@@ -131,7 +131,7 @@ func NewClient(defaultHost string) (dockerClient client.CommonAPIClient, dockerH
 	dockerClient, err = client.NewClientWithOpts(
 		client.WithAPIVersionNegotiation(),
 		client.WithHTTPClient(httpClient),
-		client.WithHost("http://placeholder/"))
+		client.WithHost("http://placeholder"))
 
 	if closer, ok := contextDialer.(io.Closer); ok {
 		dockerClient = clientWithAdditionalCleanup{


### PR DESCRIPTION
# Changes

- :bug: Fix bug caused by  Docker's `ParseHostURL()` -- I believe that function is not working correctly [see](https://github.com/moby/moby/discussions/46015). The error starts showing up when using Go 1.20.6 which does some additional percent escaping of hostname.