### PR TITLE
Updated git-clone task

### DIFF
--- a/pkg/pipelines/tekton/tasks.go
+++ b/pkg/pipelines/tekton/tasks.go
@@ -66,7 +66,7 @@ spec:
       default: "1001"
     - name: GROUP_ID
       description: The group ID of the builder image user.
-      default: "0"
+      default: "65532"
       ##############################################################
       #####  "default" has been changed to "0" for Knative Functions
     - name: PLATFORM_DIR
@@ -107,6 +107,8 @@ spec:
               chmod 775 "$(workspaces.source.path)"
           fi
         done
+
+        chmod -R g+w "$(workspaces.source.path)"
 
         echo "> Parsing additional configuration..."
         parsing_flag=""
@@ -187,7 +189,7 @@ spec:
         runAsUser: 1001
         #################################################################
         #####  "runAsGroup" has been changed to "0" for Knative Functions
-        runAsGroup: 0
+        runAsGroup: 65532
 
     - name: results
       image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6

--- a/pkg/pipelines/tekton/templates.go
+++ b/pkg/pipelines/tekton/templates.go
@@ -57,7 +57,7 @@ const (
           - name: name
             value: git-clone
           - name: version
-            value: "0.4"
+            value: "0.9"
       workspaces:
         - name: output
           workspace: source-workspace`

--- a/pkg/pipelines/tekton/templates_pack.go
+++ b/pkg/pipelines/tekton/templates_pack.go
@@ -103,6 +103,9 @@ metadata:
     {{end}}
   generateName: {{.PipelineRunName}}
 spec:
+  podTemplate:
+    securityContext:
+      fsGroup: 65532
   params:
     - name: gitRepository
       value: {{.RepoUrl}}

--- a/pkg/pipelines/tekton/templates_s2i.go
+++ b/pkg/pipelines/tekton/templates_s2i.go
@@ -108,6 +108,9 @@ metadata:
     {{end}}
   generateName: {{.PipelineRunName}}
 spec:
+  podTemplate:
+    securityContext:
+      fsGroup: 65532
   params:
     - name: gitRepository
       value: {{.RepoUrl}}


### PR DESCRIPTION
# Changes

- Updated git fetch task to newer version that is now rootless.

This changes are also already included in the "Go s2i on cluster build" PR.