### PR TITLE
Fix failure in GHA caused by missing cargo bin

### DIFF
--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -29,6 +29,10 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
       - name: Core Unit Tests
         run: make test
         env:


### PR DESCRIPTION
It appears that the cargo in no longer part of GHA image at least for macOS.

