### PR TITLE
add repository to the credentials prompt

### DIFF
--- a/cmd/prompt/prompt.go
+++ b/cmd/prompt/prompt.go
@@ -15,15 +15,15 @@ import (
 	"knative.dev/func/pkg/docker/creds"
 )
 
-func NewPromptForCredentials(in io.Reader, out, errOut io.Writer) func(registry string) (docker.Credentials, error) {
+func NewPromptForCredentials(in io.Reader, out, errOut io.Writer) func(repository string) (docker.Credentials, error) {
 	firstTime := true
-	return func(registry string) (docker.Credentials, error) {
+	return func(repository string) (docker.Credentials, error) {
 		var result docker.Credentials
 		if firstTime {
 			firstTime = false
-			fmt.Fprintf(out, "Please provide credentials for repository '%s'.\n", registry)
+			fmt.Fprintf(out, "Please provide credentials for image repository '%s'.\n", repository)
 		} else {
-			fmt.Fprintf(out, "Incorrect credentials for repository '%s'. Please make sure the image is correct and try again.\n", registry)
+			fmt.Fprintf(out, "Incorrect credentials for repository '%s'. Please make sure the repository is correct and try again.\n", repository)
 		}
 
 		var qs = []*survey.Question{

--- a/cmd/prompt/prompt.go
+++ b/cmd/prompt/prompt.go
@@ -15,16 +15,15 @@ import (
 	"knative.dev/func/pkg/docker/creds"
 )
 
-func NewPromptForCredentials(in io.Reader, out, errOut io.Writer) func(registry string) (docker.Credentials, error) {
+func NewPromptForCredentials(in io.Reader, out, errOut io.Writer) func(registryWithRepo string) (docker.Credentials, error) {
 	firstTime := true
-	return func(registry string) (docker.Credentials, error) {
+	return func(registryWithRepo string) (docker.Credentials, error) {
 		var result docker.Credentials
-
 		if firstTime {
 			firstTime = false
-			fmt.Fprintf(out, "Please provide credentials for image registry (%s).\n", registry)
+			fmt.Fprintf(out, "Please provide credentials for repository '%s'.\n", registryWithRepo)
 		} else {
-			fmt.Fprintln(out, "Incorrect credentials, please try again.")
+			fmt.Fprintf(out, "Incorrect credentials for repository '%s'. Please make sure the image name is correct and try again.\n", registryWithRepo)
 		}
 
 		var qs = []*survey.Question{

--- a/cmd/prompt/prompt.go
+++ b/cmd/prompt/prompt.go
@@ -15,15 +15,15 @@ import (
 	"knative.dev/func/pkg/docker/creds"
 )
 
-func NewPromptForCredentials(in io.Reader, out, errOut io.Writer) func(registryWithRepo string) (docker.Credentials, error) {
+func NewPromptForCredentials(in io.Reader, out, errOut io.Writer) func(registry string) (docker.Credentials, error) {
 	firstTime := true
-	return func(registryWithRepo string) (docker.Credentials, error) {
+	return func(registry string) (docker.Credentials, error) {
 		var result docker.Credentials
 		if firstTime {
 			firstTime = false
-			fmt.Fprintf(out, "Please provide credentials for repository '%s'.\n", registryWithRepo)
+			fmt.Fprintf(out, "Please provide credentials for repository '%s'.\n", registry)
 		} else {
-			fmt.Fprintf(out, "Incorrect credentials for repository '%s'. Please make sure the image is correct and try again.\n", registryWithRepo)
+			fmt.Fprintf(out, "Incorrect credentials for repository '%s'. Please make sure the image is correct and try again.\n", registry)
 		}
 
 		var qs = []*survey.Question{

--- a/cmd/prompt/prompt.go
+++ b/cmd/prompt/prompt.go
@@ -23,7 +23,7 @@ func NewPromptForCredentials(in io.Reader, out, errOut io.Writer) func(registryW
 			firstTime = false
 			fmt.Fprintf(out, "Please provide credentials for repository '%s'.\n", registryWithRepo)
 		} else {
-			fmt.Fprintf(out, "Incorrect credentials for repository '%s'. Please make sure the image name is correct and try again.\n", registryWithRepo)
+			fmt.Fprintf(out, "Incorrect credentials for repository '%s'. Please make sure the image is correct and try again.\n", registryWithRepo)
 		}
 
 		var qs = []*survey.Question{

--- a/pkg/docker/creds/credentials.go
+++ b/pkg/docker/creds/credentials.go
@@ -236,7 +236,6 @@ func (c *credentialsProvider) getCredentials(ctx context.Context, image string) 
 	}
 
 	registry := ref.Context().RegistryStr()
-
 	for _, load := range c.credentialLoaders {
 
 		result, err = load(registry)
@@ -263,8 +262,14 @@ func (c *credentialsProvider) getCredentials(ctx context.Context, image string) 
 		return docker.Credentials{}, ErrCredentialsNotFound
 	}
 
+	// this is [registry] / [repository]
+	// this is  index.io  / user/imagename
+	registryWithRepository := registry + "/" + ref.Context().RepositoryStr()
+
+	// the trying-to-actualy-authorize cycle
 	for {
-		result, err = c.promptForCredentials(registry)
+		// use repo here to print it out in prompt
+		result, err = c.promptForCredentials(registryWithRepository)
 		if err != nil {
 			return docker.Credentials{}, err
 		}

--- a/pkg/docker/creds/credentials.go
+++ b/pkg/docker/creds/credentials.go
@@ -264,12 +264,12 @@ func (c *credentialsProvider) getCredentials(ctx context.Context, image string) 
 
 	// this is [registry] / [repository]
 	// this is  index.io  / user/imagename
-	registryWithRepository := registry + "/" + ref.Context().RepositoryStr()
+	repository := registry + "/" + ref.Context().RepositoryStr()
 
 	// the trying-to-actually-authorize cycle
 	for {
 		// use repo here to print it out in prompt
-		result, err = c.promptForCredentials(registryWithRepository)
+		result, err = c.promptForCredentials(repository)
 		if err != nil {
 			return docker.Credentials{}, err
 		}

--- a/pkg/docker/creds/credentials.go
+++ b/pkg/docker/creds/credentials.go
@@ -266,7 +266,7 @@ func (c *credentialsProvider) getCredentials(ctx context.Context, image string) 
 	// this is  index.io  / user/imagename
 	registryWithRepository := registry + "/" + ref.Context().RepositoryStr()
 
-	// the trying-to-actualy-authorize cycle
+	// the trying-to-actually-authorize cycle
 	for {
 		// use repo here to print it out in prompt
 		result, err = c.promptForCredentials(registryWithRepository)

--- a/pkg/docker/creds/credentials_test.go
+++ b/pkg/docker/creds/credentials_test.go
@@ -870,6 +870,8 @@ func pwdCbkFirstWrongThenCorrect(t *testing.T) func(registry string) (Credential
 	t.Helper()
 	var firstInvocation bool
 	return func(registry string) (Credentials, error) {
+		// registry is in form of registry/repository, need to extract registry only
+		registry = strings.Split(registry, "/")[0]
 		if registry != "index.docker.io" && registry != "quay.io" {
 			return Credentials{}, fmt.Errorf("unexpected registry: %s", registry)
 		}
@@ -882,6 +884,8 @@ func pwdCbkFirstWrongThenCorrect(t *testing.T) func(registry string) (Credential
 }
 
 func correctPwdCallback(registry string) (Credentials, error) {
+	// registry is in form of registry/repository, need to extract registry only
+	registry = strings.Split(registry, "/")[0]
 	if registry == "index.docker.io" {
 		return Credentials{Username: dockerIoUser, Password: dockerIoUserPwd}, nil
 	}


### PR DESCRIPTION
Added `repository` value (now it is `registry/repository`) to prompt for credentials where its used for printing out tto terminal "during the prompt" to make it easier for the user to see what he is trying to provide credentials for.

Additionally I have created a [new issue](https://github.com/knative/func/issues/2595) that is a followup to this and its' purpose is to further optimize this "credentials" process

fix https://github.com/knative/func/issues/2562
