### PR TITLE
fix: pin octokit npm module version to 3

### DIFF
--- a/.github/workflows/update-quarkus-platform.yaml
+++ b/.github/workflows/update-quarkus-platform.yaml
@@ -23,7 +23,7 @@ jobs:
           java-version: 21
           distribution: 'temurin'
       - name: Install NPM deps.
-        run: npm install xml2js octokit
+        run: npm install xml2js octokit@3.2.1
       - name: Create PR
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/update-springboot-platform.yaml
+++ b/.github/workflows/update-springboot-platform.yaml
@@ -23,7 +23,7 @@ jobs:
           java-version: 21
           distribution: 'temurin'
       - name: Install NPM deps.
-        run: npm install xml2js octokit yaml semver
+        run: npm install xml2js octokit@3.2.1 yaml semver
       - name: Create PR
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The newer version of `octokit` (v4) uses some different module type and `require()` does not work nice with it.

This is required to fix currently failing periodic quarkus/sprint-boot version update.