### PR TITLE
allow digested images to be 'run'

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -192,7 +192,7 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 		return
 	}
 	if cfg.Push {
-		if f, err = client.Push(cmd.Context(), f); err != nil {
+		if f, _, err = client.Push(cmd.Context(), f); err != nil {
 			return
 		}
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -336,7 +336,6 @@ func runDeploy(cmd *cobra.Command, newClient ClientFactory) (err error) {
 			return
 		}
 	}
-	fmt.Printf("DEPLOY IMAGE BEFORE WRITE: %v\n", f.Deploy.Image)
 
 	// Write
 	if err = f.Write(); err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -786,7 +786,7 @@ func printDeployMessages(out io.Writer, f fn.Function) {
 // func isUndigested(v string) (validTag bool, err error) {
 // 	if v == "" {
 // 		// specif image was not given
-// 		err = fmt.Errorf("provided image is emtpy")
+// 		err = fmt.Errorf("provided image is empty")
 // 		return
 // 	}
 // 	if strings.Contains(v, "@") {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -868,29 +868,3 @@ func isDigested(v string) (validDigest bool, err error) {
 	validDigest = true
 	return
 }
-
-// processImageName processes the image name for deployment. It ensures that
-// image string is validated if --image was given and ensures that proper
-// fields of Function structure are populated if needed.
-// Returns a Function structure(1), bool indicating if image was given with
-// digest(2) and error(3)
-func processImageName(f fn.Function, configImage string) (fn.Function, bool, error) {
-	var (
-		digested bool
-		err      error
-	)
-
-	// check if --image was provided with a digest. 'digested' bool indicates if
-	// image contains a digest or not (image is "digested").
-	digested, err = isDigested(configImage)
-	// image is digested, no need to process further || error occurred
-	if digested || err != nil {
-		return f, digested, err
-	}
-
-	// assign valid, undigested image as deployed image before any other changes.
-	// This can be overridden when build&push=enabled with freshly built image
-	// OR directly deployed when build&push=disabled as is.
-	f.Deploy.Image = configImage
-	return f, digested, err
-}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -370,6 +370,8 @@ func build(cmd *cobra.Command, flag string, f fn.Function, client *fn.Client, bu
 		if f, err = client.Build(cmd.Context(), f, buildOptions...); err != nil {
 			return f, false, err
 		}
+	} else if !build {
+		return f, false, nil
 	} else if _, err = strconv.ParseBool(flag); err != nil {
 		return f, false, fmt.Errorf("--build ($FUNC_BUILD) %q not recognized.  Should be 'auto' or a truthy value such as 'true', 'false', '0', or '1'.", flag)
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -334,14 +334,11 @@ func runDeploy(cmd *cobra.Command, newClient ClientFactory) (err error) {
 			// TODO: gauron99 - temporary fix for undigested image direct deploy
 			// (w/out build) This might be more complex to do than leaving like this
 			// image digests are created via the registry on push.
-			fmt.Printf("justBuilt '%v'; justPushed '%v'\n", justBuilt, justPushed)
-			fmt.Printf("builtImage '%v'; deployimage '%v'\n", f.Build.Image, f.Deploy.Image)
 			if (justBuilt || justPushed) && f.Build.Image != "" {
 				// f.Build.Image is set in Push for now, just set it as a deployed image
 				f.Deploy.Image = f.Build.Image
 			}
 		}
-		fmt.Printf("builtImage '%v'; deployimage '%v'\n", f.Build.Image, f.Deploy.Image)
 		if f, err = client.Deploy(cmd.Context(), f, fn.WithDeploySkipBuildCheck(cfg.Build == "false")); err != nil {
 			return
 		}
@@ -786,39 +783,6 @@ func printDeployMessages(out io.Writer, f fn.Function) {
 		fmt.Fprintf(out, "Warning: git settings are only applicable when running with --remote.  Local source code will be used.")
 	}
 }
-
-// isUndigested returns true if provided image string 'v' is valid ( by
-// by acceptable standards -- tagged, untagged -> assuming :latest) and false if
-// not. It is lenient in validating - does not always throw an error, just
-// returning false in some scenarios.
-// func isUndigested(v string) (validTag bool, err error) {
-// 	if v == "" {
-// 		// specif image was not given
-// 		err = fmt.Errorf("provided image is empty")
-// 		return
-// 	}
-// 	if strings.Contains(v, "@") {
-// 		// digest has been processed separately
-// 		return
-// 	}
-// 	vv := strings.Split(v, ":")
-// 	if len(vv) < 2 {
-// 		// assume user knows what hes doing
-// 		validTag = true
-// 		return
-// 	} else if len(vv) > 2 {
-// 		err = fmt.Errorf("image '%v' contains an invalid tag (extra ':')", v)
-// 		return
-// 	}
-// 	tag := vv[1]
-// 	if tag == "" {
-// 		err = fmt.Errorf("image '%v' has an empty tag", v)
-// 		return
-// 	}
-
-// 	validTag = true
-// 	return
-// }
 
 // isDigested returns true if provided image string 'v' has digest and false if not.
 // Includes basic validation that a provided digest is correctly formatted.

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -775,7 +775,8 @@ func printDeployMessages(out io.Writer, f fn.Function) {
 	}
 }
 
