### PR TITLE
Introduce a --registry-insecure flag

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -343,7 +343,7 @@ func (c buildConfig) clientOptions() ([]fn.Option, error) {
 	if c.Builder == builders.Host {
 		o = append(o,
 			fn.WithBuilder(oci.NewBuilder(builders.Host, c.Verbose)),
-			fn.WithPusher(oci.NewPusher(c.RegistryInsecure, c.Verbose)))
+			fn.WithPusher(oci.NewPusher(c.RegistryInsecure, false, c.Verbose)))
 	} else if c.Builder == builders.Pack {
 		o = append(o,
 			fn.WithBuilder(pack.NewBuilder(

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -33,6 +33,7 @@ SYNOPSIS
 	             [-b|--build] [--builder] [--builder-image] [-p|--push]
 	             [--domain] [--platform] [--build-timestamp] [--pvc-size]
 	             [--service-account] [-c|--confirm] [-v|--verbose]
+	             [--registry-insecure]
 
 DESCRIPTION
 
@@ -124,7 +125,7 @@ EXAMPLES
 
 `,
 		SuggestFor: []string{"delpoy", "deplyo"},
-		PreRunE:    bindEnv("build", "build-timestamp", "builder", "builder-image", "confirm", "domain", "env", "git-branch", "git-dir", "git-url", "image", "namespace", "path", "platform", "push", "pvc-size", "service-account", "registry", "remote", "verbose"),
+		PreRunE:    bindEnv("build", "build-timestamp", "builder", "builder-image", "confirm", "domain", "env", "git-branch", "git-dir", "git-url", "image", "namespace", "path", "platform", "push", "pvc-size", "service-account", "registry", "registry-insecure", "remote", "verbose"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDeploy(cmd, newClient)
 		},
@@ -151,6 +152,7 @@ EXAMPLES
 		fmt.Sprintf("Builder to use when creating the function's container. Currently supported builders are %s.", KnownBuilders()))
 	cmd.Flags().StringP("registry", "r", cfg.Registry,
 		"Container registry + registry namespace. (ex 'ghcr.io/myuser').  The full image name is automatically determined using this along with function name. ($FUNC_REGISTRY)")
+	cmd.Flags().Bool("registry-insecure", cfg.RegistryInsecure, "Disable HTTPS when communicating to the registry ($FUNC_REGISTRY_INSECURE)")
 	cmd.Flags().StringP("namespace", "n", cfg.Namespace,
 		"Deploy into a specific namespace. Will use function's current namespace by default if already deployed, and the currently active namespace if it can be determined. ($FUNC_NAMESPACE)")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -169,6 +169,9 @@ func bindEnv(flags ...string) bindFunc {
 				return
 			}
 		}
+		viper.AutomaticEnv()       // read in environment variables for FUNC_<flag>
+		viper.SetEnvPrefix("func") // ensure that all have the prefix
+		viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 		return
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,7 @@ Learn more about Knative at: https://knative.dev`, cfg.Name),
 	// a version prefixed by "FUNC_"
 	viper.AutomaticEnv()       // read in environment variables for FUNC_<flag>
 	viper.SetEnvPrefix("func") // ensure that all have the prefix
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
 	// Client
 	// Use the provided ClientFactory or default to NewClient
@@ -168,8 +169,6 @@ func bindEnv(flags ...string) bindFunc {
 				return
 			}
 		}
-		viper.AutomaticEnv()       // read in environment variables for FUNC_<flag>
-		viper.SetEnvPrefix("func") // ensure that all have the prefix
 		return
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,6 +53,8 @@ type Global struct {
 	// NOTE: all members must include their yaml serialized names, even when
 	// this is the default, because these tag values are used for the static
 	// getter/setter accessors to match requests.
+
+	RegistryInsecure bool `yaml:"registryInsecure,omitempty"`
 }
 
 // New Config struct with all members set to static defaults.  See NewDefaults

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -401,6 +401,7 @@ func TestList(t *testing.T) {
 		"language",
 		"namespace",
 		"registry",
+		"registryInsecure",
 		"verbose",
 	}
 

--- a/pkg/oci/pusher.go
+++ b/pkg/oci/pusher.go
@@ -19,21 +19,24 @@ import (
 
 // Pusher of OCI multi-arch layout directories.
 type Pusher struct {
-	Insecure bool
-	Verbose  bool
-	Username string
-	Token    string
+	Insecure  bool
+	Anonymous bool
+	Verbose   bool
+	Username  string
+	Token     string
 
 	updates chan v1.Update
 	done    chan bool
 }
 
-func NewPusher(insecure, verbose bool) *Pusher {
+func NewPusher(insecure, anon, verbose bool) *Pusher {
+	fmt.Println(insecure, anon, verbose)
 	return &Pusher{
-		Insecure: insecure,
-		Verbose:  verbose,
-		updates:  make(chan v1.Update, 10),
-		done:     make(chan bool, 1),
+		Insecure:  insecure,
+		Anonymous: anon,
+		Verbose:   verbose,
+		updates:   make(chan v1.Update, 10),
+		done:      make(chan bool, 1),
 	}
 }
 
@@ -44,10 +47,15 @@ func (p *Pusher) Push(ctx context.Context, f fn.Function) (digest string, err er
 	if err != nil {
 		return
 	}
+
+	var opts []name.Option
+	if p.Insecure {
+		opts = append(opts, name.Insecure)
+	}
 	// TODO: GitOps Tagging: tag :latest by default, :[branch] for pinned
 	// environments and :[user]-[branch] for development/testing feature branches.
 	// has been enabled, where branch is tag-encoded.
-	ref, err := name.ParseReference(f.Build.Image)
+	ref, err := name.ParseReference(f.Build.Image, opts...)
 	if err != nil {
 		return
 	}
@@ -79,8 +87,8 @@ func getLastBuildDir(f fn.Function) (string, error) {
 }
 
 func (p *Pusher) writeIndex(ctx context.Context, ref name.Reference, ii v1.ImageIndex) error {
-	// If we're set to insecure, just try as-is and return on failure
-	if p.Insecure {
+	// If we're set to anonymous, just try as-is and return on failure
+	if p.Anonymous {
 		return remote.WriteIndex(ref, ii,
 			remote.WithContext(ctx),
 			remote.WithProgress(p.updates))

--- a/pkg/oci/pusher_test.go
+++ b/pkg/oci/pusher_test.go
@@ -26,6 +26,7 @@ func TestPusher(t *testing.T) {
 		root, done = Mktemp(t)
 		verbose    = false
 		insecure   = true
+		anon       = true
 		success    = false
 		err        error
 	)
@@ -61,7 +62,7 @@ func TestPusher(t *testing.T) {
 	// Create and push a function
 	client := fn.New(
 		fn.WithBuilder(NewBuilder("", verbose)),
-		fn.WithPusher(NewPusher(insecure, verbose)))
+		fn.WithPusher(NewPusher(insecure, anon, verbose)))
 
 	f := fn.Function{Root: root, Runtime: "go", Name: "f", Registry: l.Addr().String() + "/funcs"}
 


### PR DESCRIPTION
- **fix env var casing otherwise flags with hyphens will continue to have hyphens**
- **Introduce an --registry-insecure flag**
