### PR TITLE
Run func without HOME defined/ unaccessible .config dir

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -159,9 +159,6 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 		cfg buildConfig
 		f   fn.Function
 	)
-	if err = config.CreatePaths(); err != nil { // for possible auth.json usage
-		return
-	}
 	if cfg, err = newBuildConfig().Prompt(); err != nil { // gather values into a single instruction set
 		return
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -233,9 +233,6 @@ func runDeploy(cmd *cobra.Command, newClient ClientFactory) (err error) {
 		cfg deployConfig
 		f   fn.Function
 	)
-	if err = config.CreatePaths(); err != nil { // for possible auth.json usage
-		return
-	}
 	if cfg, err = newDeployConfig(cmd).Prompt(); err != nil {
 		return
 	}

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -1894,3 +1894,36 @@ func TestDeploy_NoErrorOnOldFunctionNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestDeploy_WithoutHome ensures that deploying a function without HOME &
+// XDG_CONFIG_HOME defined succeeds
+func TestDeploy_WithoutHome(t *testing.T) {
+	var (
+		root = fromTempDirectory(t)
+		ns   = "myns"
+	)
+
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	// Create a basic go Function
+	f := fn.Function{
+		Runtime: "go",
+		Root:    root,
+	}
+	_, err := fn.New().Init(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Deploy the function
+	cmd := NewDeployCmd(NewTestClient(
+		fn.WithDeployer(mock.NewDeployer()),
+		fn.WithRegistry(TestRegistry)))
+
+	cmd.SetArgs([]string{fmt.Sprintf("--namespace=%s", ns)})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -1899,7 +1899,7 @@ func TestDeploy_NoErrorOnOldFunctionNotFound(t *testing.T) {
 // XDG_CONFIG_HOME defined succeeds
 func TestDeploy_WithoutHome(t *testing.T) {
 	var (
-		root = fromTempDirectory(t)
+		root = FromTempDirectory(t)
 		ns   = "myns"
 	)
 

--- a/pkg/builders/buildpacks/builder.go
+++ b/pkg/builders/buildpacks/builder.go
@@ -211,7 +211,7 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 	if err = impl.Build(ctx, opts); err != nil {
 		if ctx.Err() != nil {
 			return // SIGINT
-		} else if !b.verbose {
+		} else if b.verbose {
 			err = fmt.Errorf("failed to build the function: %w", err)
 			fmt.Fprintln(color.Stderr(), "")
 			_, _ = io.Copy(color.Stderr(), &b.outBuff)

--- a/pkg/builders/buildpacks/builder_test.go
+++ b/pkg/builders/buildpacks/builder_test.go
@@ -2,15 +2,12 @@ package buildpacks
 
 import (
 	"context"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"testing"
 
 	pack "github.com/buildpacks/pack/pkg/client"
-	"github.com/pkg/errors"
 	"knative.dev/func/pkg/builders"
 	fn "knative.dev/func/pkg/functions"
 )
@@ -214,74 +211,6 @@ func TestBuild_Errors(t *testing.T) {
 
 			if tc.expectedErr != gotErr {
 				t.Fatalf("Unexpected error want:\n%v\ngot:\n%v", tc.expectedErr, gotErr)
-			}
-		})
-	}
-}
-
-// TestBuild_HomeAndPermissions ensures that function fails during build while HOME is
-// not defined
-// TODO: can add more options with permissions for testing
-func TestBuild_HomeAndPermissions(t *testing.T) {
-	testCases := []struct {
-		name        string
-		homePath    bool
-		homePerms   fs.FileMode
-		expectedErr bool
-		errContains string
-	}{
-		// TODO: gauron99 -- maybe add test for PACK_HOME/ specific paths -- would require to change the impl
-		{name: "xpct-fail - create pack client when HOME not defined", homePath: false, homePerms: 0, expectedErr: true, errContains: "$HOME is not defined"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tc := tc
-			var (
-				i = &mockImpl{}
-				b = NewBuilder( // Func Builder logic
-					WithName(builders.Pack),
-					WithImpl(i))
-				f = fn.Function{
-					Runtime: "go",
-					Build:   fn.BuildSpec{Image: "example.com/parent/name"},
-				}
-			)
-			// set temporary dir and assign it as func directory
-			tempdir := t.TempDir()
-			f.Root = tempdir
-
-			// setup HOME env and its perms
-			if tc.homePath == false {
-				t.Setenv("HOME", "")
-			} else {
-				// setup new home with perms
-				err := os.MkdirAll(filepath.Join(tempdir, "home"), tc.homePerms)
-				if err != nil {
-					t.Fatal(err)
-				}
-				t.Setenv("HOME", filepath.Join(tempdir, "home"))
-			}
-			i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
-				_, err := os.UserHomeDir()
-				if err != nil {
-					return errors.Wrap(err, "getting user home")
-				}
-				return nil
-			}
-
-			err := b.Build(context.Background(), f, nil)
-			// error scenarios
-			if tc.expectedErr {
-				if err == nil {
-					t.Fatalf("expected error but got nil")
-				} else if !strings.Contains(err.Error(), tc.errContains) {
-					t.Fatalf("expected error message '%v' was not found in the actual error: '%v'", tc.errContains, err)
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("didnt expect an error but got '%v'", err)
-				}
 			}
 		})
 	}

--- a/pkg/builders/buildpacks/builder_test.go
+++ b/pkg/builders/buildpacks/builder_test.go
@@ -220,7 +220,8 @@ func TestBuild_Errors(t *testing.T) {
 }
 
 // TestBuild_HomeAndPermissions ensures that function fails during build while HOME is
-// not defined and different .config permission scenarios
+// not defined
+// TODO: can add more options with permissions for testing
 func TestBuild_HomeAndPermissions(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -229,6 +230,7 @@ func TestBuild_HomeAndPermissions(t *testing.T) {
 		expectedErr bool
 		errContains string
 	}{
+		// TODO: gauron99 -- maybe add test for PACK_HOME/ specific paths -- would require to change the impl
 		{name: "xpct-fail - create pack client when HOME not defined", homePath: false, homePerms: 0, expectedErr: true, errContains: "$HOME is not defined"},
 	}
 
@@ -260,14 +262,10 @@ func TestBuild_HomeAndPermissions(t *testing.T) {
 				}
 				t.Setenv("HOME", filepath.Join(tempdir, "home"))
 			}
-			// TODO: gauron99 -- add test for pack_home?
 			i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
-				packHome := os.Getenv("PACK_HOME")
-				if packHome == "" {
-					_, err := os.UserHomeDir()
-					if err != nil {
-						return errors.Wrap(err, "getting user home")
-					}
+				_, err := os.UserHomeDir()
+				if err != nil {
+					return errors.Wrap(err, "getting user home")
 				}
 				return nil
 			}

--- a/pkg/docker/creds/credentials.go
+++ b/pkg/docker/creds/credentials.go
@@ -166,7 +166,6 @@ func NewCredentialsProvider(configPath string, opts ...Opt) docker.CredentialsPr
 	}
 
 	// default credential loaders map -- load only those that should be there.
-	// Dont include loaders that dont have valid config paths etc.
 	var defaultCredentialLoaders = []CredentialsCallback{}
 
 	c.authFilePath = filepath.Join(configPath, "auth.json")
@@ -174,8 +173,6 @@ func NewCredentialsProvider(configPath string, opts ...Opt) docker.CredentialsPr
 		AuthFilePath: c.authFilePath,
 	}
 
-	// if path to the config file does not exist -- dont include it.
-	// That is HOME/func/auth.json or XDG_CONFIG_HOME/func/auth.json (higher pref)
 	if _, err := os.Stat(c.authFilePath); err == nil {
 		defaultCredentialLoaders = append(defaultCredentialLoaders,
 			func(registry string) (docker.Credentials, error) {
@@ -183,7 +180,7 @@ func NewCredentialsProvider(configPath string, opts ...Opt) docker.CredentialsPr
 			})
 	}
 
-	// check that home is defined for .docker/config.json creds
+	// add only if home dir is defined -- for .docker/config.json creds
 	home, err := os.UserHomeDir()
 	if err == nil {
 		dockerConfigPath := filepath.Join(home, ".docker", "config.json")
@@ -294,7 +291,6 @@ func (c *credentialsProvider) getCredentials(ctx context.Context, image string) 
 				helper = strings.TrimPrefix(helper, "docker-credential-")
 				err = setCredentialHelperToConfig(c.authFilePath, helper)
 				if err != nil {
-					// fmt.Fprintf(os.Stderr, "Warning: failed to set helper to the config with error: '%v'\n", err)
 					return docker.Credentials{}, fmt.Errorf("faild to set the helper to the config: %w", err)
 				}
 				err = setCredentialsByCredentialHelper(c.authFilePath, registry, result.Username, result.Password)

--- a/pkg/docker/creds/credentials.go
+++ b/pkg/docker/creds/credentials.go
@@ -192,23 +192,20 @@ func NewCredentialsProvider(configPath string, opts ...Opt) docker.CredentialsPr
 				return getCredentialsByCredentialHelper(dockerConfigPath, registry)
 			})
 	}
