### PR TITLE
Add limit to number of manifests

### DIFF
--- a/pkg/docker/platform.go
+++ b/pkg/docker/platform.go
@@ -60,6 +60,10 @@ func GetPlatformImage(ref, platform string) (string, error) {
 		return "", fmt.Errorf("cannot get index manifest: %w", err)
 	}
 
+	if len(idxMft.Manifests) > 1000 {
+		return "", fmt.Errorf("platform image has too many manifests")
+	}
+
 	for _, manifest := range idxMft.Manifests {
 		if plat.OS == manifest.Platform.OS &&
 			plat.Architecture == manifest.Platform.Architecture {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes
A malicious image can include a high number of manifests and which makes the loop time controllable by an attacker. This can result in a DoS of func through an endless-data attack vector.

This PR sets a limit that is far more than a legitimate image would require, but that would still be fast to loop though.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
