### PR TITLE
Improve socat connection success detection using KMP

### DIFF
--- a/pkg/k8s/dialer_unit_test.go
+++ b/pkg/k8s/dialer_unit_test.go
@@ -1,0 +1,24 @@
+package k8s
+
+import (
+	"testing"
+)
+
+func TestDetectSocatSuccess(t *testing.T) {
+	ch := make(chan struct{}, 1)
+	w := detectConnSuccess(ch)
+	_, err := w.Write([]byte("some data successucces"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = w.Write([]byte("sfully connected"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-ch:
+		t.Log("OK")
+	default:
+		t.Error("NOK")
+	}
+}


### PR DESCRIPTION
# Changes

It appears that Go's `MatchReader()` returns `true` only if two characters are written to the writer after the searched word. Thta's mostly all right because `socat` actually writes several more lines to stderr. However this new implementation is better it should signal immediately when searched patter is written to the writer.

See: https://pkg.go.dev/github.com/agext/regexp#section-documentation
>Note that regular expression matches may need to examine text beyond the text returned by a match, so the methods that match text from a RuneReader may read arbitrarily far into the input before returning.

See also: https://stackoverflow.com/questions/76559206/how-to-match-a-regular-expression-on-a-slow-hanging-io-reader-in-go

KMP: https://en.wikipedia.org/wiki/Knuth%E2%80%93Morris%E2%80%93Pratt_algorithm

