### PR TITLE
Optimized disk usage in GH Action for integration tests

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -10,6 +10,11 @@ jobs:
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Remove Unnecessary Software
+        run: |
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc || true
       - name: Set Environment Variables
         run: |
           echo "KUBECONFIG=${{ github.workspace }}/hack/bin/kubeconfig.yaml" >> "$GITHUB_ENV"

--- a/docs/reference/func_build.md
+++ b/docs/reference/func_build.md
@@ -67,7 +67,7 @@ func build
       --platform string        Optionally specify a target platform, for example "linux/amd64" when using the s2i build strategy
   -u, --push                   Attempt to push the function image to the configured registry after being successfully built
   -r, --registry string        Container registry + registry namespace. (ex 'ghcr.io/myuser').  The full image name is automatically determined using this along with function name. ($FUNC_REGISTRY)
-      --registry-insecure      Disable HTTPS when communicating to the registry ($FUNC_REGISTRY_INSECURE)
+      --registry-insecure      Skip TLS certificate verification when communicating in HTTPS with the registry ($FUNC_REGISTRY_INSECURE)
   -v, --verbose                Print verbose logs ($FUNC_VERBOSE)
 ```
 

--- a/docs/reference/func_deploy.md
+++ b/docs/reference/func_deploy.md
@@ -131,7 +131,7 @@ func deploy
   -u, --push                     Push the function image to registry before deploying. ($FUNC_PUSH) (default true)
       --pvc-size string          When triggering a remote deployment, set a custom volume size to allocate for the build operation ($FUNC_PVC_SIZE)
   -r, --registry string          Container registry + registry namespace. (ex 'ghcr.io/myuser').  The full image name is automatically determined using this along with function name. ($FUNC_REGISTRY)
-      --registry-insecure        Disable HTTPS when communicating to the registry ($FUNC_REGISTRY_INSECURE)
+      --registry-insecure        Skip TLS certificate verification when communicating in HTTPS with the registry ($FUNC_REGISTRY_INSECURE)
   -R, --remote                   Trigger a remote deployment. Default is to deploy and build from the local system ($FUNC_REMOTE)
       --service-account string   Service account to be used in the deployed function ($FUNC_SERVICE_ACCOUNT)
   -v, --verbose                  Print verbose logs ($FUNC_VERBOSE)

--- a/pkg/pipelines/tekton/gitlab_test.go
+++ b/pkg/pipelines/tekton/gitlab_test.go
@@ -240,24 +240,13 @@ func setupGitlabEnv(ctx context.Context, t *testing.T, baseURL, username, passwo
 	if err != nil {
 		t.Fatal(err)
 	}
-	// For some reason the setting update does not kick in immediately.
 
-	ticker := time.NewTicker(time.Second)
-out:
-	for {
-		select {
-		case <-ctx.Done():
-			t.Fatal("cancelled")
-		case <-ticker.C:
-			s, _, e := glabCli.Settings.GetSettings()
-			if e != nil {
-				t.Fatal(e)
-			}
-			if s != nil && s.AllowLocalRequestsFromWebHooksAndServices {
-				ticker.Stop()
-				break out
-			}
-		}
+	// For some reason the setting update does not kick in immediately.
+	select {
+	case <-time.After(time.Second * 30):
+		break
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
 	}
 
 	//endregion


### PR DESCRIPTION
# Changes

- Optimized disk usage for integration tests in GH Action by deleting unnecessary software (.NET, Haskell, Android SDK). This saves cca 11GB.
- Update generated documentation since it was not updated in PR that modified flags and thus documentation.
- Added timeout in test to wait until gitlab setting modification is in effect.
 