### PR TITLE
On cluster s2i build for Go (alternative version)

### DIFF
--- a/Dockerfile.utils
+++ b/Dockerfile.utils
@@ -17,9 +17,7 @@ RUN GOARCH=$TARGETARCH go build -o func-util -trimpath -ldflags '-w -s' ./cmd/fu
 
 FROM --platform=$TARGETPLATFORM index.docker.io/library/alpine:latest
 
-RUN apk add --no-cache socat tar \
-  && addgroup func -g 1000 \
-  && adduser func -u 1001 -D -G func
+RUN apk add --no-cache socat tar
 
 COPY --from=builder /workspace/func-util /usr/local/bin/
 RUN ln -s /usr/local/bin/func-util /usr/local/bin/deploy && \
@@ -31,4 +29,4 @@ LABEL \
    org.opencontainers.image.vendor="https://github.com/knative/func" \
    org.opencontainers.image.url="https://github.com/knative/func/pkgs/container/func-utils"
 
-USER func:func
+USER 0:0

--- a/Dockerfile.utils
+++ b/Dockerfile.utils
@@ -4,6 +4,11 @@ ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETARCH
 
+WORKDIR /workspace
+
+COPY go.mod go.sum ./
+RUN go mod download -x
+
 COPY . .
 
 RUN GOARCH=$TARGETARCH go build -o func-util -trimpath -ldflags '-w -s' ./cmd/func-util
@@ -16,7 +21,7 @@ RUN apk add --no-cache socat tar \
   && addgroup func -g 1000 \
   && adduser func -u 1001 -D -G func
 
-COPY --from=builder /go/func-util /usr/local/bin/
+COPY --from=builder /workspace/func-util /usr/local/bin/
 RUN ln -s /usr/local/bin/func-util /usr/local/bin/deploy && \
     ln -s /usr/local/bin/func-util /usr/local/bin/scaffold
 

--- a/Dockerfile.utils
+++ b/Dockerfile.utils
@@ -17,7 +17,8 @@ RUN apk add --no-cache socat tar \
   && adduser func -u 1001 -D -G func
 
 COPY --from=builder /go/func-util /usr/local/bin/
-RUN ln -s /usr/local/bin/func-util /usr/local/bin/deploy
+RUN ln -s /usr/local/bin/func-util /usr/local/bin/deploy && \
+    ln -s /usr/local/bin/func-util /usr/local/bin/scaffold
 
 LABEL \
    org.opencontainers.image.description="Knative Func Utils Image" \

--- a/Dockerfile.utils
+++ b/Dockerfile.utils
@@ -6,7 +6,7 @@ ARG TARGETARCH
 
 COPY . .
 
-RUN GOARCH=$TARGETARCH go build -o deploy -trimpath -ldflags '-w -s' ./cmd/func-deployer
+RUN GOARCH=$TARGETARCH go build -o func-util -trimpath -ldflags '-w -s' ./cmd/func-util
 
 #########################
 
@@ -16,7 +16,8 @@ RUN apk add --no-cache socat tar \
   && addgroup func -g 1000 \
   && adduser func -u 1001 -D -G func
 
-COPY --from=builder /go/deploy /usr/local/bin/
+COPY --from=builder /go/func-util /usr/local/bin/
+RUN ln -s /usr/local/bin/func-util /usr/local/bin/deploy
 
 LABEL \
    org.opencontainers.image.description="Knative Func Utils Image" \

--- a/cmd/func-util/main.go
+++ b/cmd/func-util/main.go
@@ -25,12 +25,24 @@ func main() {
 		os.Exit(137)
 	}()
 
-	err := deploy(ctx)
+	var cmd func(context.Context) error = unknown
+
+	switch os.Args[0] {
+	case "deploy":
+		cmd = deploy
+	}
+
+	err := cmd(ctx)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
 		os.Exit(1)
 	}
 }
