### PR TITLE
TESTING ONLY; DO NOT MERGE

### DIFF
--- a/pkg/functions/client.go
+++ b/pkg/functions/client.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
 	"gopkg.in/yaml.v2"
 
 	"knative.dev/func/pkg/scaffolding"
@@ -992,6 +994,11 @@ func (c *Client) List(ctx context.Context, namespace string) ([]ListItem, error)
 // in which case empty namespace is accepted because its existence is checked
 // in the sub functions remover.Remove and pipilines.Remove
 func (c *Client) Remove(ctx context.Context, name, namespace string, f Function, all bool) error {
+	defer func() {
+		if dc, err := client.NewClientWithOpts(client.FromEnv); err == nil {
+			_, _ = dc.VolumesPrune(ctx, filters.Args{})
+		}
+	}()
 	// Default to name/namespace, fallback to passed Function
 	if name == "" {
 		name = f.Name

--- a/pkg/functions/client.go
+++ b/pkg/functions/client.go
@@ -995,7 +995,7 @@ func (c *Client) List(ctx context.Context, namespace string) ([]ListItem, error)
 // in the sub functions remover.Remove and pipilines.Remove
 func (c *Client) Remove(ctx context.Context, name, namespace string, f Function, all bool) error {
 	defer func() {
-		dc, err := client.NewClientWithOpts(client.FromEnv)
+		dc, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/functions/client.go
+++ b/pkg/functions/client.go
@@ -995,9 +995,15 @@ func (c *Client) List(ctx context.Context, namespace string) ([]ListItem, error)
 // in the sub functions remover.Remove and pipilines.Remove
 func (c *Client) Remove(ctx context.Context, name, namespace string, f Function, all bool) error {
 	defer func() {
-		if dc, err := client.NewClientWithOpts(client.FromEnv); err == nil {
-			_, _ = dc.VolumesPrune(ctx, filters.Args{})
+		dc, err := client.NewClientWithOpts(client.FromEnv)
+		if err != nil {
+			panic(err)
 		}
+		r, err := dc.VolumesPrune(ctx, filters.Args{})
+		if err != nil {
+			panic(err)
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "%+v\n", r)
 	}()
 	// Default to name/namespace, fallback to passed Function
 	if name == "" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
