### PR TITLE
test: increase timeout to wait func to get ready on no-container test

### DIFF
--- a/test/e2e/scenario_no_container_test.go
+++ b/test/e2e/scenario_no_container_test.go
@@ -41,7 +41,7 @@ func TestFunctionRunWithoutContainer(t *testing.T) {
 		knFuncTerm1.OnWaitCallback = func(stdout *bytes.Buffer) {
 			t.Log("-----Executing OnWaitCallback")
 			funcPort, attempts := "", 0
-			for funcPort == "" && attempts < 10 { // 5 secs
+			for funcPort == "" && attempts < 30 { // 15 secs
 				t.Logf("----Function Output:\n%v", stdout.String())
 				matches := regexp.MustCompile("Running on host port (.*)").FindStringSubmatch(stdout.String())
 				attempts++


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :broom: chanded timeout from 5sec to 15secs on wait func to get ready on no-container test

