### PR TITLE
Enable Go ARM64 buildpack

### DIFF
--- a/hack/update-builder.go
+++ b/hack/update-builder.go
@@ -510,17 +510,6 @@ func (e *exitHandler) Fail() {
 func (e *exitHandler) Pass() {
 }
 
-type auth struct {
-	uname, pwd string
-}
-
-func (a auth) Authorization() (*authn.AuthConfig, error) {
-	return &authn.AuthConfig{
-		Username: a.uname,
-		Password: a.pwd,
-	}, nil
-}
-
 func downloadBuilderToml(ctx context.Context, tarballUrl, builderTomlPath string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tarballUrl, nil)
 	if err != nil {

--- a/hack/update-builder.go
+++ b/hack/update-builder.go
@@ -862,7 +862,7 @@ func fixupGoBuildpackARM64(ctx context.Context, config *builder.Config) error {
 		cmd := exec.CommandContext(ctx, "./scripts/package.sh", "--version", version)
 		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 		cmd.Dir = srcDir
-		cmd.Env = append(os.Environ(), "GOARCH=arm64", "GOROOT=/home/mvasek/goroot")
+		cmd.Env = append(os.Environ(), "GOARCH=arm64")
 		err = cmd.Run()
 		if err != nil {
 			return fmt.Errorf("build of buildpack %q failed: %w", name, err)

--- a/hack/update-builder.go
+++ b/hack/update-builder.go
@@ -133,7 +133,7 @@ func buildBuilderImage(ctx context.Context, variant, arch string) (string, error
 	if arch == "arm64" {
 		err = fixupGoBuildpackARM64(ctx, &builderConfig)
 		if err != nil {
-			return "", fmt.Errorf("cannnot fix Go buildpack: %w", err)
+			return "", fmt.Errorf("cannot fix Go buildpack: %w", err)
 		}
 	}
 

--- a/hack/update-builder.go
+++ b/hack/update-builder.go
@@ -981,10 +981,11 @@ func fixupGoDistPkgRefs(buildpackToml, arch string) error {
 		return err
 	}
 
-	var replacements []struct {
+	var replacements = make([]struct {
 		Old string
 		New string
-	}
+	}, 0, len(releases))
+
 	for _, r := range releases {
 		if _, ok := versions[strings.TrimPrefix(r.Version, "go")]; !ok {
 			continue

--- a/hack/update-builder.go
+++ b/hack/update-builder.go
@@ -178,7 +178,7 @@ func buildBuilderImage(ctx context.Context, variant, arch string) (string, error
 
 	err = packClient.CreateBuilder(ctx, createBuilderOpts)
 	if err != nil {
-		return "", fmt.Errorf("canont create builder: %w", err)
+		return "", fmt.Errorf("cannont create builder: %w", err)
 	}
 
 	pushImage := func(img string) (string, error) {


### PR DESCRIPTION
Added adjustments that enable Go buildpack build on arm64 machines. Paketo buildpack do not distribute serveral buildpacks in arm64 variant, so we need to build them.

Namely we need to build:
* go
  * go-dist
  * go-build
  * go-mod-vendor
  * git

fixes #2623

