### PR TITLE
Clarify --registry-insecure flag description

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -102,7 +102,7 @@ EXAMPLES
 		fmt.Sprintf("Builder to use when creating the function's container. Currently supported builders are %s. ($FUNC_BUILDER)", KnownBuilders()))
 	cmd.Flags().StringP("registry", "r", cfg.Registry,
 		"Container registry + registry namespace. (ex 'ghcr.io/myuser').  The full image name is automatically determined using this along with function name. ($FUNC_REGISTRY)")
-	cmd.Flags().Bool("registry-insecure", cfg.RegistryInsecure, "Disable HTTPS when communicating to the registry ($FUNC_REGISTRY_INSECURE)")
+	cmd.Flags().Bool("registry-insecure", cfg.RegistryInsecure, "Skip TLS certificate verification when communicating in HTTPS with the registry ($FUNC_REGISTRY_INSECURE)")
 
 	// Function-Context Flags:
 	// Options whose value is available on the function with context only

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -152,7 +152,7 @@ EXAMPLES
 		fmt.Sprintf("Builder to use when creating the function's container. Currently supported builders are %s.", KnownBuilders()))
 	cmd.Flags().StringP("registry", "r", cfg.Registry,
 		"Container registry + registry namespace. (ex 'ghcr.io/myuser').  The full image name is automatically determined using this along with function name. ($FUNC_REGISTRY)")
-	cmd.Flags().Bool("registry-insecure", cfg.RegistryInsecure, "Disable HTTPS when communicating to the registry ($FUNC_REGISTRY_INSECURE)")
+	cmd.Flags().Bool("registry-insecure", cfg.RegistryInsecure, "Skip TLS certificate verification when communicating in HTTPS with the registry ($FUNC_REGISTRY_INSECURE)")
 
 	// Function-Context Flags:
 	// Options whose value is available on the function with context only


### PR DESCRIPTION
# Changes

- :broom: Clarify `--registry-insecure` flag description

/kind documentation

Related to #2335, where we discovered that the description of `registry-insecure` flag was not really accurate/clear.

After investigation, I've found that enabling this flag just means "skip TLS certificate verification when communicating to the registry", not "allow plain HTTP registries", as the current description ("Disable HTTPS when communicating to the registry") can let users think.

---

Today, the `RegistryInsecure` boolean in the config (filled from the flag) is used at two places:

1) In the `build` command: https://github.com/knative/func/blob/1e7dd33/cmd/build.go#L389

The value is simply forwarded to the `Pusher`, and is used to configure `InsecureSkipVerify`: https://github.com/knative/func/blob/1e7dd33/pkg/oci/pusher.go#L129-L135:

```go
        if p.Insecure {
		t := remote.DefaultTransport.(*http.Transport).Clone()
		t.TLSClientConfig = &tls.Config{
			InsecureSkipVerify: true,
		}
		oo = append(oo, remote.WithTransport(t))
	}
```

2) In the `deploy` command: https://github.com/knative/func/blob/1e7dd33/cmd/deploy.go#L282

The value is simply forwarded to the `fn.Client` (through `NewClient`): https://github.com/knative/func/blob/1e7dd33/cmd/client.go#L58, and then used to create the transport with `InsecureSkipVerify`:

https://github.com/knative/func/blob/1e7dd33/cmd/client.go#L96-L98

```go
func newTransport(insecureSkipVerify bool) fnhttp.RoundTripCloser {
	return fnhttp.NewRoundTripper(fnhttp.WithInsecureSkipVerify(insecureSkipVerify), fnhttp.WithOpenShiftServiceCA())
}
```

I'm pretty confident it's not used elsewhere, but I'm not familiar with the codebase, so **tell me if I've missed something**.

---

**Note**: To me, a better solution would be to completely rename this flag, to something like `--insecure-skip-verify` or `--registry-insecure-skip-verify`, as it's effectively only used to configure the `InsecureSkipVerify` booleans in HTTP transport-related parts of the code.

However, since renaming is a breaking change, I'm not sure if it can be done easily. Another approach, if we want to rename, would be to just 1) add a new flag `--insecure-skip-verify`, 2) deprecate the existing `--registry-insecure`, and 3) _eventually_ sunset `--registry-insecure`.

Internally changing the variable name from `RegistryInsecure` to `InsecureSkipVerify`, without touching the flag name, is also possible though. Tell me what you think of this.

In the meantime, changing the description is a good first step IMO to help users figuring out what this flag really means. 

**Release Note**

/

**Docs**

/