### PR TITLE
fix: codegen does not use current ns

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 source "$(go run knative.dev/hack/cmd/script library.sh)"
 
-go run ${REPO_ROOT_DIR}/docs/generator/main.go
+KUBECONFIG="$(mktemp)" go run ${REPO_ROOT_DIR}/docs/generator/main.go
 
 # Make sure our dependencies are up-to-date
 ${REPO_ROOT_DIR}/hack/update-deps.sh


### PR DESCRIPTION
Force empty kubeconfig so default namespace in --help is "default" not the current kubeconfig context.

This is required since otherwise `./hack/verify-codegen.sh` would fail on machines where kubectl context NS is other  than `default`.