### PR TITLE
rename knative-sandbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,10 +175,10 @@ test-typescript: ## Test Typescript templates
 update-runtimes:  pull-runtimes generate/zz_filesystem_generated.go ## Update Scaffolding Runtimes
 
 pull-runtimes:
-	cd templates/go/scaffolding/instanced-http && go get -u github.com/knative-sandbox/func-go/http
-	cd templates/go/scaffolding/static-http && go get -u github.com/knative-sandbox/func-go/http
-	cd templates/go/scaffolding/instanced-cloudevents && go get -u github.com/knative-sandbox/func-go/cloudevents
-	cd templates/go/scaffolding/static-cloudevents && go get -u github.com/knative-sandbox/func-go/cloudevents
+	cd templates/go/scaffolding/instanced-http && go get -u github.com/knative-extensions/func-go/http
+	cd templates/go/scaffolding/static-http && go get -u github.com/knative-extensions/func-go/http
+	cd templates/go/scaffolding/instanced-cloudevents && go get -u github.com/knative-extensions/func-go/cloudevents
+	cd templates/go/scaffolding/static-cloudevents && go get -u github.com/knative-extensions/func-go/cloudevents
 
 .PHONY: cert
 certs: templates/certs/ca-certificates.crt ## Update root certificates

--- a/Makefile
+++ b/Makefile
@@ -175,10 +175,10 @@ test-typescript: ## Test Typescript templates
 update-runtimes:  pull-runtimes generate/zz_filesystem_generated.go ## Update Scaffolding Runtimes
 
 pull-runtimes:
-	cd templates/go/scaffolding/instanced-http && go get -u github.com/knative-extensions/func-go/http
-	cd templates/go/scaffolding/static-http && go get -u github.com/knative-extensions/func-go/http
-	cd templates/go/scaffolding/instanced-cloudevents && go get -u github.com/knative-extensions/func-go/cloudevents
-	cd templates/go/scaffolding/static-cloudevents && go get -u github.com/knative-extensions/func-go/cloudevents
+	cd templates/go/scaffolding/instanced-http && go get -u knative.dev/func-go/http
+	cd templates/go/scaffolding/static-http && go get -u knative.dev/func-go/http
+	cd templates/go/scaffolding/instanced-cloudevents && go get -u knative.dev/func-go/cloudevents
+	cd templates/go/scaffolding/static-cloudevents && go get -u knative.dev/func-go/cloudevents
 
 .PHONY: cert
 certs: templates/certs/ca-certificates.crt ## Update root certificates

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -108,7 +108,7 @@ EXAMPLES
 	  $ {{rootCmdUse}} repository -c
 
 	o Add a repository and create a new function using a template from it:
-	  $ {{rootCmdUse}} repository add functastic https://github.com/knative-sandbox/func-tastic
+	  $ {{rootCmdUse}} repository add functastic https://github.com/knative-extensions/func-tastic
 	  $ {{rootCmdUse}} repository list
 	  default
 	  functastic
@@ -116,7 +116,7 @@ EXAMPLES
 	  ...
 
 		o Add a repository specifying the branch to use (metacontroller):
-	  $ {{rootCmdUse}} repository add metacontroller https://github.com/knative-sandbox/func-tastic#metacontroler
+	  $ {{rootCmdUse}} repository add metacontroller https://github.com/knative-extensions/func-tastic#metacontroler
 	  $ {{rootCmdUse}} repository list
 	  default
 	  metacontroller
@@ -126,7 +126,7 @@ EXAMPLES
 	o List all repositories including the URL from which remotes were installed
 	  $ {{rootCmdUse}} repository list -v
 	  default
-	  metacontroller	https://github.com/knative-sandbox/func-tastic#metacontroller
+	  metacontroller	https://github.com/knative-extensions/func-tastic#metacontroller
 
 	o Rename an installed repository
 	  $ {{rootCmdUse}} repository list

--- a/docs/language-packs/language-pack-contract.md
+++ b/docs/language-packs/language-pack-contract.md
@@ -137,7 +137,7 @@ Built in to the Functions library are Language Packs for Go, Node.js, Python, Qu
 Language Packs are distributed as a set of templates for one or more languages via Git repositories, and installed by the developer locally using the `func` CLI.
 
 ```
-func repository add func https://github.com/knative-sandbox/func-tastic
+func repository add func https://github.com/knative-extensions/func-tastic
 func create -l go -t func/hello-world
 ```
 
