### PR TITLE
fix: pipeline run yaml format for newer PaC

### DIFF
--- a/pkg/pipelines/tekton/templates.go
+++ b/pkg/pipelines/tekton/templates.go
@@ -235,8 +235,8 @@ func createPipelineRunTemplatePAC(f fn.Function, labels map[string]string) error
 
 		S2iImageScriptsUrl: s2iImageScriptsUrl,
 
-		RepoUrl:  "{{ repo_url }}",
-		Revision: "{{ revision }}",
+		RepoUrl:  "\"{{ repo_url }}\"",
+		Revision: "\"{{ revision }}\"",
 	}
 
 	var template string


### PR DESCRIPTION
Newer versions of PaC do not work without the quotes.