### PR TITLE
chore: use ./mvnw not mvn in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,12 +155,12 @@ test-python: ## Test Python templates
 	cd templates/python/http && python3 test_func.py && rm -rf __pycache__
 
 test-quarkus: ## Test Quarkus templates
-	cd templates/quarkus/cloudevents && mvn -q test && mvn clean
-	cd templates/quarkus/http && mvn -q test && mvn clean
+	cd templates/quarkus/cloudevents && ./mvnw -q test && ./mvnw clean
+	cd templates/quarkus/http && ./mvnw -q test && ./mvnw clean
 
 test-springboot: ## Test Spring Boot templates
-	cd templates/springboot/cloudevents && mvn -q test && mvn clean
-	cd templates/springboot/http && mvn -q test && mvn clean
+	cd templates/springboot/cloudevents && ./mvnw -q test && ./mvnw clean
+	cd templates/springboot/http && ./mvnw -q test && ./mvnw clean
 
 test-rust: ## Test Rust templates
 	cd templates/rust/cloudevents && cargo -q test && cargo clean


### PR DESCRIPTION

# Changes

* Use ./mvnw not mvn in tests.