### PR TITLE
fix: use correct Go version in GH action

### DIFF
--- a/.github/workflows/update-quarkus-platform.yaml
+++ b/.github/workflows/update-quarkus-platform.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: ./.github/composite/go-setup
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/update-springboot-platform.yaml
+++ b/.github/workflows/update-springboot-platform.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: ./.github/composite/go-setup
       - uses: actions/setup-node@v3
         with:
           node-version: 18


### PR DESCRIPTION
Use correct Go version in GH action.

Incorrect Go version was causing failure of auto-updater for Quarkus and Spring templates.