### PR TITLE
fix: add pod security context to avoid permission denied (#1857)

### DIFF
--- a/pkg/k8s/persistent_volumes.go
+++ b/pkg/k8s/persistent_volumes.go
@@ -117,14 +117,17 @@ func runWithVolumeMounted(ctx context.Context, podImage string, podCommand []str
 
 	const volumeMntPoint = "/tmp/volume_mnt"
 	const pVol = "p-vol"
+	fsGroup := int64(1000)
 	job := &batchV1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: jobName,
 		},
 		Spec: batchV1.JobSpec{
-
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup: &fsGroup,
+					},
 					Containers: []corev1.Container{
 						{
 							Name:       "container",


### PR DESCRIPTION
@matejvasek this addition causes that the permission denied error on EKS...

```
❯ ./func deploy --remote -p func-node-2-remote
🕗 Creating Pipeline resources
🕔 25 22:39:59.387273   60639 v2.go:105] write tcp 192.168.178.20:61074->52.57.203.11:443: use of closed network connection
Error: failed to run pipeline: cannot upload sources to the PVC: the command failed: exitcode=1, out="tar: can't create directory 'source': Permission denied\ntar: can't open 'source/.funcignore': No such file or directory"
```
is gone. 

```
❯ ./func deploy --remote -p func-node-2-remote
   ✅ Function deployed in namespace "knative-func" and exposed at URL: 
   http://func-node-2-remote.knative-func.3.121.145.23.sslip.io
```
I believe we should always set the `fsGroup` on pods that access a PV to ensure that the pod can access the volume. Please, check the impact of this change on deployments on OpenShift and KinD.