### PR TITLE
Remove unnecessary annotations from Pipeline-as-Code template

### DIFF
--- a/pkg/pipelines/tekton/templates_s2i.go
+++ b/pkg/pipelines/tekton/templates_s2i.go
@@ -174,12 +174,6 @@ metadata:
     # Fetch the git-clone task from hub
     pipelinesascode.tekton.dev/task: {{.GitCloneTaskRef}}
 
-    # Fetch the func-s2i task
-    pipelinesascode.tekton.dev/task-1: {{.FuncS2iTaskRef}}
-
-    # Fetch the func-deploy task
-    pipelinesascode.tekton.dev/task-2: {{.FuncDeployTaskRef}}
-
     # Fetch the pipelie definition from the .tekton directory
     pipelinesascode.tekton.dev/pipeline: {{.PipelineYamlURL}}
 


### PR DESCRIPTION
# Changes

- :broom: Remove unnecessary annotations from Pipeline-as-Code template

These extra annotations prevents the pipeline to be triggered on Openshift 

/kind cleanup