### PR TITLE
Standalone deploy binary/image 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,6 +145,24 @@ jobs:
           name: Windows Binary
           path: func_windows_amd64.exe
 
+  publish-utils-image:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: |
+          docker buildx create --name multiarch --driver docker-container --use
+          docker buildx build . -f Dockerfile.utils \
+            --platform=linux/ppc64le,linux/s390x,linux/amd64,linux/arm64 \
+            --push \
+            -t "ghcr.io/knative/func-utils:latest"
+
   publish-image:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/test-podman.yaml
+++ b/.github/workflows/test-podman.yaml
@@ -33,6 +33,8 @@ jobs:
         run: ./hack/allocate.sh
       - name: Local Registry
         run: ./hack/registry.sh
+      - name: Setup testing images
+        run: ./hack/setup-testing-images.sh
       - name: Integration Test Podman
         env:
           FUNC_REPO_REF: ${{ github.event.pull_request.head.repo.full_name }}

--- a/Dockerfile.utils
+++ b/Dockerfile.utils
@@ -1,0 +1,21 @@
+FROM --platform=$BUILDPLATFORM index.docker.io/library/golang:1.22.1-alpine3.19 AS builder
+
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+ARG TARGETARCH
+
+COPY . .
+
+RUN GOARCH=$TARGETARCH go build -o deploy -trimpath -ldflags '-w -s' ./cmd/func-deployer
+
+#########################
+
+FROM --platform=$TARGETPLATFORM index.docker.io/library/alpine:latest
+
+RUN apk add --no-cache socat tar \
+  && addgroup func -g 1000 \
+  && adduser func -u 1001 -D -G func
+
+COPY --from=builder /go/deploy /usr/local/bin/
+
+USER func:func

--- a/cmd/func-deployer/main.go
+++ b/cmd/func-deployer/main.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	fn "knative.dev/func/pkg/functions"
+	"knative.dev/func/pkg/k8s"
+	"knative.dev/func/pkg/knative"
+)
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		cancel()
+		<-sigs // second sigint/sigterm is treated as sigkill
+		os.Exit(137)
+	}()
+
+	err := deploy(ctx)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+		os.Exit(1)
+	}
+}
+func deploy(ctx context.Context) error {
+	var err error
+	deployer := knative.NewDeployer(
+		knative.WithDeployerVerbose(true),
+		knative.WithDeployerDecorator(deployDecorator{}))
+
+	var root string
+	if len(os.Args) > 1 {
+		root = os.Args[1]
+	} else {
+		root, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("cannot determine working directory: %w", err)
+		}
+	}
+
+	f, err := fn.NewFunction(root)
+	if err != nil {
+		return fmt.Errorf("cannot load function: %w", err)
+	}
+	if len(os.Args) > 2 {
+		f.Deploy.Image = os.Args[2]
+	}
+	if f.Deploy.Image == "" {
+		f.Deploy.Image = f.Image
+	}
+
+	res, err := deployer.Deploy(ctx, f)
+	if err != nil {
+		return fmt.Errorf("cannont deploy the function: %w", err)
+	}
+
+	fmt.Printf("function has been deployed\n%+v\n", res)
+	return nil
+}
+
+type deployDecorator struct {
+	oshDec k8s.OpenshiftMetadataDecorator
+}
+
+func (d deployDecorator) UpdateAnnotations(function fn.Function, annotations map[string]string) map[string]string {
+	if k8s.IsOpenShift() {
+		return d.oshDec.UpdateAnnotations(function, annotations)
+	}
+	return annotations
+}
+
+func (d deployDecorator) UpdateLabels(function fn.Function, labels map[string]string) map[string]string {
+	if k8s.IsOpenShift() {
+		return d.oshDec.UpdateLabels(function, labels)
+	}
+	return labels
+}

--- a/hack/setup-testing-images.sh
+++ b/hack/setup-testing-images.sh
@@ -4,10 +4,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KO_DOCKER_REPO="localhost:50000/knative/func"
-export KO_DOCKER_REPO
+FUNC_UTILS_IMG="localhost:50000/knative/func-utils:latest"
 
-ko build --tags "latest" -B ./cmd/func
+docker build . -f Dockerfile.utils -t "${FUNC_UTILS_IMG}"
+docker push "${FUNC_UTILS_IMG}"
 
 # Build custom buildah image for tests.
 # This image will accept registries ending with .cluster.local as insecure (non-TLS).

--- a/pkg/k8s/dialer.go
+++ b/pkg/k8s/dialer.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-var SocatImage = "quay.io/boson/alpine-socat:1.7.4.3-r1-non-root"
+var SocatImage = "ghcr.io/knative/func-utils:latest"
 
 // NewInClusterDialer creates context dialer that will dial TCP connections via POD running in k8s cluster.
 // This is useful when accessing k8s services that are not exposed outside cluster (e.g. openshift image registry).

--- a/pkg/k8s/persistent_volumes.go
+++ b/pkg/k8s/persistent_volumes.go
@@ -67,7 +67,7 @@ func DeletePersistentVolumeClaims(ctx context.Context, namespaceOverride string,
 	return client.CoreV1().PersistentVolumeClaims(namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, listOptions)
 }
 
-var TarImage = "quay.io/boson/alpine-socat:1.7.4.3-r1-non-root"
+var TarImage = "ghcr.io/knative/func-utils:latest"
 
 // UploadToVolume uploads files (passed in form of tar stream) into volume.
 func UploadToVolume(ctx context.Context, content io.Reader, claimName, namespace string) error {

--- a/pkg/k8s/persistent_volumes_test.go
+++ b/pkg/k8s/persistent_volumes_test.go
@@ -50,7 +50,7 @@ func TestUploadToVolume(t *testing.T) {
 
 	// First, test error handling by uploading empty content stream.
 	err = k8s.UploadToVolume(ctx, &bytes.Buffer{}, testingPVCName, testingNS)
-	if err == nil || !strings.Contains(err.Error(), "short read") {
+	if err == nil || !strings.Contains(err.Error(), "does not look like a tar") {
 		t.Error("got <nil> error, or error with unexpected message")
 	}
 

--- a/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
@@ -24,6 +24,6 @@ spec:
       description: The workspace containing the function project
   steps:
     - name: func-deploy
-      image: "ghcr.io/knative/func/func:latest"
+      image: "ghcr.io/knative/func-utils:latest"
       script: |
-        func deploy --verbose --build=false --push=false --path=$(params.path) --remote=false --image="$(params.image)"
+        deploy $(params.path) "$(params.image)"


### PR DESCRIPTION
# Changes

* The utility (socat/tar) image is now built in GH Action and stored in GH image registry. Previously it was build completely ad-hoc and stored in some quay.io repository.

* The utility image contains new tiny standalone `deploy` binary. This binary is used in deploy task instead of full-fat `func` binary. The binary is smaller and breaks cyclical dependency where `func` CLI references image with `func` CLI itself.