### PR TITLE
Set platform of builder image

### DIFF
--- a/Dockerfile.utils
+++ b/Dockerfile.utils
@@ -1,4 +1,4 @@
-FROM scratch AS builder
+FROM --platform=$BUILDPLATFORM scratch AS builder
 
 ARG BUILDPLATFORM
 ARG BUILDARCH


### PR DESCRIPTION
Previously I thought the platform does not matter for 'scratch'. However the image build is failing in CI.
It worked on my machine with both podman and moby.

