### PR TITLE
test: making e2e config tests builder agnostic

### DIFF
--- a/test/e2e/scenario_config-envs_test.go
+++ b/test/e2e/scenario_config-envs_test.go
@@ -165,7 +165,7 @@ func TestConfigEnvs(t *testing.T) {
 
 	// Deploy
 	knFunc.TestCmd.WithEnv(testEnvName, testEnvValue)
-	knFunc.TestCmd.Exec("deploy", "--builder", "pack", "--registry", common.GetRegistry())
+	knFunc.TestCmd.Exec("deploy", "--registry", common.GetRegistry())
 	defer knFunc.TestCmd.Exec("delete")
 	_, functionUrl := common.WaitForFunctionReady(t, funcName)
 

--- a/test/e2e/scenario_config-labels_test.go
+++ b/test/e2e/scenario_config-labels_test.go
@@ -74,7 +74,7 @@ func TestConfigLabel(t *testing.T) {
 	// Deploy
 	knFunc.TestCmd.
 		WithEnv(testEnvName, testEnvValue).
-		Exec("deploy", "--registry", common.GetRegistry(), "--builder", "pack")
+		Exec("deploy", "--registry", common.GetRegistry())
 	defer knFunc.TestCmd.Exec("delete")
 
 	// Then assert that...

--- a/test/e2e/scenario_config-volumes_test.go
+++ b/test/e2e/scenario_config-volumes_test.go
@@ -147,7 +147,7 @@ func TestConfigVolumes(t *testing.T) {
 	configVolumesRemove("/bad-cm", enter)
 
 	// Deploy
-	knFunc.TestCmd.Exec("deploy", "--builder", "pack", "--registry", common.GetRegistry())
+	knFunc.TestCmd.Exec("deploy", "--registry", common.GetRegistry())
 	defer knFunc.TestCmd.Exec("delete")
 	_, functionUrl := common.WaitForFunctionReady(t, funcName)
 
@@ -271,7 +271,7 @@ func TestConfigVolumesPvcEmptyDir(t *testing.T) {
 
 	// Deploy
 
-	knFunc.TestCmd.Exec("deploy", "--builder", "pack", "--registry", common.GetRegistry())
+	knFunc.TestCmd.Exec("deploy", "--registry", common.GetRegistry())
 	t.Cleanup(func() {
 		knFunc.TestCmd.Exec("delete")
 	})

--- a/test/e2e/scenario_remote-repository_test.go
+++ b/test/e2e/scenario_remote-repository_test.go
@@ -28,7 +28,7 @@ func TestRemoteRepository(t *testing.T) {
 
 	knFunc.SourceDir = funcPath
 
-	knFunc.Exec("deploy", "--builder", "pack", "--registry", common.GetRegistry())
+	knFunc.Exec("deploy", "--registry", common.GetRegistry())
 	defer knFunc.Exec("delete")
 	_, functionUrl := common.WaitForFunctionReady(t, funcName)
 


### PR DESCRIPTION
# Changes

- :broom: Making config envs tests builder agnostic

/kind cleanup

The referred test are written using go functions which previously were only supported with `pack` builder. Since `s2i` builder also can build go functions now, the `--builder` specific flags are no longer required.
