### PR TITLE
Fix missing workspaces decl in the scaffold task

### DIFF
--- a/pkg/pipelines/tekton/tasks.go
+++ b/pkg/pipelines/tekton/tasks.go
@@ -440,6 +440,9 @@ spec:
     - name: path
       description: Path to the function project
       default: ""
+  workspaces:
+    - name: source
+      description: The workspace containing the function project
   steps:
     - name: func-scaffold
       image: %s


### PR DESCRIPTION
# Changes

- :bug: Fix missing `source` workspaces declaration in the `scaffold` task. This led to TaskRun ending with `TaskRunValidationFailed: workspace binding "source" does not match any declared workspace`.
This behaviour was observed by @alanreynosov on his k3s cluster, we have not seen it so far.

/kind bug

```release-note
fix: workspace binding "source" does not match any declared workspace for scaffold task
```