+
+func unknown(_ context.Context) error {
+	return fmt.Errorf("unknown command: " + os.Args[0])
+}
+
 func deploy(ctx context.Context) error {
 	var err error
 	deployer := knative.NewDeployer(

--- a/cmd/func-util/main.go
+++ b/cmd/func-util/main.go
@@ -83,7 +83,7 @@ func scaffold(ctx context.Context) error {
 		return fmt.Errorf("unable to create .s2i bin dir. %w", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(f.Root, ".s2i", "bin", "assemble"), []byte(s2i.GoAssembler), 0700); err != nil {
+	if err := os.WriteFile(filepath.Join(f.Root, ".s2i", "bin", "assemble"), []byte(s2i.GoAssembler), 0755); err != nil {
 		return fmt.Errorf("unable to write go assembler. %w", err)
 	}
 

--- a/cmd/func-util/main.go
+++ b/cmd/func-util/main.go
@@ -61,8 +61,8 @@ func scaffold(ctx context.Context) error {
 		return fmt.Errorf("cannot load func project: %w", err)
 	}
 
-	if f.Runtime != "go" || f.Build.Builder != "s2i" {
-		// Scaffolding is for now supported/needed only for Go S2I build.
+	if f.Runtime != "go" {
+		// Scaffolding is for now supported/needed only for Go.
 		return nil
 	}
 

--- a/pkg/pipelines/tekton/tasks.go
+++ b/pkg/pipelines/tekton/tasks.go
@@ -321,7 +321,7 @@ spec:
         cat /env-vars/env-file
         echo "------------------------------"
 
-        /usr/local/bin/s2i --loglevel=$(params.LOGLEVEL) build $(params.PATH_CONTEXT) $(params.BUILDER_IMAGE) \
+        /usr/local/bin/s2i --loglevel=$(params.LOGLEVEL) build --keep-symlinks $(params.PATH_CONTEXT) $(params.BUILDER_IMAGE) \
         --image-scripts-url $(params.S2I_IMAGE_SCRIPTS_URL) \
         --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
 
@@ -413,9 +413,34 @@ spec:
 `, DeployerImage)
 }
 
+func getScaffoldTask() string {
+	return fmt.Sprintf(`apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: func-scaffold
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: CLI
+    tekton.dev/tags: cli
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  params:
+    - name: path
+      description: Path to the function project
+      default: ""
+  steps:
+    - name: func-scaffold
+      image: %s
+      script: |
+        scaffold $(params.path)
+`, DeployerImage)
+}
+
 // GetClusterTasks returns multi-document yaml containing tekton tasks used by func.
 func GetClusterTasks() string {
-	tasks := getBuildpackTask() + "\n---\n" + getS2ITask() + "\n---\n" + getDeployTask()
+	tasks := getBuildpackTask() + "\n---\n" + getS2ITask() + "\n---\n" + getDeployTask() + "\n---\n" + getScaffoldTask()
 	tasks = strings.Replace(tasks, "kind: Task", "kind: ClusterTask", -1)
 	tasks = strings.ReplaceAll(tasks, "apiVersion: tekton.dev/v1", "apiVersion: tekton.dev/v1beta1")
 	return tasks

--- a/pkg/pipelines/tekton/templates.go
+++ b/pkg/pipelines/tekton/templates.go
@@ -99,6 +99,7 @@ type templateData struct {
 	FuncBuildpacksTaskRef string
 	FuncS2iTaskRef        string
 	FuncDeployTaskRef     string
+	FuncScaffoldTaskRef   string
 
 	// Reference for build task - whether it should run after fetch-sources task or not
 	RunAfterFetchSources string
@@ -128,6 +129,7 @@ func createPipelineTemplatePAC(f fn.Function, labels map[string]string) error {
 		{getBuildpackTask(), &data.FuncBuildpacksTaskRef},
 		{getS2ITask(), &data.FuncS2iTaskRef},
 		{getDeployTask(), &data.FuncDeployTaskRef},
+		{getScaffoldTask(), &data.FuncScaffoldTaskRef},
 	} {
 		ts, err := getTaskSpec(val.ref)
 		if err != nil {
@@ -327,6 +329,7 @@ func createAndApplyPipelineTemplate(f fn.Function, namespace string, labels map[
 		{getBuildpackTask(), &data.FuncBuildpacksTaskRef},
 		{getS2ITask(), &data.FuncS2iTaskRef},
 		{getDeployTask(), &data.FuncDeployTaskRef},
+		{getScaffoldTask(), &data.FuncScaffoldTaskRef},
 	} {
 		ts, err := getTaskSpec(val.ref)
 		if err != nil {

--- a/pkg/pipelines/tekton/templates_pack.go
+++ b/pkg/pipelines/tekton/templates_pack.go
@@ -42,6 +42,15 @@ spec:
       type: array
   tasks:
     {{.GitCloneTaskRef}}
+    - name: scaffold
+      params:
+        - name: path
+          value: $(workspaces.source.path)/$(params.contextDir)
+      workspaces:
+        - name: source
+          workspace: source-workspace
+      {{.RunAfterFetchSources}}
+      {{.FuncScaffoldTaskRef}}
     - name: build
       params:
         - name: APP_IMAGE
@@ -55,7 +64,8 @@ spec:
         - name: ENV_VARS
           value:
             - '$(params.buildEnvs[*])'
-      {{.RunAfterFetchSources}}
+      runAfter:
+        - scaffold
       {{.FuncBuildpacksTaskRef}}
       workspaces:
         - name: source

--- a/pkg/pipelines/tekton/templates_s2i.go
+++ b/pkg/pipelines/tekton/templates_s2i.go
@@ -46,6 +46,15 @@ spec:
       default: 'image:///usr/libexec/s2i'
   tasks:
     {{.GitCloneTaskRef}}
+    - name: scaffold
+      params:
+        - name: path
+          value: $(workspaces.source.path)/$(params.contextDir)
+      workspaces:
+        - name: source
+          workspace: source-workspace
+      {{.RunAfterFetchSources}}
+      {{.FuncScaffoldTaskRef}}
     - name: build
       params:
         - name: IMAGE
@@ -61,7 +70,8 @@ spec:
             - '$(params.buildEnvs[*])'
         - name: S2I_IMAGE_SCRIPTS_URL
           value: $(params.s2iImageScriptsUrl)
-      {{.RunAfterFetchSources}}
+      runAfter:
+        - scaffold
       {{.FuncS2iTaskRef}}
       workspaces:
         - name: source

--- a/test/oncluster/scenario_runtime_test.go
+++ b/test/oncluster/scenario_runtime_test.go
@@ -15,7 +15,7 @@ import (
 
 var runtimeSupportMap = map[string][]string{
 	"node":       {"pack", "s2i"},
-	"go":         {"pack"},
+	"go":         {"pack", "s2i"},
 	"rust":       {"pack"},
 	"python":     {"pack", "s2i"},
 	"quarkus":    {"pack", "s2i"},

--- a/test/oncluster/scenario_runtime_test.go
+++ b/test/oncluster/scenario_runtime_test.go
@@ -15,7 +15,7 @@ import (
 
 var runtimeSupportMap = map[string][]string{
 	"node":       {"pack", "s2i"},
-	"go":         {"pack", "s2i"},
+	"go":         {"pack"},
 	"rust":       {"pack"},
 	"python":     {"pack", "s2i"},
 	"quarkus":    {"pack", "s2i"},


### PR DESCRIPTION
# Changes 

- :gift: Enabled on-cluster s2i build for Go by adding scaffolding task into the tekton pipeline.

This is alternative version where the util image is rootfull. Since git and buildpack are already rootfull I don't see any issue with this. In addition this does not require FSGroup setting which makes it easier to port it in midstream. For OCP we would have to remove the FSGroup part in midstream patching process.

/kind enhancement

Fixes #2443

```release-note
feat: enabled on-cluster s2i build for Go
```
