### PR TITLE
fix: mount of Docker API socket from Docker Desktop

### DIFF
--- a/pkg/docker/docker_client.go
+++ b/pkg/docker/docker_client.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/docker/cli/cli/config"
@@ -90,8 +91,8 @@ func NewClient(defaultHost string) (dockerClient client.CommonAPIClient, dockerH
 		dockerHostInRemote = ""
 	}
 
-	if isUnix && runtime.GOOS == "darwin" {
-		// A unix socket on macOS is most likely tunneled from VM,
+	if isUnix && (runtime.GOOS == "darwin" || strings.HasSuffix(dockerHost, ".docker/desktop/docker.sock")) {
+		// The unix socket is most likely tunneled from VM,
 		// so it cannot be mounted under that path.
 		dockerHostInRemote = ""
 	}

--- a/pkg/docker/docker_client_test.go
+++ b/pkg/docker/docker_client_test.go
@@ -69,10 +69,15 @@ func TestNewClient_DockerHost(t *testing.T) {
 			dockerHostEnvVar:         "unix:///some/path/docker.sock",
 			expectedRemoteDockerHost: map[string]string{"darwin": "", "windows": "", "linux": "unix:///some/path/docker.sock"},
 		},
+		{
+			name:                     "Docker Desktop",
+			dockerHostEnvVar:         "unix:///home/jdoe/.docker/desktop/docker.sock",
+			expectedRemoteDockerHost: map[string]string{"darwin": "", "windows": "", "linux": ""},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.name == "unix" && runtime.GOOS == "windows" {
+			if strings.HasPrefix(tt.dockerHostEnvVar, "unix") && runtime.GOOS == "windows" {
 				t.Skip("Windows cannot handle Unix sockets")
 			}
 


### PR DESCRIPTION
* Fixed mountpoint of docker socket for `Docker Desktop`.

fixes: #2347

```release-note
fix: buildpack build failure caused by wrong socket mount-point when using Docker Desktop
```