### PR TITLE
fix: capitalise kind broker and bump versions in script

### DIFF
--- a/hack/allocate.sh
+++ b/hack/allocate.sh
@@ -26,7 +26,7 @@ source "$(dirname "$(realpath "$0")")/common.sh"
 set_versions() {
   # Note: Kubernetes Version node image per Kind releases (full hash is suggested):
   # https://github.com/kubernetes-sigs/kind/releases
-  kind_node_version=v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
+  kind_node_version=v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
   knative_serving_version="v$(get_latest_release_version "knative" "serving")"
   knative_eventing_version="v$(get_latest_release_version "knative" "eventing")"
   contour_version="v$(get_latest_release_version "knative-extensions" "net-contour")"
@@ -305,7 +305,7 @@ namespace() {
   # Default Broker
   $KUBECTL apply -f - <<EOF
   apiVersion: eventing.knative.dev/v1
-  kind: broker
+  kind: Broker
   metadata:
    name: func-broker
    namespace: func

--- a/hack/install-binaries.sh
+++ b/hack/install-binaries.sh
@@ -25,8 +25,8 @@ install_binaries() {
   local root="$(dirname "$(realpath "$0")")"
   local bin="${root}/bin"
 
-  local kubectl_version=1.29.2
-  local kind_version=0.22.0
+  local kubectl_version=1.32.0
+  local kind_version=0.26.0
   local dapr_version=1.11.0
   local helm_version=3.12.0
   local stern_version=1.25.0
@@ -71,7 +71,7 @@ warn_architecture() {
 
 install_kubectl() {
     echo '=== kubectl'
-    curl -sSLo "${bin}"/kubectl "https://storage.googleapis.com/kubernetes-release/release/v$kubectl_version/bin/linux/${ARCH}/kubectl"
+    curl -sSLo "${bin}"/kubectl "https://dl.k8s.io/v${kubectl_version}/bin/linux/${ARCH}/kubectl"
     chmod +x "${bin}"/kubectl
     "${bin}"/kubectl version --client=true
 }


### PR DESCRIPTION
beginning with eventing 1.17, tests now fail -> kind type of eventing CRD was never capitalised (how did this work?) and eventing now requires 1.30+ k8s version -> bumping