### PR TITLE
chore: released binaries refer correct tekton task yamls

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -25,7 +25,7 @@ PIPELINE_ARTIFACTS="pkg/pipelines/resources/tekton/task/func-buildpacks/0.1/func
 
 function build_release() {
   echo "🚧 🐧 Building cross platform binaries: Linux 🐧 (amd64 / arm64 / ppc64le / s390x), MacOS 🍏, and Windows 🎠"
-  ETAG=${TAG} make cross-platform
+  FUNC_REPO_BRANCH_REF="$(git branch --show-current)" ETAG=${TAG} make cross-platform
 
   ARTIFACTS_TO_PUBLISH="func_darwin_amd64 func_darwin_arm64 func_linux_amd64 func_linux_arm64 func_linux_ppc64le func_linux_s390x func_windows_amd64.exe"
   ARTIFACTS_TO_PUBLISH="${ARTIFACTS_TO_PUBLISH} ${PIPELINE_ARTIFACTS}"


### PR DESCRIPTION
# Changes

- :broom: The `./hack/release.sh` script builds binaries that refer to correct tekton tasks. Without this changes binaries refer task from `main` branch, not the release branch.