### PR TITLE
chore: update buildah image ref

### DIFF
--- a/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
@@ -99,7 +99,7 @@ spec:
         - mountPath: /env-vars
           name: env-vars
     - name: build
-      image: quay.io/buildah/stable:v1.27.0
+      image: quay.io/buildah/stable:v1.31.0
       workingDir: /gen-source
       script: |
         TLS_VERIFY_FLAG=""


### PR DESCRIPTION
The older image has been deleted. We need this to even function.