-	// dont add this loader when configPath is empty
-	if configPath != "" {
-		defaultCredentialLoaders = append(defaultCredentialLoaders,
-			func(registry string) (docker.Credentials, error) {
-				creds, err := dockerConfig.GetCredentials(sys, registry)
-				if err != nil {
-					return docker.Credentials{}, err
-				}
-				if creds.Username == "" || creds.Password == "" {
-					return docker.Credentials{}, ErrCredentialsNotFound
-				}
-				return docker.Credentials{
-					Username: creds.Username,
-					Password: creds.Password,
-				}, nil
-			})
-	}
+	defaultCredentialLoaders = append(defaultCredentialLoaders,
+		func(registry string) (docker.Credentials, error) {
+			creds, err := dockerConfig.GetCredentials(sys, registry)
+			if err != nil {
+				return docker.Credentials{}, err
+			}
+			if creds.Username == "" || creds.Password == "" {
+				return docker.Credentials{}, ErrCredentialsNotFound
+			}
+			return docker.Credentials{
+				Username: creds.Username,
+				Password: creds.Password,
+			}, nil
+		})
 	defaultCredentialLoaders = append(defaultCredentialLoaders,
 		func(registry string) (docker.Credentials, error) {
 			// Fallback onto default docker config locations
@@ -297,9 +294,8 @@ func (c *credentialsProvider) getCredentials(ctx context.Context, image string) 
 				helper = strings.TrimPrefix(helper, "docker-credential-")
 				err = setCredentialHelperToConfig(c.authFilePath, helper)
 				if err != nil {
-					// TODO: gauron99 -- figure out what to do with this
-					fmt.Fprintf(os.Stderr, "Warning: failed to set helper to the config with error: '%v'\n", err)
-					// return docker.Credentials{}, fmt.Errorf("faild to set the helper to the config: %w", err)
+					// fmt.Fprintf(os.Stderr, "Warning: failed to set helper to the config with error: '%v'\n", err)
+					return docker.Credentials{}, fmt.Errorf("faild to set the helper to the config: %w", err)
 				}
 				err = setCredentialsByCredentialHelper(c.authFilePath, registry, result.Username, result.Password)
 				if err != nil {

--- a/pkg/docker/creds/credentials.go
+++ b/pkg/docker/creds/credentials.go
@@ -192,20 +192,23 @@ func NewCredentialsProvider(configPath string, opts ...Opt) docker.CredentialsPr
 				return getCredentialsByCredentialHelper(dockerConfigPath, registry)
 			})
 	}
