### PR TITLE
feat: s2i builder go support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@
 /target
 /hack/bin
 
+/e2e/testdata/default_home/go
+/e2e/testdata/default_home/.cache
+
+/pkg/functions/testdata/migrations/*/.gitignore
+
 # Nodejs
 node_modules
 

--- a/pkg/builders/s2i/assemblers.go
+++ b/pkg/builders/s2i/assemblers.go
@@ -1,0 +1,66 @@
+package s2i
+
+import (
+	"fmt"
+
+	fn "knative.dev/func/pkg/functions"
+)
+
+// GoAssembler
+//
+// Adapted from /usr/libexec/s2i/assemble within the UBI-8 go-toolchain
+// such that the "go build" command builds subdirectory .s2i/builds/last
+// (where main resides) rather than the root.
+// TODO: many apps use the pattern of having main in a subdirectory, for
+// example the idiomatic "./cmd/myapp/main.go".  It would therefore be
+// beneficial to submit a patch to the go-toolchain source allowing this
+// path to be customized with an environment variable instead
+const GoAssembler = `
+#!/bin/bash
+set -e
+pushd /tmp/src
+if [[ $(go list -f {{.Incomplete}}) == "true" ]]; then
+    INSTALL_URL=${INSTALL_URL:-$IMPORT_URL}
+    if [[ ! -z "$IMPORT_URL" ]]; then
+        popd
+        echo "Assembling GOPATH"
+        export GOPATH=$(realpath $HOME/go)
+        mkdir -p $GOPATH/src/$IMPORT_URL
+        mv /tmp/src/* $GOPATH/src/$IMPORT_URL
+        if [[ -d /tmp/artifacts/pkg ]]; then
+            echo "Restoring previous build artifacts"
+            mv /tmp/artifacts/pkg $GOPATH
+        fi
+        # Resolve dependencies, ignore if vendor present
+        if [[ ! -d $GOPATH/src/$INSTALL_URL/vendor ]]; then
+            echo "Resolving dependencies"
+            pushd $GOPATH/src/$INSTALL_URL
+            go get
+            popd
+        fi
+        # lets build
+        pushd $GOPATH/src/$INSTALL_URL
+        echo "Building"
+        go install -i $INSTALL_URL
+        mv $GOPATH/bin/* /opt/app-root/gobinary
+        popd
+        exit
+    fi
+    exec /$STI_SCRIPTS_PATH/usage
+else
+    pushd .s2i/builds/last
+    go get f
+    go build -o /opt/app-root/gobinary
+    popd
+    popd
+fi
+`
+
+func assembler(f fn.Function) (string, error) {
+	switch f.Runtime {
+	case "go":
+		return GoAssembler, nil
+	default:
+		return "", fmt.Errorf("no assembler defined for runtime %q", f.Runtime)
+	}
+}

--- a/pkg/oci/pusher_test.go
+++ b/pkg/oci/pusher_test.go
@@ -61,7 +61,7 @@ func TestPusher_Push(t *testing.T) {
 
 	// Create and push a function
 	client := fn.New(
-		fn.WithBuilder(NewBuilder("", verbose)),
+		fn.WithBuilder(NewBuilder("", false)),
 		fn.WithPusher(NewPusher(insecure, anon, verbose)))
 
 	f := fn.Function{Root: root, Runtime: "go", Name: "f", Registry: l.Addr().String() + "/funcs"}
@@ -85,7 +85,7 @@ func TestPusher_Push(t *testing.T) {
 	}
 }
 
-// TestPusher_Auth ensures that the pusher authenticates via basic auth when
+// TestPusher_BasicAuth ensures that the pusher authenticates via basic auth when
 // supplied with a username/password via the context.
 func TestPusher_BasicAuth(t *testing.T) {
 	var (
@@ -106,7 +106,7 @@ func TestPusher_BasicAuth(t *testing.T) {
 			// no header.  ask for auth
 			w.Header().Add("www-authenticate", "Basic realm=\"Registry Realm\"")
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-		} else if u != "username" || p != "password" {
+		} else if u != username || p != password {
 			// header exists, but creds are either missing or incorrect
 			t.Fatalf("Unauthorized.  Expected user %q pass %q, got user %q pass %q", username, password, u, p)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)

--- a/pkg/pipelines/tekton/validate_test.go
+++ b/pkg/pipelines/tekton/validate_test.go
@@ -82,7 +82,7 @@ func Test_validatePipeline(t *testing.T) {
 		{
 			name:     "Unsupported runtime - Go - s2i builder",
 			function: fn.Function{Build: fn.BuildSpec{Builder: builders.S2I}, Runtime: "go"},
-			wantErr:  true,
+			wantErr:  false,
 		},
 		{
 			name:     "Supported runtime - Quarkus - pack builder - without additional Buildpacks",


### PR DESCRIPTION
# Changes

- :gift: S2I builder now supports Go functions
- :gift: S2I Go functions now include Instance-based method signatures and lifecycle events

/kind enhancement

**Release Note**

```release-note
The S2I builder now supports Go functions.
Go functions built with the S2I builder now support the new instance-based method signatures and lifecycle methods.
```