### PR TITLE
Adding support for `func subscribe` for creating mutiple triggers, based on event filters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # Default Targets
 all: build docs
+	@echo '🎉 Build process completed!'
 
 # Help Text
 # Headings: lines with `##$` comment prefix

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,6 +76,7 @@ Learn more about Knative at: https://knative.dev`, cfg.Name),
 				NewDeployCmd(newClient),
 				NewDeleteCmd(newClient),
 				NewListCmd(newClient),
+				NewSubscribeCmd(),
 			},
 		},
 		{

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -33,9 +33,6 @@ func runSubscribe(cmd *cobra.Command, args []string) (err error) {
 	)
 	cfg = newSubscribeConfig()
 
-	if err = config.CreatePaths(); err != nil { // for possible auth.json usage
-		return
-	}
 	if f, err = fn.NewFunction(""); err != nil {
 		return
 	}

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -39,9 +39,6 @@ func runSubscribe(cmd *cobra.Command, args []string) (err error) {
 	if !f.Initialized() {
 		return fn.NewErrNotInitialized(f.Root)
 	}
-	if f, err = fn.NewFunction(""); err != nil {
-		return
-	}
 	if !f.Initialized() {
 		return fn.NewErrNotInitialized(f.Root)
 	}

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -44,9 +44,6 @@ func runSubscribe(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// add it
-	if f.Subscription == nil {
-		f.Subscription = []fn.SubscriptionSpec{}
-	}
 	f.Subscription = append(f.Subscription, fn.SubscriptionSpec{
 		Source: cfg.Source,
 		Filters: map[string]string{

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -52,7 +52,7 @@ func runSubscribe(cmd *cobra.Command, args []string) (err error) {
 	})
 
 	// pump it
-	f.Write()
+	return f.Write()
 
 }
 

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -11,10 +11,23 @@ import (
 
 func NewSubscribeCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:        "subscribe",
-		Short:      "Subscribe to a function",
-		Long:       `Subscribe to a function`,
-		SuggestFor: []string{"subscribe", "subscribe"},
+		Use:   "subscribe",
+		Short: "Subscribe a function to events",
+		Long: `Subscribe a function to events
+
+Subscribe the function to a set of events, matching a set of filters for Cloud Event metadata
+and a Knative Broker from where the events are consumed.
+`,
+		Example: `
+# Subscribe the function to the 'default' broker where  events have 'type' of 'com.example'
+and an 'extension' attribute for the value 'my-extension-value'.
+{{rootCmdUse}} subscribe --filter type=com.example --filter extension=my-extension-value
+
+# Subscribe the function to the 'my-broker' broker where  events have 'type' of 'com.example'
+and an 'extension' attribute for the value 'my-extension-value'.
+{{rootCmdUse}} subscribe --filter type=com.example --filter extension=my-extension-value --source my-broker
+`,
+		SuggestFor: []string{"subcsribe", "subsrcibe"},
 		PreRunE:    bindEnv("filter", "source"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSubscribe(cmd, args)

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -27,7 +27,7 @@ and an 'extension' attribute for the value 'my-extension-value'.
 and an 'extension' attribute for the value 'my-extension-value'.
 {{rootCmdUse}} subscribe --filter type=com.example --filter extension=my-extension-value --source my-broker
 `,
-		SuggestFor: []string{"subcsribe", "subsrcibe"},
+		SuggestFor: []string{"subcsribe"}, //nolint:misspell
 		PreRunE:    bindEnv("filter", "source"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSubscribe(cmd, args)

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
 	fn "knative.dev/func/pkg/functions"
@@ -18,19 +21,19 @@ func NewSubscribeCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("filter", "f", "", "The event metadata to filter for")
+	cmd.Flags().StringArrayP("filter", "f", []string{}, "Filter for the Cloud Event metadata")
+
 	cmd.Flags().StringP("source", "s", "default", "The source, like a Knative Broker")
 
 	return cmd
 }
 
-// /
 func runSubscribe(cmd *cobra.Command, args []string) (err error) {
 	var (
 		cfg subscibeConfig
 		f   fn.Function
 	)
-	cfg = newSubscribeConfig()
+	cfg = newSubscribeConfig(cmd)
 
 	if f, err = fn.NewFunction(""); err != nil {
 		return
@@ -42,12 +45,10 @@ func runSubscribe(cmd *cobra.Command, args []string) (err error) {
 		return fn.NewErrNotInitialized(f.Root)
 	}
 
-	// add it
+	// add subscription	to function
 	f.Subscription = append(f.Subscription, fn.SubscriptionSpec{
-		Source: cfg.Source,
-		Filters: map[string]string{
-			"type": cfg.Filter,
-		},
+		Source:  cfg.Source,
+		Filters: extractFilterMap(cfg),
 	})
 
 	// pump it
@@ -55,16 +56,38 @@ func runSubscribe(cmd *cobra.Command, args []string) (err error) {
 
 }
 
+func extractFilterMap(cfg subscibeConfig) map[string]string {
+	subscriptionFilters := make(map[string]string)
+	for _, filter := range cfg.Filter {
+		kv := strings.Split(filter, "=")
+		if len(kv) != 2 {
+			fmt.Println("Invalid pair:", filter)
+			continue
+		}
+		key := kv[0]
+		value := kv[1]
+		subscriptionFilters[key] = value
+	}
+	return subscriptionFilters
+}
+
 type subscibeConfig struct {
-	Filter string
+	Filter []string
 	Source string
 }
 
-func newSubscribeConfig() subscibeConfig {
-	c := subscibeConfig{
-		Filter: viper.GetString("filter"),
+func newSubscribeConfig(cmd *cobra.Command) (c subscibeConfig) {
+	c = subscibeConfig{
+		Filter: viper.GetStringSlice("filter"),
 		Source: viper.GetString("source"),
 	}
+	// NOTE: .Filter should be viper.GetStringSlice, but this returns unparsed
+	// results and appears to be an open issue since 2017:
+	// https://github.com/spf13/viper/issues/380
+	var err error
+	if c.Filter, err = cmd.Flags().GetStringArray("filter"); err != nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "error reading filter arguments: %v", err)
+	}
 
-	return c
+	return
 }

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
-	"knative.dev/func/pkg/config"
 	fn "knative.dev/func/pkg/functions"
 )
 

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -54,7 +54,6 @@ func runSubscribe(cmd *cobra.Command, args []string) (err error) {
 	// pump it
 	f.Write()
 
-	return f.Stamp()
 }
 
 type subscibeConfig struct {

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -14,8 +14,8 @@ func NewSubscribeCmd() *cobra.Command {
 		Long:       `Subscribe to a function`,
 		SuggestFor: []string{"subscribe", "subscribe"},
 		PreRunE:    bindEnv("filter", "source"),
-		Run: func(cmd *cobra.Command, args []string) {
-			runSubscribe(cmd, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSubscribe(cmd, args)
 		},
 	}
 

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"github.com/ory/viper"
+	"github.com/spf13/cobra"
+	"knative.dev/func/pkg/config"
+	fn "knative.dev/func/pkg/functions"
+)
+
+func NewSubscribeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:        "subscribe",
+		Short:      "Subscribe to a function",
+		Long:       `Subscribe to a function`,
+		SuggestFor: []string{"subscribe", "subscribe"},
+		PreRunE:    bindEnv("filter", "source"),
+		Run: func(cmd *cobra.Command, args []string) {
+			runSubscribe(cmd, args)
+		},
+	}
+
+	cmd.Flags().StringP("filter", "f", "", "The event metadata to filter for")
+	cmd.Flags().StringP("source", "s", "default", "The source, like a Knative Broker")
+
+	return cmd
+}
+
+// /
+func runSubscribe(cmd *cobra.Command, args []string) (err error) {
+	var (
+		cfg subscibeConfig
+		f   fn.Function
+	)
+	cfg = newSubscribeConfig()
+
+	if err = config.CreatePaths(); err != nil { // for possible auth.json usage
+		return
+	}
+	if f, err = fn.NewFunction(""); err != nil {
+		return
+	}
+	if !f.Initialized() {
+		return fn.NewErrNotInitialized(f.Root)
+	}
+	if f, err = fn.NewFunction(""); err != nil {
+		return
+	}
+	if !f.Initialized() {
+		return fn.NewErrNotInitialized(f.Root)
+	}
+
+	// add it
+	if f.Subscription == nil {
+		f.Subscription = []fn.SubscriptionSpec{}
+	}
+	f.Subscription = append(f.Subscription, fn.SubscriptionSpec{
+		Source: cfg.Source,
+		Filters: map[string]string{
+			"type": cfg.Filter,
+		},
+	})
+
+	// pump it
+	f.Write()
+
+	return f.Stamp()
+}
+
+type subscibeConfig struct {
+	Filter string
+	Source string
+}
+
+func newSubscribeConfig() subscibeConfig {
+	c := subscibeConfig{
+		Filter: viper.GetString("filter"),
+		Source: viper.GetString("source"),
+	}
+
+	return c
+}

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -46,7 +46,7 @@ func runSubscribe(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// add subscription	to function
-	f.Subscription = append(f.Subscription, fn.SubscriptionSpec{
+	f.Deploy.Subscriptions = append(f.Deploy.Subscriptions, fn.KnativeSubscription{
 		Source:  cfg.Source,
 		Filters: extractFilterMap(cfg),
 	})

--- a/cmd/subscribe_test.go
+++ b/cmd/subscribe_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"testing"
+
+	fn "knative.dev/func/pkg/functions"
+)
+
+func TestSubscribeWithAll(t *testing.T) {
+	root := fromTempDirectory(t)
+
+	_, err := fn.New().Init(fn.Function{Runtime: "go", Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewSubscribeCmd()
+	cmd.SetArgs([]string{"--source", "my-broker", "--filter", "foo=go"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now load the function and ensure that the subscription is set correctly.
+	f, err := fn.NewFunction(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if f.Deploy.Subscriptions == nil {
+		t.Fatal("Expected subscription to be present ")
+	}
+	if f.Deploy.Subscriptions[0].Source != "my-broker" {
+		t.Fatalf("Expected subscription for broker to be 'my-broker', but got '%v'", f.Deploy.Subscriptions[0].Source)
+	}
+
+	if f.Deploy.Subscriptions[0].Filters["foo"] != "go" {
+		t.Fatalf("Expected subscription filter for 'foo' to be 'go', but got '%v'", f.Deploy.Subscriptions[0].Filters["foo"])
+	}
+}
+
+func TestSubscribeWithNoExplicitSourceAll(t *testing.T) {
+	root := fromTempDirectory(t)
+
+	_, err := fn.New().Init(fn.Function{Runtime: "go", Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewSubscribeCmd()
+	cmd.SetArgs([]string{"--filter", "foo=go"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now load the function and ensure that the subscription is set correctly.
+	f, err := fn.NewFunction(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if f.Deploy.Subscriptions == nil {
+		t.Fatal("Expected subscription to be present ")
+	}
+	if f.Deploy.Subscriptions[0].Source != "default" {
+		t.Fatalf("Expected subscription for broker to be 'default', but got '%v'", f.Deploy.Subscriptions[0].Source)
+	}
+
+	if f.Deploy.Subscriptions[0].Filters["foo"] != "go" {
+		t.Fatalf("Expected subscription filter for 'foo' to be 'go', but got '%v'", f.Deploy.Subscriptions[0].Filters["foo"])
+	}
+}

--- a/docs/reference/func.md
+++ b/docs/reference/func.md
@@ -36,6 +36,7 @@ Learn more about Knative at: https://knative.dev
 * [func list](func_list.md)	 - List deployed functions
 * [func repository](func_repository.md)	 - Manage installed template repositories
 * [func run](func_run.md)	 - Run the function locally
+* [func subscribe](func_subscribe.md)	 - Subscribe to a function
 * [func templates](func_templates.md)	 - List available function source templates
 * [func version](func_version.md)	 - Function client version information
 

--- a/docs/reference/func.md
+++ b/docs/reference/func.md
@@ -36,7 +36,7 @@ Learn more about Knative at: https://knative.dev
 * [func list](func_list.md)	 - List deployed functions
 * [func repository](func_repository.md)	 - Manage installed template repositories
 * [func run](func_run.md)	 - Run the function locally
-* [func subscribe](func_subscribe.md)	 - Subscribe to a function
+* [func subscribe](func_subscribe.md)	 - Subscribe a function to events
 * [func templates](func_templates.md)	 - List available function source templates
 * [func version](func_version.md)	 - Function client version information
 

--- a/docs/reference/func_subscribe.md
+++ b/docs/reference/func_subscribe.md
@@ -1,13 +1,31 @@
 ## func subscribe
 
-Subscribe to a function
+Subscribe a function to events
 
 ### Synopsis
 
-Subscribe to a function
+Subscribe a function to events
+
+Subscribe the function to a set of events, matching a set of filters for Cloud Event metadata
+and a Knative Broker from where the events are consumed.
+
 
 ```
 func subscribe
+```
+
+### Examples
+
+```
+
+# Subscribe the function to the 'default' broker where  events have 'type' of 'com.example'
+and an 'extension' attribute for the value 'my-extension-value'.
+func subscribe --filter type=com.example --filter extension=my-extension-value
+
+# Subscribe the function to the 'my-broker' broker where  events have 'type' of 'com.example'
+and an 'extension' attribute for the value 'my-extension-value'.
+func subscribe --filter type=com.example --filter extension=my-extension-value --source my-broker
+
 ```
 
 ### Options

--- a/docs/reference/func_subscribe.md
+++ b/docs/reference/func_subscribe.md
@@ -13,9 +13,9 @@ func subscribe
 ### Options
 
 ```
-  -f, --filter string   The event metadata to filter for
-  -h, --help            help for subscribe
-  -s, --source string   The source, like a Knative Broker (default "default")
+  -f, --filter stringArray   Filter for the Cloud Event metadata
+  -h, --help                 help for subscribe
+  -s, --source string        The source, like a Knative Broker (default "default")
 ```
 
 ### SEE ALSO

--- a/docs/reference/func_subscribe.md
+++ b/docs/reference/func_subscribe.md
@@ -1,0 +1,24 @@
+## func subscribe
+
+Subscribe to a function
+
+### Synopsis
+
+Subscribe to a function
+
+```
+func subscribe
+```
+
+### Options
+
+```
+  -f, --filter string   The event metadata to filter for
+  -h, --help            help for subscribe
+  -s, --source string   The source, like a Knative Broker (default "default")
+```
+
+### SEE ALSO
+
+* [func](func.md)	 - func manages Knative Functions
+

--- a/pkg/functions/client_int_test.go
+++ b/pkg/functions/client_int_test.go
@@ -163,6 +163,31 @@ func TestDeployWithOptions(t *testing.T) {
 	defer del(t, client, "test-deploy-with-options")
 }
 
+func TestDeployWithTriggers(t *testing.T) {
+	root, cleanup := Mktemp(t)
+	defer cleanup()
+	verbose := true
+
+	f := fn.Function{Runtime: "go", Name: "test-deploy-with-triggers", Root: root}
+	f.Deploy = fn.DeploySpec{
+		Subscriptions: []fn.KnativeSubscription{
+			{
+				Source: "default",
+				Filters: map[string]string{
+					"key": "value",
+					"foo": "bar",
+				},
+			},
+		},
+	}
+
+	client := newClient(verbose)
+	if _, _, err := client.New(context.Background(), f); err != nil {
+		t.Fatal(err)
+	}
+	defer del(t, client, "test-deploy-with-triggers")
+}
+
 func TestUpdateWithAnnotationsAndLabels(t *testing.T) {
 	functionName := "updateannlab"
 	defer Within(t, "testdata/example.com/"+functionName)()

--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -82,8 +82,6 @@ type Function struct {
 	// Build defines the build properties for a function
 	Build BuildSpec `yaml:"build,omitempty"`
 
-	Subscription []SubscriptionSpec `yaml:"subscriptions,omitempty"`
-
 	// Run defines the runtime properties for a function
 	Run RunSpec `yaml:"run,omitempty"`
 
@@ -91,8 +89,8 @@ type Function struct {
 	Deploy DeploySpec `yaml:"deploy,omitempty"`
 }
 
-// SubscriptionSpec
-type SubscriptionSpec struct {
+// KnativeSubscription
+type KnativeSubscription struct {
 	Source  string            `yaml:"source"`
 	Filters map[string]string `yaml:"filters,omitempty"`
 }
@@ -167,6 +165,8 @@ type DeploySpec struct {
 	// succeed.
 	// More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 	ServiceAccountName string `yaml:"serviceAccountName,omitempty"`
+
+	Subscriptions []KnativeSubscription `yaml:"subscriptions,omitempty"`
 }
 
 // HealthEndpoints specify the liveness and readiness endpoints for a Runtime

--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -82,11 +82,19 @@ type Function struct {
 	// Build defines the build properties for a function
 	Build BuildSpec `yaml:"build,omitempty"`
 
+	Subscription []SubscriptionSpec `yaml:"subscriptions,omitempty"`
+
 	// Run defines the runtime properties for a function
 	Run RunSpec `yaml:"run,omitempty"`
 
 	// Deploy defines the deployment properties for a function
 	Deploy DeploySpec `yaml:"deploy,omitempty"`
+}
+
+// SubscriptionSpec
+type SubscriptionSpec struct {
+	Source  string            `yaml:"source"`
+	Filters map[string]string `yaml:"filters,omitempty"`
 }
 
 // BuildSpec

--- a/pkg/knative/deployer.go
+++ b/pkg/knative/deployer.go
@@ -314,6 +314,9 @@ func createTriggers(ctx context.Context, f fn.Function, err error, client client
 		err = fmt.Errorf("knative deployer failed to get the Service for Trigger: %v", err)
 		return err
 	}
+
+	fmt.Fprintf(os.Stderr, "🎯 Creating Triggers on the cluster\n")
+
 	for i, sub := range f.Subscription {
 		// create the filter:
 		attributes := make(map[string]string)

--- a/pkg/knative/deployer.go
+++ b/pkg/knative/deployer.go
@@ -317,7 +317,7 @@ func createTriggers(ctx context.Context, f fn.Function, err error, client client
 
 	fmt.Fprintf(os.Stderr, "🎯 Creating Triggers on the cluster\n")
 
-	for i, sub := range f.Subscription {
+	for i, sub := range f.Deploy.Subscriptions {
 		// create the filter:
 		attributes := make(map[string]string)
 		for key, value := range sub.Filters {

--- a/pkg/knative/deployer.go
+++ b/pkg/knative/deployer.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 	"io"
-	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"os"
 	"regexp"
 	"strings"
 	"time"
+
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/knative/deployer.go
+++ b/pkg/knative/deployer.go
@@ -231,7 +231,7 @@ func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (fn.DeploymentResu
 				return fn.DeploymentResult{}, err
 			}
 
-			err = createTriggers(ctx, f, err, client, eventingClient)
+			err = createTriggers(ctx, f, client, eventingClient)
 			if err != nil {
 				return fn.DeploymentResult{}, err
 			}
@@ -295,7 +295,7 @@ func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (fn.DeploymentResu
 			return fn.DeploymentResult{}, err
 		}
 
-		err = createTriggers(ctx, f, err, client, eventingClient)
+		err = createTriggers(ctx, f, client, eventingClient)
 		if err != nil {
 			return fn.DeploymentResult{}, err
 		}
@@ -308,7 +308,7 @@ func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (fn.DeploymentResu
 	}
 }
 
-func createTriggers(ctx context.Context, f fn.Function, err error, client clientservingv1.KnServingClient, eventingClient clienteventingv1.KnEventingClient) error {
+func createTriggers(ctx context.Context, f fn.Function, client clientservingv1.KnServingClient, eventingClient clienteventingv1.KnEventingClient) error {
 	ksvc, err := client.GetService(ctx, f.Name)
 	if err != nil {
 		err = fmt.Errorf("knative deployer failed to get the Service for Trigger: %v", err)

--- a/schema/func_yaml-schema.json
+++ b/schema/func_yaml-schema.json
@@ -90,6 +90,13 @@
 				"serviceAccountName": {
 					"type": "string",
 					"description": "ServiceAccountName is the name of the service account used for the\nfunction pod. The service account must exist in the namespace to\nsucceed.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/"
+				},
+				"subscriptions": {
+					"items": {
+						"$schema": "http://json-schema.org/draft-04/schema#",
+						"$ref": "#/definitions/KnativeSubscription"
+					},
+					"type": "array"
 				}
 			},
 			"additionalProperties": false,
@@ -218,6 +225,27 @@
 			"additionalProperties": false,
 			"type": "object",
 			"description": "HealthEndpoints specify the liveness and readiness endpoints for a Runtime"
+		},
+		"KnativeSubscription": {
+			"required": [
+				"source"
+			],
+			"properties": {
+				"source": {
+					"type": "string"
+				},
+				"filters": {
+					"patternProperties": {
+						".*": {
+							"type": "string"
+						}
+					},
+					"type": "object"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"description": "KnativeSubscription"
 		},
 		"Label": {
 			"required": [


### PR DESCRIPTION
Little demo: https://youtu.be/O6M7mfR6JfM 

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- - :gift: Add new `subscribe` command to create Knative Triggers for event routing

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
kn func subscribe will allow you to create Knative Eventing Triggers for improved event processing for kn func
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
