### PR TITLE
Honor --registry-insecure flag in deploy command

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -282,7 +282,7 @@ func runDeploy(cmd *cobra.Command, newClient ClientFactory) (err error) {
 	if err != nil {
 		return
 	}
-	client, done := newClient(ClientConfig{Verbose: cfg.Verbose}, clientOptions...)
+	client, done := newClient(ClientConfig{Verbose: cfg.Verbose, InsecureSkipVerify: cfg.RegistryInsecure}, clientOptions...)
 	defer done()
 
 	// Deploy


### PR DESCRIPTION
# Changes

- :bug: Honor `--registry-insecure` flag in `deploy` command

/kind bug

<!-- Please include the 'why' behind your changes if no issue exists -->

While playing with `func` in a local environment (with `kind`), I've noticed `certificate signed by unknown authority` issues when trying to connect to my local registry, despite passing the `--registry-insecure` flag:

```shell
$ kn func deploy --path myfunc --remote --registry kind-registry:5000 --registry-insecure
```

> Creating Pipeline resources
> Error: failed to run pipeline: creating push check transport for kind-registry:5000 failed: Get "https://kind-registry:5000/v2/": tls: failed to verify certificate: x509: certificate signed by unknown authority

Same result with `FUNC_REGISTRY_INSECURE`; after debugging, it turns out that `RegistryInsecure` was simply not forwarded from `deployConfig` to `InsecureSkipVerify` in `ClientConfig` :sweat_smile:

Looking at the PR that introduced `--registry-insecure` (#2234), it looks like it has never been forwarded. Kind ping to @dprotaso as the author of this PR, maybe I've missed something.

**Release Note**

```release-note
fix: honor --registry-insecure flag in deploy command
```