### PR TITLE
fix: use overlay storage for s2i

### DIFF
--- a/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
@@ -110,12 +110,12 @@ spec:
         [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
         ARTIFACTS_CACHE_PATH="$(workspaces.cache.path)/mvn-artifacts"
         [ -d "${ARTIFACTS_CACHE_PATH}" ] || mkdir "${ARTIFACTS_CACHE_PATH}"
-        buildah ${CERT_DIR_FLAG} bud --storage-driver=vfs ${TLS_VERIFY_FLAG} --layers \
+        buildah ${CERT_DIR_FLAG} bud --storage-driver=overlay ${TLS_VERIFY_FLAG} --layers \
           -v "${ARTIFACTS_CACHE_PATH}:/tmp/artifacts/:rw,z,U" \
           -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
 
         [[ "$(workspaces.dockerconfig.bound)" == "true" ]] && export DOCKER_CONFIG="$(workspaces.dockerconfig.path)"
-        buildah ${CERT_DIR_FLAG} push --storage-driver=vfs ${TLS_VERIFY_FLAG} --digestfile $(workspaces.source.path)/image-digest \
+        buildah ${CERT_DIR_FLAG} push --storage-driver=overlay ${TLS_VERIFY_FLAG} --digestfile $(workspaces.source.path)/image-digest \
           $(params.IMAGE) docker://$(params.IMAGE)
 
         cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST


### PR DESCRIPTION
# Changes


- :gift: Use overlay storage for `buildah` instead of vfs in `s2i` on cluster build. It is much more efficient where vfs takes 5.5G overlay takes just 1.2G.

```release-note
Use overlay storage driver instead of vfs driver in s2i tekton task.
```
