### PR TITLE
chore: refer correct tekton task yamls in tests

### DIFF
--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -33,6 +33,9 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Core Unit Tests
         run: make test
+        env:
+          FUNC_REPO_REF: ${{ github.event.pull_request.head.repo.full_name }}
+          FUNC_REPO_BRANCH_REF: ${{ github.head_ref }}
       - name: Template Unit Tests
         run: make test-templates
       - uses: codecov/codecov-action@v3

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ $(BIN): $(CODE)
 	env CGO_ENABLED=0 go build -ldflags $(LDFLAGS) ./cmd/$(BIN)
 
 test: $(CODE) ## Run core unit tests
-	go test -race -cover -coverprofile=coverage.txt ./...
+	go test -ldflags $(LDFLAGS) -race -cover -coverprofile=coverage.txt ./...
 
 .PHONY: check
 check: $(BIN_GOLANGCI_LINT) ## Check code quality (lint)

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -25,7 +25,10 @@ export NODE_DISTRO=linux-x64
 
 export KNATIVE_SERVING_VERSION=${KNATIVE_SERVING_VERSION:-latest}
 export KNATIVE_EVENTING_VERSION=${KNATIVE_EVENTING_VERSION:-latest}
-source $(dirname $0)/../vendor/knative.dev/hack/presubmit-tests.sh
+source "$(dirname "$0")/../vendor/knative.dev/hack/presubmit-tests.sh"
+
+FUNC_REPO_BRANCH_REF="${PULL_PULL_SHA}"
+export FUNC_REPO_BRANCH_REF
 
 function post_build_tests() {
   local failed=0
@@ -71,7 +74,7 @@ function unit_tests() {
   make test || failed=1
   if (( failed )); then
     results_banner "Unit tests failed"
-    exit ${failed}
+    exit "${failed}"
   fi
   template_tests
 }
@@ -81,7 +84,7 @@ function template_tests() {
   make test-templates || failed=2
   if (( failed )); then
     results_banner "Built-in template tests failed"
-    exit ${failed}
+    exit "${failed}"
   fi
 }
 


### PR DESCRIPTION
# Changes

- Refer correct tekton task yamls in tests. Without this change tests would refer tekton task yamls from the `main` branch, not from the PR head branch.

-  Fixed some lint issues.
