### PR TITLE
fix: use current func image in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,10 +102,10 @@ jobs:
       - uses: imjasonh/setup-ko@v0.6
       - name: Install Binaries
         run: ./hack/binaries.sh
-      - name: Setup testing func image
-        run: ./hack/create-testing-func-image.sh
       - name: Allocate Cluster
         run: ./hack/allocate.sh
+      - name: Setup testing func image
+        run: ./hack/create-testing-func-image.sh
       - name: Deploy Tekton
         run: ./hack/tekton.sh
       - name: Deploy Test Git Server

--- a/.github/workflows/test-e2e-oncluster-runtime.yaml
+++ b/.github/workflows/test-e2e-oncluster-runtime.yaml
@@ -18,10 +18,10 @@ jobs:
       - uses: imjasonh/setup-ko@v0.6
       - name: Install Binaries
         run: ./hack/binaries.sh
-      - name: Setup testing func image
-        run: ./hack/create-testing-func-image.sh
       - name: Allocate Cluster
         run: ./hack/allocate.sh
+      - name: Setup testing func image
+        run: ./hack/create-testing-func-image.sh
       - name: Deploy Tekton
         run: ./hack/tekton.sh
       - name: Deploy Test Git Server

--- a/.github/workflows/test-e2e-oncluster.yaml
+++ b/.github/workflows/test-e2e-oncluster.yaml
@@ -18,10 +18,10 @@ jobs:
       - uses: imjasonh/setup-ko@v0.6
       - name: Install Binaries
         run: ./hack/binaries.sh
-      - name: Setup testing func image
-        run: ./hack/create-testing-func-image.sh
       - name: Allocate Cluster
         run: ./hack/allocate.sh
+      - name: Setup testing func image
+        run: ./hack/create-testing-func-image.sh
       - name: Deploy Tekton
         run: ./hack/tekton.sh
       - name: Deploy Test Git Server

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -18,12 +18,12 @@ jobs:
       - uses: imjasonh/setup-ko@v0.6
       - name: Install Binaries
         run: ./hack/binaries.sh
-      - name: Setup testing func image
-        run: ./hack/create-testing-func-image.sh
       - name: Local Registry
         run: ./hack/registry.sh
       - name: Allocate Cluster
         run: ./hack/allocate.sh
+      - name: Setup testing func image
+        run: ./hack/create-testing-func-image.sh
       - name: Patch S2I Task
         run: ./hack/patch-s2i-task.sh
       - name: Install Tekton

--- a/hack/allocate.sh
+++ b/hack/allocate.sh
@@ -76,6 +76,8 @@ containerdConfigPatches:
     endpoint = ["http://func-registry:5000"]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.default.svc.cluster.local:5000"]
     endpoint = ["http://func-registry:5000"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."ghcr.io"]
+    endpoint = ["http://func-registry:5000"]
 EOF
   sleep 10
   kubectl wait pod --for=condition=Ready -l '!job-name' -n kube-system --timeout=5m

--- a/hack/create-testing-func-image.sh
+++ b/hack/create-testing-func-image.sh
@@ -4,12 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KO_DOCKER_REPO="ttl.sh/$(head -c 128 </dev/urandom | LC_CTYPE=C tr -dc 'a-z0-9' | fold -w 8 | head -n 1)"
+KO_DOCKER_REPO="localhost:50000/knative/func"
 export KO_DOCKER_REPO
 
-REF_FILE=$(mktemp)
-
-ko build --image-refs "${REF_FILE}" --tags "30m" -B ./cmd/func
-
-yq -Y -i ".spec.steps[0].image = \"$(cat "${REF_FILE}")\"" \
-  pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+ko build --tags "latest" -B ./cmd/func


### PR DESCRIPTION
# Changes



- :gift: Use a different approach to pass current func image to the tests, this approach does not require modification of task yaml nor access to outer internet (ttl.sh). The important thing is that now we are refering tekton tasks from github --  they are not preinstalled meaning any local patches to task have no effect.

