### PR TITLE
fix s2i on cluster RT tests

### DIFF
--- a/pkg/builders/s2i/builder.go
+++ b/pkg/builders/s2i/builder.go
@@ -36,7 +36,7 @@ import (
 // DefaultName when no WithName option is provided to NewBuilder
 const DefaultName = builders.S2I
 
-var DefaultNodeBuilder = "registry.access.redhat.com/ubi8/nodejs-16"
+var DefaultNodeBuilder = "registry.access.redhat.com/ubi8/nodejs-16-minimal"
 var DefaultQuarkusBuilder = "registry.access.redhat.com/ubi8/openjdk-17"
 var DefaultPythonBuilder = "registry.access.redhat.com/ubi8/python-39"
 

--- a/test/oncluster/scenario_runtime_test.go
+++ b/test/oncluster/scenario_runtime_test.go
@@ -42,6 +42,9 @@ func TestRuntime(t *testing.T) {
 	}
 
 	for _, lang := range runtimeList {
+		if lang == "python" && os.Getenv("GITHUB_ACTIONS") == "true" {
+			t.Skip("skipping python test in GH action because of space requirement")
+		}
 		for _, builder := range runtimeSupportMap[lang] {
 			if targetBuilder == "" || builder == targetBuilder {
 				t.Run(fmt.Sprintf("%v_%v_test", lang, builder), func(t *testing.T) {

--- a/test/oncluster/scenario_runtime_test.go
+++ b/test/oncluster/scenario_runtime_test.go
@@ -42,12 +42,12 @@ func TestRuntime(t *testing.T) {
 	}
 
 	for _, lang := range runtimeList {
-		if lang == "python" && os.Getenv("GITHUB_ACTIONS") == "true" {
-			t.Skip("skipping python test in GH action because of space requirement")
-		}
 		for _, builder := range runtimeSupportMap[lang] {
 			if targetBuilder == "" || builder == targetBuilder {
 				t.Run(fmt.Sprintf("%v_%v_test", lang, builder), func(t *testing.T) {
+					if lang == "python" && os.Getenv("GITHUB_ACTIONS") == "true" {
+						t.Skip("skipping python test in GH action because of space requirement")
+					}
 					runtimeImpl(t, lang, builder)
 				})
 			}


### PR DESCRIPTION
Fix s2i on cluster RT tests.
* Use smaller s2i builder image for nodejs
* Skip python s2i on cluster build when running in GH action

```release-note
chore: using nodejs-16-minimal instead of nodejs-16 as default builder for JS/TS
```