@@ -190,7 +190,7 @@ When `func create` is used to generate a Function project, the Language Pack pro
 Using external Language Packs is made possible through the `func repository` command, which allows Function developers to add and remove Language Packs from their local development environment. For example:
 
 ```
-❯ func repository add https://github.com/knative-sandbox/func-tastic functastic # Add the func-tastic repo to the local environment
+❯ func repository add https://github.com/knative-extensions/func-tastic functastic # Add the func-tastic repo to the local environment
 ❯ func repo list # list repos
 default
 functastic

--- a/docs/language-packs/templates.md
+++ b/docs/language-packs/templates.md
@@ -8,11 +8,11 @@ To make use of more complex initial function implementions, or to define runtime
 
 ## External Git Repositories
 
-When creating a new function, a Git repository can be specified as the source for the template files.  For example, the the [knative-sandbox/func-tastic repository](https://github.com/knative-sandbox/func-tastic) contains a set of example functions which can be used during project creation.
+When creating a new function, a Git repository can be specified as the source for the template files.  For example, the the [knative-extensions/func-tastic repository](https://github.com/knative-extensions/func-tastic) contains a set of example functions which can be used during project creation.
 
 For example, the func-tastic repository contains an example ["metacontroller"](https://metacontroller.github.io/metacontroller) function implementation for Node.js.  To use this template via the CLI, use the flags:
 
-func create <name> --template metacontroller --repository https://github.com/knative-sandbox/func-tastic
+func create <name> --template metacontroller --repository https://github.com/knative-extensions/func-tastic
 
 ## Locally Installing Repositories
 
@@ -21,7 +21,7 @@ Template repositories can also be installed locally by placing them in the funct
 To install the func-tastic templates locally, for example, use the `func repository add` command:
 
 ```
-func repository add https://github.com/knative-sandbox/func-tastic
+func repository add https://github.com/knative-extensions/func-tastic
 ```
 
 Once installed, the metacontroller template can be specified:

--- a/docs/reference/func_repository.md
+++ b/docs/reference/func_repository.md
@@ -91,7 +91,7 @@ EXAMPLES
 	  $ func repository -c
 
 	o Add a repository and create a new function using a template from it:
-	  $ func repository add functastic https://github.com/knative-sandbox/func-tastic
+	  $ func repository add functastic https://github.com/knative-extensions/func-tastic
 	  $ func repository list
 	  default
 	  functastic
@@ -99,7 +99,7 @@ EXAMPLES
 	  ...
 
 		o Add a repository specifying the branch to use (metacontroller):
-	  $ func repository add metacontroller https://github.com/knative-sandbox/func-tastic#metacontroler
+	  $ func repository add metacontroller https://github.com/knative-extensions/func-tastic#metacontroler
 	  $ func repository list
 	  default
 	  metacontroller
@@ -109,7 +109,7 @@ EXAMPLES
 	o List all repositories including the URL from which remotes were installed
 	  $ func repository list -v
 	  default
-	  metacontroller	https://github.com/knative-sandbox/func-tastic#metacontroller
+	  metacontroller	https://github.com/knative-extensions/func-tastic#metacontroller
 
 	o Rename an installed repository
 	  $ func repository list

--- a/hack/update-builder.go
+++ b/hack/update-builder.go
@@ -257,7 +257,7 @@ func patchBuilder(config *builder.Config) {
 		},
 		{
 			ModuleInfo: dist.ModuleInfo{
-				ID:      "dev.knative-sandbox.go",
+				ID:      "dev.knative-extensions.go",
 				Version: "0.0.4",
 			},
 			ImageOrURI: dist.ImageOrURI{
@@ -285,7 +285,7 @@ func patchBuilder(config *builder.Config) {
 				},
 				{
 					ModuleInfo: dist.ModuleInfo{
-						ID: "dev.knative-sandbox.go",
+						ID: "dev.knative-extensions.go",
 					},
 				},
 			},

--- a/hack/update-builder.go
+++ b/hack/update-builder.go
@@ -272,7 +272,7 @@ func patchBuilder(config *builder.Config) {
 				{
 					ModuleInfo: dist.ModuleInfo{
 						ID: "paketo-community/rust",
-					},sssssssssssssssssssssssssssssssssss
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Renames `knative-sandbox` to `knative-extensions` in a few remaining places.

Supersedes #1899 

/kind chore