-// isUndigested returns true if provided image string 'v' has valid tag and false if
+// isUndigested returns true if provided image string 'v' is valid ( by
+// by acceptable standards -- tagged, untagged -> assuming :latest) and false if
 // not. It is lenient in validating - does not always throw an error, just
 // returning false in some scenarios.
 func isUndigested(v string) (validTag bool, err error) {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -780,6 +780,10 @@ func printDeployMessages(out io.Writer, f fn.Function) {
 // not. It is lenient in validating - does not always throw an error, just
 // returning false in some scenarios.
 func isUndigested(v string) (validTag bool, err error) {
+	if v == "" {
+		// specif image was not given
+		return
+	}
 	if strings.Contains(v, "@") {
 		// digest has been processed separately
 		return

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -372,7 +372,6 @@ func build(cmd *cobra.Command, flag string, f fn.Function, client *fn.Client, bu
 	} else if _, err = strconv.ParseBool(flag); err != nil {
 		return f, false, fmt.Errorf("--build ($FUNC_BUILD) %q not recognized.  Should be 'auto' or a truthy value such as 'true', 'false', '0', or '1'.", flag)
 	} else if !build {
-		fmt.Printf("didnt currently build anything but no errors either\n")
 		return f, false, nil
 	}
 	return f, true, nil

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -677,10 +677,6 @@ func (c deployConfig) Validate(cmd *cobra.Command) (err error) {
 		return
 	}
 
-	if _, err = isTagged(c.Image); err != nil {
-		return
-	}
-
 	// --build can be "auto"|true|false
 	if c.Build != "auto" {
 		if _, err := strconv.ParseBool(c.Build); err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -336,6 +336,7 @@ func runDeploy(cmd *cobra.Command, newClient ClientFactory) (err error) {
 			return
 		}
 	}
+	fmt.Printf("DEPLOY IMAGE BEFORE WRITE: %v\n", f.Deploy.Image)
 
 	// Write
 	if err = f.Write(); err != nil {
@@ -677,10 +678,9 @@ func (c deployConfig) Validate(cmd *cobra.Command) (err error) {
 		return
 	}
 
-	// TODO: gauron99
-	// if _, err = isTagged(c.Image); err != nil {
-	// 	return
-	// }
+	if _, err = isTagged(c.Image); err != nil {
+		return
+	}
 
 	// --build can be "auto"|true|false
 	if c.Build != "auto" {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -677,6 +677,11 @@ func (c deployConfig) Validate(cmd *cobra.Command) (err error) {
 		return
 	}
 
+	// TODO: gauron99
+	// if _, err = isTagged(c.Image); err != nil {
+	// 	return
+	// }
+
 	// --build can be "auto"|true|false
 	if c.Build != "auto" {
 		if _, err := strconv.ParseBool(c.Build); err != nil {

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -2042,7 +2042,6 @@ func TestDeploy_AfterBuild(t *testing.T) {
 
 	deployer := mock.NewDeployer()
 	deployer.DeployFn = func(_ context.Context, f fn.Function) (result fn.DeploymentResult, err error) {
-		fmt.Printf("IMAGE IN DEPLOYER IS %v\n", f.Deploy.Image)
 		if f.Deploy.Image == "" {
 			return fn.DeploymentResult{}, fmt.Errorf("image was not set for deployer")
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -173,24 +173,17 @@ func runRun(cmd *cobra.Command, newClient ClientFactory) (err error) {
 	defer done()
 
 	var (
-		digested        bool
-		validUndigested bool
-		justBuilt       bool
+		digested  bool
+		justBuilt bool
 	)
 
-	// check for digested image first
-	digested, err = isDigested(cfg.Image)
-	if err != nil {
-		return err
-	}
-
-	if !digested {
-		validUndigested, err = isUndigested(cfg.Image)
+	// if image was specified, check if its digested and do basic validation
+	if cfg.Image != "" {
+		digested, err = isDigested(cfg.Image)
 		if err != nil {
 			return err
 		}
 	}
-
 	// Build
 	//
 	// If requesting to run via the container, build the container if it is
@@ -209,7 +202,7 @@ func runRun(cmd *cobra.Command, newClient ClientFactory) (err error) {
 			if f, justBuilt, err = build(cmd, cfg.Build, f, client, buildOptions); err != nil {
 				return err
 			}
-			if !justBuilt && validUndigested {
+			if !justBuilt && !digested {
 				f.Build.Image = cfg.Image
 			}
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -172,6 +172,14 @@ func runRun(cmd *cobra.Command, newClient ClientFactory) (err error) {
 	client, done := newClient(ClientConfig{Verbose: cfg.Verbose}, clientOptions...)
 	defer done()
 
+	f, digested, err := processImageName(f, cfg.Image)
+	if err != nil {
+		return
+	}
+	if digested {
+		f.Deploy.Image = cfg.Image
+	}
+
 	// Build
 	//
 	// If requesting to run via the container, build the container if it is

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -192,24 +192,19 @@ func TestRun_Images(t *testing.T) {
 			args:         []string{"--image", "exampleimage@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"},
 			runInvoked:   true,
 			buildInvoked: false,
-			runError:     nil,
-			buildError:   nil,
 		},
 		{
 			name:         "image with tag direct deploy",
 			args:         []string{"--image", "exampleimage:latest", "--build=false"},
 			runInvoked:   true,
 			buildInvoked: false,
-			runError:     nil,
-			buildError:   nil,
 		},
 		{
-			name:         "image without tag direct deploy",
-			args:         []string{"--image", "exampleimage", "--build=false"},
-			runInvoked:   true,
+			name:         "digested image without container should fail",
+			args:         []string{"--container=false", "--image", "exampleimage@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"},
+			runInvoked:   false,
 			buildInvoked: false,
-			runError:     nil,
-			buildError:   nil,
+			buildError:   fmt.Errorf("cannot use digested image with --container=false"),
 		},
 	}
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -195,7 +195,7 @@ func TestRun_Images(t *testing.T) {
 		},
 		{
 			name:         "image with tag direct deploy",
-			args:         []string{"--image", "exampleimage:latest", "--build=false"},
+			args:         []string{"--image", "username/exampleimage:latest", "--build=false"},
 			runInvoked:   true,
 			buildInvoked: false,
 		},
@@ -205,6 +205,12 @@ func TestRun_Images(t *testing.T) {
 			runInvoked:   false,
 			buildInvoked: false,
 			buildError:   fmt.Errorf("cannot use digested image with --container=false"),
+		},
+		{
+			name:         "image should build even with tagged image given",
+			args:         []string{"--image", "username/exampleimage:latest"},
+			runInvoked:   true,
+			buildInvoked: true,
 		},
 	}
 

--- a/pkg/docker/runner_int_test.go
+++ b/pkg/docker/runner_int_test.go
@@ -24,21 +24,24 @@ import (
 
 const displayEventImg = "gcr.io/knative-releases/knative.dev/eventing/cmd/event_display@sha256:610234e4319b767b187398085971d881956da660a4e0fab65a763e0f81881d82"
 
+// public image from repo (author: github.com/gauron99)
+const testImageWithDigest = "index.docker.io/4141gauron3268/teste-builder@sha256:4cf9eddf34f14cc274364a4ae60274301385d470de1fb91cbc6fec1227daa739"
+
 func TestRun(t *testing.T) {
 	root, cleanup := Mktemp(t)
 	defer cleanup()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
 	t.Cleanup(cancel)
-
-	prePullTestImages(t)
+	image := displayEventImg
+	prePullTestImages(t, image)
 
 	// No need to check for port 8080 since the runner should automatically
 	// choose an open port, with 8080 only being the preferred first choice.
 
 	// Initialize a new function (creates all artifacts on disk necessary
 	// to perform actions such as running)
-	f := fn.Function{Runtime: "go", Root: root, Image: displayEventImg}
+	f := fn.Function{Runtime: "go", Root: root, Image: image}
 
 	client := fn.New()
 	f, err := client.Init(f)
@@ -95,13 +98,92 @@ func TestRun(t *testing.T) {
 	}
 }
 
-func prePullTestImages(t *testing.T) {
+// TestRunDigested ensures that passing a digested image to the runner will deploy
+// that image instead of the previously built one. This test is depended on the
+// specific image since its verifying the function's output.
+func TestRunDigested(t *testing.T) {
+	root, cleanup := Mktemp(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
+	t.Cleanup(cancel)
+
+	image := testImageWithDigest
+	prePullTestImages(t, image)
+
+	f := fn.Function{Runtime: "go", Root: root}
+
+	client := fn.New()
+	f, err := client.Init(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// prebuild default image
+	f, err = client.Build(ctx, f)
+
+	// simulate passing image from --image flag since client.Run just sets
+	// a timeout and simply calls runner.Run.
+	f.Build.Image = image
+
+	// Run the function using a docker runner
+	var out, errOut bytes.Buffer
+	runner := docker.NewRunner(true, &out, &errOut)
+	j, err := runner.Run(ctx, f, fn.DefaultStartTimeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = j.Stop() })
+	time.Sleep(time.Second * 5)
+
+	var (
+		id  = "runner-my-id"
+		src = "runner-my-src"
+		typ = "runner-my-type"
+	)
+
+	event := cloudevents.NewEvent()
+	event.SetID(id)
+	event.SetSource(src)
+	event.SetType(typ)
+
+	c, err := cloudevents.NewClientHTTP(cloudevents.WithTarget("http://localhost:" + j.Port))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var httpErr *http.Result
+	res := c.Send(ctx, event)
+	if ok := errors.As(res, &httpErr); ok {
+		if httpErr.StatusCode < 200 || httpErr.StatusCode > 299 {
+			t.Fatal("non 2XX code")
+		}
+	} else {
+		t.Error("expected http.Result type")
+	}
+	time.Sleep(time.Second * 5)
+
+	t.Log("out: ", out.String())
+	t.Log("errOut: ", errOut.String())
+
+	outStr := out.String()
+
+	if !(strings.Contains(outStr, id) && strings.Contains(outStr, src) && strings.Contains(outStr, typ)) {
+		t.Error("output doesn't contain invocation info")
+	}
+
+	if !(strings.Contains(outStr, "testing the waters - serverside")) {
+		t.Error("output doesn't contain expected text")
+	}
+}
+
+func prePullTestImages(t *testing.T, img string) {
 	t.Helper()
 	c, _, err := docker.NewClient(dockerClient.DefaultDockerHost)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err := c.ImagePull(context.Background(), displayEventImg, types.ImagePullOptions{})
+	resp, err := c.ImagePull(context.Background(), img, types.ImagePullOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/docker/runner_int_test.go
+++ b/pkg/docker/runner_int_test.go
@@ -108,6 +108,10 @@ func TestRunDigested(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
 	t.Cleanup(cancel)
 
+	// TODO: gauron99 - if image-digest-on-build is implemented, rework this
+	// to fit this schema -- build image (get digest) then run from temporary dir
+	// such that its .func stamp is not considered. All of this to remove the
+	// external pre-built container dependency
 	image := testImageWithDigest
 	prePullTestImages(t, image)
 

--- a/pkg/functions/client.go
+++ b/pkg/functions/client.go
@@ -456,7 +456,7 @@ func (c *Client) Update(ctx context.Context, f Function) (string, Function, erro
 	if f, err = c.Build(ctx, f); err != nil {
 		return "", f, err
 	}
-	if f, err = c.Push(ctx, f); err != nil {
+	if f, _, err = c.Push(ctx, f); err != nil {
 		return "", f, err
 	}
 
@@ -505,7 +505,7 @@ func (c *Client) New(ctx context.Context, cfg Function) (string, Function, error
 	// Push the produced function image
 	fmt.Fprintf(os.Stderr, "Pushing container image to registry\n")
 
-	if f, err = c.Push(ctx, f); err != nil {
+	if f, _, err = c.Push(ctx, f); err != nil {
 		return route, f, err
 	}
 
@@ -739,6 +739,8 @@ func WithDeploySkipBuildCheck(skipBuiltCheck bool) DeployOption {
 // Errors if the function has not been built unless explicitly instructed
 // to ignore this build check.
 func (c *Client) Deploy(ctx context.Context, f Function, oo ...DeployOption) (Function, error) {
+	fmt.Fprintf(os.Stderr, ">> deploying image: %s\n", f.Deploy.Image)
+
 	options := &DeployOptions{}
 	for _, o := range oo {
 		o(options)
@@ -1071,15 +1073,17 @@ func (c *Client) Invoke(ctx context.Context, root string, target string, m Invok
 }
 
 // Push the image for the named service to the configured registry
-func (c *Client) Push(ctx context.Context, f Function) (Function, error) {
+// returns in this order: 1)Function structure 2)bool indicating if push succeeded
+// 3) error
+func (c *Client) Push(ctx context.Context, f Function) (Function, bool, error) {
 	if !f.Built() {
-		return f, ErrNotBuilt
+		return f, false, ErrNotBuilt
 	}
 	var err error
 
 	imageDigest, err := c.pusher.Push(ctx, f)
 	if err != nil {
-		return f, err
+		return f, false, err
 	}
 
 	// TODO: gauron99 - this is here because of a temporary workaround.
@@ -1089,7 +1093,7 @@ func (c *Client) Push(ctx context.Context, f Function) (Function, error) {
 	// the full image name and its digest right after building
 	f.Build.Image = f.ImageNameWithDigest(imageDigest)
 
-	return f, err
+	return f, true, err
 }
 
 // ensureRunDataDir creates a .func directory at the given path, and

--- a/pkg/functions/client.go
+++ b/pkg/functions/client.go
@@ -739,7 +739,6 @@ func WithDeploySkipBuildCheck(skipBuiltCheck bool) DeployOption {
 // Errors if the function has not been built unless explicitly instructed
 // to ignore this build check.
 func (c *Client) Deploy(ctx context.Context, f Function, oo ...DeployOption) (Function, error) {
-	fmt.Fprintf(os.Stderr, ">> deploying image: %s\n", f.Deploy.Image)
 
 	options := &DeployOptions{}
 	for _, o := range oo {

--- a/pkg/functions/client_int_test.go
+++ b/pkg/functions/client_int_test.go
@@ -124,7 +124,7 @@ func TestDeploy_Defaults(t *testing.T) {
 	if f, err = client.Build(context.Background(), f); err != nil {
 		t.Fatal(err)
 	}
-	if f, err = client.Push(context.Background(), f); err != nil {
+	if f, _, err = client.Push(context.Background(), f); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/oci/pusher_test.go
+++ b/pkg/oci/pusher_test.go
@@ -74,7 +74,7 @@ func TestPusher_Push(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err = client.Push(context.Background(), f); err != nil {
+	if _, _, err = client.Push(context.Background(), f); err != nil {
 		t.Fatal(err)
 	}
 
@@ -152,7 +152,7 @@ func TestPusher_BasicAuth(t *testing.T) {
 	ctx = context.WithValue(ctx, fn.PushUsernameKey{}, username)
 	ctx = context.WithValue(ctx, fn.PushPasswordKey{}, password)
 
-	if _, err = client.Push(ctx, f); err != nil {
+	if _, _, err = client.Push(ctx, f); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
In order to match the `deploy` command, make it possible to `run` digested images as well when building into the container

## changes

### run (`func run`) images directly ~ for convenience 
Ive added a way to use digested/ valid undigested images to be run using `func run` cmd. With`--build=false` one can also run the undigested images directly via skipping the build and using the `--image` for the image name that they want to deploy.

### tests
Ive also added tests that cover which image gets passed on to `.Build.Image` (which is the image used for the runner) and therefore what image actually gets "run".

### new `client.Push` return value
Added a return value to `client.Push` which now matches build function (bool indicating if the current push/build was successful or not) 

todo:
- [x] digested image deploys correct image (`.Build.Image`) when `--container=true`
- [x] undigested images direct deploy only with `--build=false` flag