### PR TITLE
test: preventing dubios ownership repository error on git unit tests

### DIFF
--- a/pkg/testing/testing.go
+++ b/pkg/testing/testing.go
@@ -143,6 +143,13 @@ func ServeRepo(name string, t *testing.T) string {
 		repo   = filepath.Base(path)
 		url    = RunGitServer(abs, t)
 	)
+	// This is to prevent "fatal: detected dubious ownership in repository at <source_reposutory_path>" while executing
+	// unit tests on other environments (such as Prow CI)
+	cmd := exec.Command("git", "config", "--global", "--add", "safe.directory", abs)
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
 	return fmt.Sprintf("%v/%v", url, repo)
 }
 


### PR DESCRIPTION
# Changes

This chages are meant to preventing dubios ownership repository error on git unit tests (running on Prow/CI)

Sample error observed on midstream CI
```
--- FAIL: TestTemplates_Remote (0.01s)
    templates_test.go:184: failed to get repository from URI ("http://127.0.0.1:38599/repository.git"): failed to clone repository: unexpected client error: unexpected requesting "http://127.0.0.1:38599/repository.git/info/refs?service=git-upload-pack" status code: 500
fatal: detected dubious ownership in repository at '/go/src/github.com/openshift-knative/kn-plugin-func/pkg/functions/testdata/repository.git'
To add an exception for this directory, call:

	git config --global --add safe.directory /go/src/github.com/openshift-knative/kn-plugin-func/pkg/functions/testdata/repository.git
```