### PR TITLE
use knative go setup in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/composite/go-setup
+      - uses: knative/actions/setup-go@main
       - name: Lint
         run: make check && make check-templates
       - name: Check that 'func.yaml schema' is up-to-date


### PR DESCRIPTION
Keeps the Go version used by Knative projects in sync with each-other and tooling.

/kind cleanup