### PR TITLE
fix: revert action version

### DIFF
--- a/.github/workflows/update-knative-hack.yaml
+++ b/.github/workflows/update-knative-hack.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Update components
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
         go-version: 1.23.0


### PR DESCRIPTION
I have accidentally updated a `action/checkout` version in one of the PRs where I updated the `codecov` action (here)
https://github.com/knative/func/commit/104e90ce5c69b62153066374566e16b93ac6f11d#diff-0a1c47bbdfcabf42604d25d72fcbc5dedada8eccec097530bac82b9159bd71a4R16
 (Sorry!). 
Revert this since `action/checkout` doesnt even have a v5 yet -- the workflow fails.