### PR TITLE
chore: upload coverage of unittests together

### DIFF
--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           name: coverage-${{ matrix.os }}
           path: ./coverage.txt
-          retention-days: 7
+          retention-days: 1
   upload-coverage:
     needs: [test]
     name: "Upload coverage"

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -36,7 +36,23 @@ jobs:
           FUNC_REPO_BRANCH_REF: ${{ github.head_ref }}
       - name: Template Unit Tests
         run: make test-templates
+      - name: "Archive code coverage results"
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}
+          path: ./coverage.txt
+          retention-days: 7
+  upload-coverage:
+    needs: [test]
+    name: "Upload coverage"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Download Coverage
+        run: |
+          gh run download -R ${{ github.repository }} ${{ github.run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: codecov/codecov-action@v4
         with:
-          files: ./coverage.txt
-          flags: unit-tests-${{ matrix.os }}
+          files: ./coverage-ubuntu-latest/coverage.txt,./coverage-windows-latest/coverage.txt,./coverage-macos-latest/coverage.txt
+          flags: unit-tests

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -47,6 +47,7 @@ jobs:
     name: "Upload coverage"
     runs-on: "ubuntu-latest"
     steps:
+      - uses: actions/checkout@v4
       - name: Download Coverage
         run: |
           gh run download -R ${{ github.repository }} ${{ github.run_id }}


### PR DESCRIPTION
Upload results of unit tests on various operating systems at once as opposed to uploading them individually. 