### PR TITLE
Create test symlinks dynamically

### DIFF
--- a/pkg/oci/containerize_test.go
+++ b/pkg/oci/containerize_test.go
@@ -1,6 +1,8 @@
 package oci
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -10,7 +12,16 @@ import (
 // links which are absolute or refer to targets outside the given root, in
 // addition to the basic job of returning the value of reading the link.
 func Test_validatedLinkTarget(t *testing.T) {
-	root := "testdata/test-links"
+	root := filepath.Join("testdata", "test-links")
+
+	err := os.Symlink("/var/example/absolute/link", filepath.Join(root, "absoluteLink"))
+	if err != nil && !errors.Is(err, os.ErrExist) {
+		t.Fatal(err)
+	}
+	err = os.Symlink("c://some/absolute/path", filepath.Join(root, "absoluteLinkWindows"))
+	if err != nil && !errors.Is(err, os.ErrExist) {
+		t.Fatal(err)
+	}
 
 	// Windows-specific absolute link and link target values:
 	absoluteLink := "absoluteLink"

--- a/pkg/oci/testdata/test-links/absoluteLink
+++ b/pkg/oci/testdata/test-links/absoluteLink
@@ -1,1 +1,0 @@
-/var/example/absolute/link

--- a/pkg/oci/testdata/test-links/absoluteLinkWindows
+++ b/pkg/oci/testdata/test-links/absoluteLinkWindows
@@ -1,1 +1,0 @@
-c://some/absolute/path


### PR DESCRIPTION
Some tools dislike having questionable symlinks in git repository so we must create this symlinks dynamically in the test instead of having it committed into the repository.