### PR TITLE
fix: Fix Test_deployerNamespace with empty kubeconfig

### DIFF
--- a/pkg/knative/deployer.go
+++ b/pkg/knative/deployer.go
@@ -145,7 +145,7 @@ func namespace(dflt string, f fn.Function) string {
 		// still not set, just use the defaultest default
 		namespace, err = k8s.GetDefaultNamespace()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "trying to get default namespace returns an error: '%s'\nSetting static default namespace '%s'", err, StaticDefaultNamespace)
+			fmt.Fprintf(os.Stderr, "trying to get default namespace returns an error: '%s'\nSetting static default namespace '%s'\n", err, StaticDefaultNamespace)
 			namespace = StaticDefaultNamespace
 		}
 	}

--- a/pkg/knative/deployer_test.go
+++ b/pkg/knative/deployer_test.go
@@ -130,12 +130,13 @@ func Test_deployerNamespace(t *testing.T) {
 	)
 	f := fn.Function{Name: "myfunc"}
 
-	// FIXME(dsimansk): ignored for unblocking release job
-	// It doesn't seem likely that namespace() function can resolve to value of `StaticDefaultNamespace`
-	//set static default
-	//if ns := namespace("", f); ns != StaticDefaultNamespace {
-	//	t.Fatal("expected static default namespace")
-	//}
+	// set static default
+	// mock empty Kubeconfig to trigger namespace fallback
+	t.Setenv("KUBECONFIG", fmt.Sprintf("%s/testdata/test_empty", cwd()))
+	if ns := namespace("", f); ns != StaticDefaultNamespace {
+		t.Fatalf("expected static default namespace: expected '%s', actual '%s'", StaticDefaultNamespace, ns)
+	}
+
 	t.Setenv("KUBECONFIG", fmt.Sprintf("%s/testdata/test_default_namespace", cwd()))
 
 	// active kubernetes default

--- a/pkg/knative/testdata/test_empty
+++ b/pkg/knative/testdata/test_empty
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Config
+clusters:
+contexts:
+preferences: {}
+users:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- fix: Fix Test_deployerNamespace with empty kubeconfig

That's should work for any cluster/no-cluster situation hopefully.

/cc @gauron99 