### PR TITLE
feat: run host-built containers as non-root

### DIFF
--- a/pkg/oci/containerize.go
+++ b/pkg/oci/containerize.go
@@ -392,6 +392,7 @@ func newConfig(cfg *buildConfig, p v1.Platform, layers ...v1.Layer) (desc v1.Des
 			Cmd:          []string{"/func/f"}, // NOTE: Using Cmd because Entrypoint can not be overridden
 			WorkingDir:   "/func/",
 			StopSignal:   "SIGKILL",
+			User:         "1000",
 			Volumes:      volumes,
 			// Labels
 			// History


### PR DESCRIPTION
:gift: Containers built by the Host builder run as a non-root user.

Impetus is PR #1886 which hardens pod security for services deployed by the Knative Deployer, which causes #1913, an error running host-built function containers which were still attempting to run as root.

/kind enhancement

(_partially_ fixes #1913)