### PR TITLE
Use our own s2i image

### DIFF
--- a/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
@@ -60,7 +60,7 @@ spec:
       description: Digest of the image just built.
   steps:
     - name: generate
-      image: quay.io/openshift-pipeline/s2i:nightly
+      image: quay.io/boson/s2i:latest
       workingDir: $(workspaces.source.path)
       args: ["$(params.ENV_VARS[*])"]
       script: |


### PR DESCRIPTION
# Changes

- :gift: Use our own s2i image. It is much more recent (the previous one is 2 years old) but more importantly the new image is multi-arch.

