### PR TITLE
corrected error msg

### DIFF
--- a/pkg/knative/deployer.go
+++ b/pkg/knative/deployer.go
@@ -966,7 +966,7 @@ func checkResourcesArePresent(ctx context.Context, namespace string, referencedS
 		_, err := k8s.GetSecret(ctx, s, namespace)
 		if err != nil {
 			if errors.IsForbidden(err) {
-				errMsg += fmt.Sprintf("  Ensure that the service account has the necessary permissions to access the secret.\n")
+				errMsg += " Ensure that the service account has the necessary permissions to access the secret.\n"
 			} else {
 				errMsg += fmt.Sprintf("  referenced Secret \"%s\" is not present in namespace \"%s\"\n", s, namespace)
 			}

--- a/pkg/knative/deployer.go
+++ b/pkg/knative/deployer.go
@@ -965,7 +965,11 @@ func checkResourcesArePresent(ctx context.Context, namespace string, referencedS
 	for s := range *referencedSecrets {
 		_, err := k8s.GetSecret(ctx, s, namespace)
 		if err != nil {
-			errMsg += fmt.Sprintf("  referenced Secret \"%s\" is not present in namespace \"%s\"\n", s, namespace)
+			if errors.IsForbidden(err) {
+				errMsg += fmt.Sprintf("  Ensure that the service account has the necessary permissions to access the secret.\n")
+			} else {
+				errMsg += fmt.Sprintf("  referenced Secret \"%s\" is not present in namespace \"%s\"\n", s, namespace)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2257


<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
