### PR TITLE
Adding GO s2i to e2e test suite

### DIFF
--- a/test/e2e/scenario_runtime-http_test.go
+++ b/test/e2e/scenario_runtime-http_test.go
@@ -17,7 +17,7 @@ import (
 
 var runtimeSupportMap = map[string][]string{
 	"node":       {"pack", "s2i"},
-	"go":         {"pack"},
+	"go":         {"pack", "s2i"},
 	"rust":       {"pack"},
 	"python":     {"pack", "s2i"},
 	"quarkus":    {"pack", "s2i"},


### PR DESCRIPTION
# Changes

- Add e2e tests for Go functions using s2i builder (**except** for OnCluster builds scenarios)