-	defaultCredentialLoaders = append(defaultCredentialLoaders,
-		func(registry string) (docker.Credentials, error) {
-			creds, err := dockerConfig.GetCredentials(sys, registry)
-			if err != nil {
-				return docker.Credentials{}, err
-			}
-			if creds.Username == "" || creds.Password == "" {
-				return docker.Credentials{}, ErrCredentialsNotFound
-			}
-			return docker.Credentials{
-				Username: creds.Username,
-				Password: creds.Password,
-			}, nil
-		})
+	// dont add this loader when configPath is empty
+	if configPath != "" {
+		defaultCredentialLoaders = append(defaultCredentialLoaders,
+			func(registry string) (docker.Credentials, error) {
+				creds, err := dockerConfig.GetCredentials(sys, registry)
+				if err != nil {
+					return docker.Credentials{}, err
+				}
+				if creds.Username == "" || creds.Password == "" {
+					return docker.Credentials{}, ErrCredentialsNotFound
+				}
+				return docker.Credentials{
+					Username: creds.Username,
+					Password: creds.Password,
+				}, nil
+			})
+	}
 	defaultCredentialLoaders = append(defaultCredentialLoaders,
 		func(registry string) (docker.Credentials, error) {
 			// Fallback onto default docker config locations
@@ -295,7 +298,7 @@ func (c *credentialsProvider) getCredentials(ctx context.Context, image string) 
 				err = setCredentialHelperToConfig(c.authFilePath, helper)
 				if err != nil {
 					// TODO: gauron99 -- figure out what to do with this
-					fmt.Fprintf(os.Stderr, "Warning: failed to set the helper to the config with error: '%v'\n", err)
+					fmt.Fprintf(os.Stderr, "Warning: failed to set helper to the config with error: '%v'\n", err)
 					// return docker.Credentials{}, fmt.Errorf("faild to set the helper to the config: %w", err)
 				}
 				err = setCredentialsByCredentialHelper(c.authFilePath, registry, result.Username, result.Password)

--- a/pkg/docker/creds/credentials_test.go
+++ b/pkg/docker/creds/credentials_test.go
@@ -478,11 +478,13 @@ func TestNewCredentialsSkipDockerConfigWhenNoHome(t *testing.T) {
 	helper := newInMemoryHelper()
 	setUpMockHelper("docker-credential-mock", helper)(t)
 
-	helper.Add(&credentials.Credentials{
+	if err := helper.Add(&credentials.Credentials{
 		ServerURL: "docker.io",
 		Username:  dockerIoUser,
 		Secret:    dockerIoUserPwd,
-	})
+	}); err != nil {
+		t.Error(err)
+	}
 
 	// have docker config credential loader but HOME is not defined -- should return nil
 	t.Setenv("HOME", "")

--- a/pkg/functions/client_int_test.go
+++ b/pkg/functions/client_int_test.go
@@ -309,7 +309,7 @@ func TestBuildWithoutHome(t *testing.T) {
 }
 
 // TestDeployWithoutWritableDotConfig ensures that running client.New works without
-// .config being accessable (write/read)
+// .config being accessible (write/read)
 // TODO: change this test to for-loop of Runs with different dir permissions?
 func TestDeployWithoutWritableDotConfig(t *testing.T) {
 	// defer Within(t, "tempdata/example.com/baddotconfig")

--- a/pkg/functions/client_int_test.go
+++ b/pkg/functions/client_int_test.go
@@ -292,9 +292,9 @@ func TestUpdateWithAnnotationsAndLabels(t *testing.T) {
 	}
 }
 
-// TestDeployWithoutHomeWithS2i ensures that running client.New works without
+// TestDeployS2iBuilderWithoutHome ensures that running client.New works without
 // home
-func TestDeployWithoutHomeWithS2i(t *testing.T) {
+func TestDeployS2iBuilderWithoutHome(t *testing.T) {
 	root, cleanup := Mktemp(t)
 	defer cleanup()
 
@@ -302,7 +302,7 @@ func TestDeployWithoutHomeWithS2i(t *testing.T) {
 	verbose := true
 	name := "test-deploy-no-home"
 
-	f := fn.Function{Runtime: "node", Name: name, Root: root}
+	f := fn.Function{Runtime: "node", Name: name, Root: root, Namespace: DefaultNamespace}
 
 	// client with s2i builder
 	client := newClientWithS2i(verbose)
@@ -312,7 +312,7 @@ func TestDeployWithoutHomeWithS2i(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no errors but got %v", err)
 	}
-	defer del(t, client, name)
+	defer del(t, client, name, DefaultNamespace)
 }
 
 // TestRemove ensures removal of a function instance.
@@ -599,10 +599,10 @@ func newClient(verbose bool) *fn.Client {
 func newClientWithS2i(verbose bool) *fn.Client {
 	builder := s2i.NewBuilder(s2i.WithVerbose(verbose))
 	pusher := docker.NewPusher(docker.WithVerbose(verbose))
-	deployer := knative.NewDeployer(knative.WithDeployerNamespace(DefaultNamespace), knative.WithDeployerVerbose(verbose))
-	describer := knative.NewDescriber(DefaultNamespace, verbose)
+	deployer := knative.NewDeployer(knative.WithDeployerVerbose(verbose))
+	describer := knative.NewDescriber(verbose)
 	remover := knative.NewRemover(verbose)
-	lister := knative.NewLister(DefaultNamespace, verbose)
+	lister := knative.NewLister(verbose)
 
 	return fn.New(
 		fn.WithRegistry(DefaultRegistry),

--- a/pkg/functions/client_int_test.go
+++ b/pkg/functions/client_int_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -289,6 +290,53 @@ func TestUpdateWithAnnotationsAndLabels(t *testing.T) {
 			t.Fatal(fmt.Errorf("label %q not found in the deployed service", *l.Key))
 		}
 	}
+}
+
+// TestBuildWithoutHome ensures that running func without HOME fails for pack builder
+func TestBuildWithoutHome(t *testing.T) {
+	root, cleanup := Mktemp(t)
+	defer cleanup()
+	t.Setenv("HOME", "")
+	verbose := true
+
+	f := fn.Function{Runtime: "go", Name: "test-deploy-without-home", Root: root}
+	client := newClient(verbose)
+	if _, err := client.Build(context.Background(), f); err == nil {
+		t.Fatalf("expected an error for HOME not defined with pack builder, got none")
+	}
+
+	// dont call del() because function wasnt deployed
+}
+
+// TestDeployWithoutWritableDotConfig ensures that running client.New works without
+// .config being accessable (write/read)
+// TODO: change this test to for-loop of Runs with different dir permissions?
+func TestDeployWithoutWritableDotConfig(t *testing.T) {
+	// defer Within(t, "tempdata/example.com/baddotconfig")
+	root, cleanup := Mktemp(t)
+	defer cleanup()
+
+	t.Setenv("HOME", root)
+	verbose := true
+
+	// write new .config with no perms
+	err := os.Mkdir(path.Join(root, ".config"), 0000)
+	if err != nil {
+		t.Error(err)
+	}
+
+	f := fn.Function{Runtime: "go", Name: "test-deploy-no-perms-config", Root: root}
+
+	// client with pack builder
+	client := newClient(verbose)
+
+	// expect to fail on build for HOME not being defined with pack builder
+	_, _, err = client.New(context.Background(), f)
+	// this error should be 'permission denied' for trying to write to open .config
+	if err == nil {
+		t.Fatalf("expected an error but got nil")
+	}
+	// dont call del() because function wasnt deployed
 }
 
 // TestRemove ensures removal of a function instance.

--- a/pkg/functions/client_int_test.go
+++ b/pkg/functions/client_int_test.go
@@ -546,19 +546,20 @@ func Handle(ctx context.Context, w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-// TestDeployS2iBuilderWithoutHome ensures that running client.New works without
+// TestDeployWithoutHome ensures that running client.New works without
 // home
-func TestDeployS2iBuilderWithoutHome(t *testing.T) {
+func TestDeployWithoutHome(t *testing.T) {
 	root, cleanup := Mktemp(t)
 	defer cleanup()
 
 	t.Setenv("HOME", "")
-	verbose := true
+	t.Setenv("XDG_CONFIG_HOME", "")
+	verbose := false
 	name := "test-deploy-no-home"
 
-	f := fn.Function{Runtime: "python", Name: name, Root: root, Namespace: DefaultNamespace}
+	f := fn.Function{Runtime: "node", Name: name, Root: root, Namespace: DefaultNamespace}
 
-	// client with s2i builder
+	// client with s2i builder because pack needs HOME
 	client := newClientWithS2i(verbose)
 
 	// expect to succeed

--- a/pkg/functions/client_int_test.go
+++ b/pkg/functions/client_int_test.go
@@ -292,29 +292,6 @@ func TestUpdateWithAnnotationsAndLabels(t *testing.T) {
 	}
 }
 
-// TestDeployS2iBuilderWithoutHome ensures that running client.New works without
-// home
-func TestDeployS2iBuilderWithoutHome(t *testing.T) {
-	root, cleanup := Mktemp(t)
-	defer cleanup()
-
-	t.Setenv("HOME", "")
-	verbose := true
-	name := "test-deploy-no-home"
-
-	f := fn.Function{Runtime: "node", Name: name, Root: root, Namespace: DefaultNamespace}
-
-	// client with s2i builder
-	client := newClientWithS2i(verbose)
-
-	// expect to succeed
-	_, _, err := client.New(context.Background(), f)
-	if err != nil {
-		t.Fatalf("expected no errors but got %v", err)
-	}
-	defer del(t, client, name, DefaultNamespace)
-}
-
 // TestRemove ensures removal of a function instance.
 func TestRemove(t *testing.T) {
 	defer Within(t, "testdata/example.com/remove")()
@@ -567,6 +544,34 @@ func Handle(ctx context.Context, w http.ResponseWriter, req *http.Request) {
 	if string(body) != "TestInvoke_ServiceToService OK" {
 		t.Fatalf("Unexpected response from Function B: %v", string(body))
 	}
+}
+
+// TestDeployS2iBuilderWithoutHome ensures that running client.New works without
+// home
+func TestDeployS2iBuilderWithoutHome(t *testing.T) {
+	root, cleanup := Mktemp(t)
+	defer cleanup()
+
+	t.Setenv("HOME", "")
+	verbose := true
+	name := "test-deploy-no-home"
+
+	f := fn.Function{Runtime: "node", Name: name, Root: root, Namespace: DefaultNamespace}
+
+	// client with s2i builder
+	client := newClientWithS2i(verbose)
+
+	// expect to succeed
+	_, _, err := client.New(context.Background(), f)
+	if err != nil {
+		t.Fatalf("expected no errors but got %v", err)
+	}
+
+	// NOTE: gauron99: this del is commented out until client.delete is resolved.
+	// Currently, the remover is looking for resources to delete and is taking about
+	// triple the time of current timeout.
+	// For remover/deleter resolution, see issue: https://github.com/knative/func/issues/2316
+	// defer del(t, client, name, DefaultNamespace)
 }
 
 // ***********

--- a/pkg/functions/client_int_test.go
+++ b/pkg/functions/client_int_test.go
@@ -556,7 +556,7 @@ func TestDeployS2iBuilderWithoutHome(t *testing.T) {
 	verbose := true
 	name := "test-deploy-no-home"
 
-	f := fn.Function{Runtime: "node", Name: name, Root: root, Namespace: DefaultNamespace}
+	f := fn.Function{Runtime: "python", Name: name, Root: root, Namespace: DefaultNamespace}
 
 	// client with s2i builder
 	client := newClientWithS2i(verbose)
@@ -567,11 +567,7 @@ func TestDeployS2iBuilderWithoutHome(t *testing.T) {
 		t.Fatalf("expected no errors but got %v", err)
 	}
 
-	// NOTE: gauron99: this del is commented out until client.delete is resolved.
-	// Currently, the remover is looking for resources to delete and is taking about
-	// triple the time of current timeout.
-	// For remover/deleter resolution, see issue: https://github.com/knative/func/issues/2316
-	// defer del(t, client, name, DefaultNamespace)
+	defer del(t, client, name, DefaultNamespace)
 }
 
 // ***********

--- a/pkg/functions/client_int_test.go
+++ b/pkg/functions/client_int_test.go
@@ -292,25 +292,8 @@ func TestUpdateWithAnnotationsAndLabels(t *testing.T) {
 	}
 }
 
-// TestBuildWithoutHome ensures that running func without HOME fails for pack builder
-func TestBuildWithoutHome(t *testing.T) {
-	root, cleanup := Mktemp(t)
-	defer cleanup()
-	t.Setenv("HOME", "")
-	verbose := true
-
-	f := fn.Function{Runtime: "go", Name: "test-deploy-without-home", Root: root}
-	client := newClient(verbose)
-	if _, err := client.Build(context.Background(), f); err == nil {
-		t.Fatalf("expected an error for HOME not defined with pack builder, got none")
-	}
-
-	// dont call del() because function wasnt deployed
-}
-
 // TestDeployWithoutHomeWithS2i ensures that running client.New works without
 // home
-// TODO: change this test to for-loop of Runs with different dir permissions?
 func TestDeployWithoutHomeWithS2i(t *testing.T) {
 	root, cleanup := Mktemp(t)
 	defer cleanup()


### PR DESCRIPTION
# Changes
Use func without the need for HOME definition or accessible ~/.config with slightly limited functionality (like docker creds or local templates/repos or the pack builder)

When running `func deploy` without `HOME` or `XDG_CONFIG_HOME` specified, deployment is possible if the correct credentials are provided via user prompt (if needed). Additionally, pack builder requires some HOME path for its dot directory where it stores data hence it needs HOME to work. S2i builder is non-problematic. 

/kind enhancement
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2150

