### PR TITLE
Adding local field to function for handling transient spec (Local.Remote)

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -175,7 +175,7 @@ EXAMPLES
 		"Git revision (branch) to be used when deploying via the Git repository ($FUNC_GIT_BRANCH)")
 	cmd.Flags().StringP("git-dir", "d", f.Build.Git.ContextDir,
 		"Directory in the Git repository containing the function (default is the root) ($FUNC_GIT_DIR)")
-	cmd.Flags().BoolP("remote", "R", f.Deploy.Remote,
+	cmd.Flags().BoolP("remote", "R", f.Local.Remote,
 		"Trigger a remote deployment. Default is to deploy and build from the local system ($FUNC_REMOTE)")
 	cmd.Flags().String("pvc-size", f.Build.PVCSize,
 		"When triggering a remote deployment, set a custom volume size to allocate for the build operation ($FUNC_PVC_SIZE)")
@@ -506,8 +506,8 @@ func (c deployConfig) Configure(f fn.Function) (fn.Function, error) {
 	f.Build.Git.ContextDir = c.GitDir
 	f.Build.Git.Revision = c.GitBranch // TODO: should match; perhaps "refSpec"
 	f.Deploy.Namespace = c.Namespace
-	f.Deploy.Remote = c.Remote
 	f.Deploy.ServiceAccountName = c.ServiceAccountName
+	f.Local.Remote = c.Remote
 
 	// PVCSize
 	// If a specific value is requested, ensure it parses as a resource.Quantity

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -1433,7 +1433,7 @@ func TestDeploy_RemotePersists(t *testing.T) {
 	if f, err = fn.NewFunction(root); err != nil {
 		t.Fatal(err)
 	}
-	if !f.Deploy.Remote {
+	if !f.Local.Remote {
 		t.Fatalf("value of remote flag not persisted")
 	}
 
@@ -1449,7 +1449,7 @@ func TestDeploy_RemotePersists(t *testing.T) {
 	if f, err = fn.NewFunction(root); err != nil {
 		t.Fatal(err)
 	}
-	if !f.Deploy.Remote {
+	if !f.Local.Remote {
 		t.Fatalf("value of remote flag not persisted")
 	}
 
@@ -1464,7 +1464,7 @@ func TestDeploy_RemotePersists(t *testing.T) {
 	if f, err = fn.NewFunction(root); err != nil {
 		t.Fatal(err)
 	}
-	if f.Deploy.Remote {
+	if f.Local.Remote {
 		t.Fatalf("value of remote flag not persisted")
 	}
 }

--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -22,8 +22,17 @@ const (
 
 	// RunDataDir holds transient runtime metadata
 	// By default it is excluded from source control.
-	RunDataDir = ".func"
+	RunDataDir       = ".func"
+	RunDataLocalFile = "local.yaml"
 )
+
+// Local represents the transient runtime metadata which
+// is only relevant to the local copy of the function
+type Local struct {
+	// Remote indicates the deployment (and possibly build) process are to
+	// be triggered in a remote environment rather than run locally.
+	Remote bool `yaml:"remote,omitempty"`
+}
 
 // Function
 type Function struct {
@@ -87,6 +96,8 @@ type Function struct {
 
 	// Deploy defines the deployment properties for a function
 	Deploy DeploySpec `yaml:"deploy,omitempty"`
+
+	Local Local `yaml:"-"`
 }
 
 // BuildSpec
@@ -136,10 +147,6 @@ type RunSpec struct {
 type DeploySpec struct {
 	// Namespace into which the function is deployed on supported platforms.
 	Namespace string `yaml:"namespace,omitempty"`
-
-	// Remote indicates the deployment (and possibly build) process are to
-	// be triggered in a remote environment rather than run locally.
-	Remote bool `yaml:"remote,omitempty"`
 
 	// Map containing user-supplied annotations
 	// Example: { "division": "finance" }
@@ -257,6 +264,7 @@ func NewFunction(root string) (f Function, err error) {
 		errorText += "\n" + "Migration: " + functionMigrationError.Error()
 		return Function{}, errors.New(errorText)
 	}
+	f.Local, err = f.newLocal()
 	return
 }
 
@@ -385,7 +393,23 @@ func (f Function) Write() (err error) {
 	}
 	// TODO: open existing file for writing, such that existing permissions
 	// are preserved?
-	return os.WriteFile(filepath.Join(f.Root, FunctionFile), bb, 0644)
+	err = os.WriteFile(filepath.Join(f.Root, FunctionFile), bb, 0644)
+	if err != nil {
+		return
+	}
+
+	// Write local settings
+	err = ensureRunDataDir(f.Root)
+	if err != nil {
+		return
+	}
+	if bb, err = yaml.Marshal(&f.Local); err != nil {
+		return
+	}
+	localConfigPath := filepath.Join(f.Root, RunDataDir, RunDataLocalFile)
+
+	err = os.WriteFile(localConfigPath, bb, 0644)
+	return
 }
 
 type stampOptions struct{ journal bool }
@@ -665,4 +689,24 @@ func (f Function) BuildStamp() string {
 		return ""
 	}
 	return string(b)
+}
+
+// localSettings returns the local settings set for the function
+func (f Function) newLocal() (localConfig Local, err error) {
+	err = ensureRunDataDir(f.Root)
+	if err != nil {
+		return
+	}
+	localSettingsPath := filepath.Join(f.Root, RunDataDir, RunDataLocalFile)
+	if _, err = os.Stat(localSettingsPath); os.IsNotExist(err) {
+		err = nil
+		return
+	}
+	b, err := os.ReadFile(localSettingsPath)
+	if err != nil {
+		return
+	}
+
+	err = yaml.Unmarshal(b, &localConfig)
+	return
 }

--- a/pkg/pipelines/tekton/gitlab_test.go
+++ b/pkg/pipelines/tekton/gitlab_test.go
@@ -85,9 +85,9 @@ func TestGitlab(t *testing.T) {
 			PVCSize:       "256Mi",
 		},
 		Deploy: fn.DeploySpec{
-			Remote:    true,
 			Namespace: ns,
 		},
+		Local: fn.Local{Remote: true},
 	}
 	f = fn.NewFunctionWith(f)
 	err = f.Write()

--- a/schema/func_yaml-schema.json
+++ b/schema/func_yaml-schema.json
@@ -56,10 +56,6 @@
 					"type": "string",
 					"description": "Namespace into which the function is deployed on supported platforms."
 				},
-				"remote": {
-					"type": "boolean",
-					"description": "Remote indicates the deployment (and possibly build) process are to\nbe triggered in a remote environment rather than run locally."
-				},
 				"annotations": {
 					"patternProperties": {
 						".*": {


### PR DESCRIPTION
Added a `Local` field to represent the local spec (such as `Remote`)

<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🎁 Added a new field `Local.Remote` to the `function` spec
- 🎁 Modified `func.write` to write it only to `.func/local.yaml` so it is not persisted across clones but only locally
- 🎁 Added unit tests to ensure the expected behaviour

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
