### PR TITLE
Remove dependency on docker hub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,6 +188,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: |
+          ./hack/fetch-util-img-prerequisites.sh
           docker buildx create --name multiarch --driver docker-container --use
           docker buildx build . -f Dockerfile.utils \
             --platform=linux/ppc64le,linux/s390x,linux/amd64,linux/arm64 \

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /bin
 /target
 /hack/bin
+/.artifacts
 
 /e2e/testdata/default_home/go
 /e2e/testdata/default_home/.cache

--- a/Dockerfile.utils
+++ b/Dockerfile.utils
@@ -1,8 +1,15 @@
-FROM --platform=$BUILDPLATFORM index.docker.io/library/golang:1.23-alpine3.20 AS builder
+FROM scratch AS builder
 
 ARG BUILDPLATFORM
+ARG BUILDARCH
 ARG TARGETPLATFORM
 ARG TARGETARCH
+
+ADD .artifacts/alpine-minirootfs-$BUILDARCH.tar.gz /
+
+COPY .artifacts/go.tar.gz /tmp/go.tar.gz
+RUN tar -C /usr/local -xzf /tmp/go.tar.gz
+ENV PATH="/usr/local/go/bin:$PATH"
 
 WORKDIR /workspace
 
@@ -15,7 +22,11 @@ RUN GOARCH=$TARGETARCH go build -o func-util -trimpath -ldflags '-w -s' ./cmd/fu
 
 #########################
 
-FROM index.docker.io/library/alpine:latest
+FROM scratch
+
+ARG TARGETARCH
+
+ADD .artifacts/alpine-minirootfs-$TARGETARCH.tar.gz /
 
 RUN apk add --no-cache tar
 

--- a/hack/fetch-util-img-prerequisites.sh
+++ b/hack/fetch-util-img-prerequisites.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+alpine_version='3.21.2'
+go_version='1.23.5'
+
+alpine_release_key='0482D84022F52DF1C4E7CD43293ACD0907D9495A'
+google_release_key='EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796'
+
+artifacts_dir="$(dirname "$(realpath "$0")")/../.artifacts"
+if [ ! -d "$artifacts_dir" ]; then
+  mkdir "$artifacts_dir";
+fi
+
+GNUPGHOME="$(mktemp -d)"
+export GNUPGHOME
+gpg --keyserver 'keyserver.ubuntu.com' --recv-keys "$alpine_release_key"
+gpg --keyserver 'keyserver.ubuntu.com' --recv-keys "$google_release_key"
+
+declare -A arch_map
+arch_map['x86_64']='amd64'
+arch_map['aarch64']='arm64'
+
+function fetch_alpine_minirootfs() {
+  local alpine_rel_url='https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases'
+
+  local arch
+  for arch in 'x86_64' 'aarch64' 'ppc64le' 's390x'; do
+    local arch_alt="${arch_map[$arch]:-$arch}"
+    local tarball="${artifacts_dir}/alpine-minirootfs-${arch_alt}.tar.gz"
+    local signature="${artifacts_dir}/alpine-minirootfs-${arch_alt}.tar.gz.asc"
+    curl -sSL "${alpine_rel_url}/${arch}/alpine-minirootfs-${alpine_version}-${arch}.tar.gz" > \
+      "${tarball}"
+    curl -sSL "${alpine_rel_url}/${arch}/alpine-minirootfs-${alpine_version}-${arch}.tar.gz.asc" > \
+      "${signature}"
+    gpg --assert-signer="$alpine_release_key" --verify "${signature}" "${tarball}"
+  done
+}
+
+function fetch_golang() {
+
+  local arch
+  arch="$(uname -m)"
+  local arch_alt="${arch_map[$arch]:-$arch}"
+  local tarball="${artifacts_dir}/go.tar.gz"
+  local signature="${artifacts_dir}/go.tar.gz.asc"
+  curl -sSL "https://go.dev/dl/go${go_version}.linux-${arch_alt}.tar.gz" > "${tarball}"
+  curl -sSL "https://go.dev/dl/go${go_version}.linux-${arch_alt}.tar.gz.asc" > "${signature}"
+  gpg --assert-signer="$google_release_key" --verify "${signature}" "${tarball}"
+}
+
+function main() {
+  fetch_alpine_minirootfs
+  fetch_golang
+}
+
+main "$@"

--- a/hack/setup-testing-images.sh
+++ b/hack/setup-testing-images.sh
@@ -6,6 +6,8 @@ set -o pipefail
 
 FUNC_UTILS_IMG="localhost:50000/knative/func-utils:latest"
 
+"$(dirname "$(realpath "$0")")/fetch-util-img-prerequisites.sh"
+
 docker build . -f Dockerfile.utils -t "${FUNC_UTILS_IMG}"
 docker push "${FUNC_UTILS_IMG}"
 


### PR DESCRIPTION
Removed dependency on 
* `index.docker.io/library/golang:1.23-alpine3.20` and
* `index.docker.io/library/alpine:latest`.

For future I consider making the image `scratch` or at least `distroless` but for now it's still `alpine`.
Also we might consider skipping the `builder` part -- we could build the binaries locally and then use `COPY`.

Also I hate the fact that the `ADD` clause do not have `--from` flag, because of that I have to do fetching outside of the `Dockerfile`.