### PR TITLE
Enforce branch on test remote repository

### DIFF
--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -35,7 +35,14 @@ jobs:
         env:
           FUNC_REPO_REF: ${{ github.event.pull_request.head.repo.full_name }}
           FUNC_REPO_BRANCH_REF: ${{ github.head_ref }}
+      - name: Template Unit Tests on Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          python3 -m venv ${{ github.workspace }}/.venv
+          . ${{ github.workspace }}/.venv/bin/activate
+          make test-templates
       - name: Template Unit Tests
+        if: matrix.os != 'ubuntu-latest'
         run: make test-templates
       - name: "Archive code coverage results"
         uses: actions/upload-artifact@v4

--- a/test/oncluster/scenario_remote-repository_test.go
+++ b/test/oncluster/scenario_remote-repository_test.go
@@ -10,7 +10,6 @@ import (
 
 	"gotest.tools/v3/assert"
 	"knative.dev/func/test/common"
-	"knative.dev/func/test/testhttp"
 )
 
 func setupRemoteRepository(t *testing.T) (reposutoryUrl string) {
@@ -83,16 +82,15 @@ func TestRemoteRepository(t *testing.T) {
 	knFunc.Exec("create",
 		"--language", "go",
 		"--template", "testhello",
-		"--repository", gitRepoUrl,
+		"--repository", gitRepoUrl+"#main", // enforce branch to be used
 		funcPath)
 
 	knFunc.SourceDir = funcPath
 
-	knFunc.Exec("deploy", "--registry", common.GetRegistry())
+	knFunc.Exec("deploy", "--registry", common.GetRegistry(), "--remote")
 	defer knFunc.Exec("delete")
-	_, functionUrl := common.WaitForFunctionReady(t, funcName)
 
-	_, funcResponse := testhttp.TestGet(t, functionUrl)
-	assert.Assert(t, strings.Contains(funcResponse, "HELLO TEST"))
+	result := knFunc.Exec("invoke", "-p", funcPath)
+	assert.Assert(t, strings.Contains(result.Out, "HELLO TEST"))
 
 }


### PR DESCRIPTION
# Changes

- :broom: Set branch on remote repository test.
- It also contains a fix environment [error](https://github.com/knative/func/actions/runs/11284604957/job/31403100368?pr=2540#step:9:136) on python test-template run on GitHub action

/kind cleanup
