### PR TITLE
Add a retry functionality to workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,24 @@ jobs:
       - name: Install Binaries
         run: ./hack/install-binaries.sh
       - name: Allocate Cluster
-        run: ./hack/allocate.sh
+        run: |
+          attempt=0
+          max_attempts=5
+          until [ $attempt -ge $max_attempts ]
+          do
+            attempt=$((attempt+1))
+            echo "------------------ Attempt $attempt ------------------"
+            ./hack/allocate.sh && break
+            echo "------------------ failed, retrying... ------------------"
+            if [ $attempt -ge $max_attempts ]; then
+              echo "------------------ max # of retries reached, exiting ------------------"
+              exit 1
+            fi
+            ./hack/delete.sh
+            echo "------------------ sleep for 5 minutes ------------------"
+            sleep 300
+          done
+          echo "------------------ finished! attempt $attempt ------------------"
       - name: Local Registry
         run: ./hack/registry.sh
       - name: E2E Test
@@ -134,7 +151,24 @@ jobs:
       - name: Install Binaries
         run: ./hack/install-binaries.sh
       - name: Allocate Cluster
-        run: ./hack/allocate.sh
+        run: |
+          attempt=0
+          max_attempts=5
+          until [ $attempt -ge $max_attempts ]
+          do
+            attempt=$((attempt+1))
+            echo "------------------ Attempt $attempt ------------------"
+            ./hack/allocate.sh && break
+            echo "------------------ failed, retrying... ------------------"
+            if [ $attempt -ge $max_attempts ]; then
+              echo "------------------ max # of retries reached, exiting ------------------"
+              exit 1
+            fi
+            ./hack/delete.sh
+            echo "------------------ sleep for 5 minutes ------------------"
+            sleep 300
+          done
+          echo "------------------ finished! attempt $attempt ------------------"
       - name: Setup testing images
         run: ./hack/setup-testing-images.sh
       - name: Deploy Tekton

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,8 @@ jobs:
               exit 1
             fi
             ./hack/delete.sh
+            echo "------------------ sleep for 5 minutes ------------------"
+            sleep 300
           done
           echo "------------------ finished! attempt $attempt ------------------"
       - name: Local Registry

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,22 @@ jobs:
       - name: Install Binaries
         run: ./hack/install-binaries.sh
       - name: Allocate Cluster
-        run: ./hack/allocate.sh
+        run: |
+          attempt=0
+          max_attempts=5
+          until [ $attempt -ge $max_attempts ]
+          do
+            attempt=$((attempt+1))
+            echo "------------------ Attempt $attempt ------------------"
+            ./hack/allocate.sh && break
+            echo "------------------ failed, retrying... ------------------"
+            if [ $attempt -ge $max_attempts ]; then
+              echo "------------------ max # of retries reached, exiting ------------------"
+              exit 1
+            fi
+            ./hack/delete.sh
+          done
+          echo "------------------ finished! attempt $attempt ------------------"
       - name: Local Registry
         run: ./hack/registry.sh
       - name: Setup testing images

--- a/.github/workflows/test-e2e-oncluster-runtime.yaml
+++ b/.github/workflows/test-e2e-oncluster-runtime.yaml
@@ -22,7 +22,22 @@ jobs:
       - name: Install Binaries
         run: ./hack/install-binaries.sh
       - name: Allocate Cluster
-        run: ./hack/allocate.sh
+        run: |
+          attempt=0
+          max_attempts=5
+          until [ $attempt -ge $max_attempts ]
+          do
+            attempt=$((attempt+1))
+            echo "------------------ Attempt $attempt ------------------"
+            ./hack/allocate.sh && break
+            echo "------------------ failed, retrying... ------------------"
+            if [ $attempt -ge $max_attempts ]; then
+              echo "------------------ max # of retries reached, exiting ------------------"
+              exit 1
+            fi
+            ./hack/delete.sh
+          done
+          echo "------------------ finished! attempt $attempt ------------------"
       - name: Setup testing images
         run: ./hack/setup-testing-images.sh
       - name: Deploy Tekton

--- a/.github/workflows/test-e2e-oncluster-runtime.yaml
+++ b/.github/workflows/test-e2e-oncluster-runtime.yaml
@@ -36,6 +36,8 @@ jobs:
               exit 1
             fi
             ./hack/delete.sh
+            echo "------------------ sleep for 5 minutes ------------------"
+            sleep 300
           done
           echo "------------------ finished! attempt $attempt ------------------"
       - name: Setup testing images

--- a/.github/workflows/test-e2e-oncluster.yaml
+++ b/.github/workflows/test-e2e-oncluster.yaml
@@ -20,7 +20,22 @@ jobs:
       - name: Install Binaries
         run: ./hack/install-binaries.sh
       - name: Allocate Cluster
-        run: ./hack/allocate.sh
+        run: |
+          attempt=0
+          max_attempts=5
+          until [ $attempt -ge $max_attempts ]
+          do
+            attempt=$((attempt+1))
+            echo "------------------ Attempt $attempt ------------------"
+            ./hack/allocate.sh && break
+            echo "------------------ failed, retrying... ------------------"
+            if [ $attempt -ge $max_attempts ]; then
+              echo "------------------ max # of retries reached, exiting ------------------"
+              exit 1
+            fi
+            ./hack/delete.sh
+          done
+          echo "------------------ finished! attempt $attempt ------------------"
       - name: Setup testing images
         run: ./hack/setup-testing-images.sh
       - name: Deploy Tekton

--- a/.github/workflows/test-e2e-oncluster.yaml
+++ b/.github/workflows/test-e2e-oncluster.yaml
@@ -34,6 +34,8 @@ jobs:
               exit 1
             fi
             ./hack/delete.sh
+            echo "------------------ sleep for 5 minutes ------------------"
+            sleep 300
           done
           echo "------------------ finished! attempt $attempt ------------------"
       - name: Setup testing images

--- a/.github/workflows/test-e2e-runtime.yaml
+++ b/.github/workflows/test-e2e-runtime.yaml
@@ -24,7 +24,20 @@ jobs:
       - name: Install Binaries
         run: ./hack/install-binaries.sh
       - name: Allocate Cluster
-        run: ./hack/allocate.sh
+        run: |
+          attempt=0
+          max_attempts=5
+          until [ $attempt -ge $max_attempts ]
+          do
+            attempt=$((attempt+1))
+            echo "------------------ Attempt $attempt for ${{matrix.runtime}} ------------------"
+            ./hack/allocate.sh && break
+            echo "------------------ failed, retrying... ------------------"
+            if [ $attempt -ge $max_attempts ]; then
+              echo "------------------ max # of retries reached, exiting ------------------"
+              exit 1
+            fi
+          done
       - name: Local Registry
         run: ./hack/registry.sh
       - name: Build

--- a/.github/workflows/test-e2e-runtime.yaml
+++ b/.github/workflows/test-e2e-runtime.yaml
@@ -30,7 +30,20 @@ jobs:
       - name: Build
         run: make
       - name: E2E runtime for ${{ matrix.runtime }}
-        run: make test-e2e-runtime runtime=${{ matrix.runtime }}
+        run: |
+          attempt=0
+          max_attempts=5
+          until [ $attempt -ge $max_attempts ]
+          do
+            attempt=$((attempt+1))
+            echo "------------------ Attempt $attempt for ${{matrix.runtime}} ------------------"
+            make test-e2e-runtime runtime=${{ matrix.runtime }} && break
+            echo "------------------ failed, retrying... ------------------"
+            if [ $attempt -ge $max_attempts ]; then
+              echo "------------------ max # of retries reached, exiting ------------------"
+              exit 1
+            fi
+          done
       - uses: codecov/codecov-action@v5
         with:
           files: ./coverage.txt

--- a/.github/workflows/test-e2e-runtime.yaml
+++ b/.github/workflows/test-e2e-runtime.yaml
@@ -37,6 +37,7 @@ jobs:
               echo "------------------ max # of retries reached, exiting ------------------"
               exit 1
             fi
+            ./delete.sh
           done
       - name: Local Registry
         run: ./hack/registry.sh

--- a/.github/workflows/test-e2e-runtime.yaml
+++ b/.github/workflows/test-e2e-runtime.yaml
@@ -39,6 +39,7 @@ jobs:
             fi
             ./hack/delete.sh
           done
+          echo "------------------ finished! attempt $attempt ------------------"
       - name: Local Registry
         run: ./hack/registry.sh
       - name: Build
@@ -58,6 +59,7 @@ jobs:
               exit 1
             fi
           done
+          echo "------------------ finished! attempt $attempt ------------------"
       - uses: codecov/codecov-action@v5
         with:
           files: ./coverage.txt

--- a/.github/workflows/test-e2e-runtime.yaml
+++ b/.github/workflows/test-e2e-runtime.yaml
@@ -37,7 +37,7 @@ jobs:
               echo "------------------ max # of retries reached, exiting ------------------"
               exit 1
             fi
-            ./delete.sh
+            ./hack/delete.sh
           done
       - name: Local Registry
         run: ./hack/registry.sh

--- a/.github/workflows/test-e2e-runtime.yaml
+++ b/.github/workflows/test-e2e-runtime.yaml
@@ -38,6 +38,8 @@ jobs:
               exit 1
             fi
             ./hack/delete.sh
+            echo "------------------ sleep for 5 minutes ------------------"
+            sleep 300
           done
           echo "------------------ finished! attempt $attempt ------------------"
       - name: Local Registry

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -19,7 +19,22 @@ jobs:
       - name: Install Binaries
         run: ./hack/install-binaries.sh
       - name: Allocate Cluster
-        run: ./hack/allocate.sh
+        run: |
+          attempt=0
+          max_attempts=5
+          until [ $attempt -ge $max_attempts ]
+          do
+            attempt=$((attempt+1))
+            echo "------------------ Attempt $attempt ------------------"
+            ./hack/allocate.sh && break
+            echo "------------------ failed, retrying... ------------------"
+            if [ $attempt -ge $max_attempts ]; then
+              echo "------------------ max # of retries reached, exiting ------------------"
+              exit 1
+            fi
+            ./hack/delete.sh
+          done
+          echo "------------------ finished! attempt $attempt ------------------"
       - name: Local Registry
         run: ./hack/registry.sh
       - name: E2E Test

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -33,6 +33,8 @@ jobs:
               exit 1
             fi
             ./hack/delete.sh
+            echo "------------------ sleep for 5 minutes ------------------"
+            sleep 300
           done
           echo "------------------ finished! attempt $attempt ------------------"
       - name: Local Registry

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -44,6 +44,8 @@ jobs:
               exit 1
             fi
             ./hack/delete.sh
+            echo "------------------ sleep for 5 minutes ------------------"
+            sleep 300
           done
           echo "------------------ finished! attempt $attempt ------------------"
       - name: Local Registry

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -29,10 +29,25 @@ jobs:
       - uses: imjasonh/setup-ko@v0.6
       - name: Install Binaries
         run: ./hack/install-binaries.sh
+      - name: Allocate Cluster
+        run: |
+          attempt=0
+          max_attempts=5
+          until [ $attempt -ge $max_attempts ]
+          do
+            attempt=$((attempt+1))
+            echo "------------------ Attempt $attempt ------------------"
+            ./hack/allocate.sh && break
+            echo "------------------ failed, retrying... ------------------"
+            if [ $attempt -ge $max_attempts ]; then
+              echo "------------------ max # of retries reached, exiting ------------------"
+              exit 1
+            fi
+            ./hack/delete.sh
+          done
+          echo "------------------ finished! attempt $attempt ------------------"
       - name: Local Registry
         run: ./hack/registry.sh
-      - name: Allocate Cluster
-        run: ./hack/allocate.sh
       - name: Setup testing images
         run: ./hack/setup-testing-images.sh
       - name: Install Tekton

--- a/.github/workflows/test-podman.yaml
+++ b/.github/workflows/test-podman.yaml
@@ -38,6 +38,8 @@ jobs:
               exit 1
             fi
             ./hack/delete.sh
+            echo "------------------ sleep for 5 minutes ------------------"
+            sleep 300
           done
           echo "------------------ finished! attempt $attempt ------------------"
       - name: Local Registry

--- a/.github/workflows/test-podman.yaml
+++ b/.github/workflows/test-podman.yaml
@@ -24,7 +24,22 @@ jobs:
       - name: Install Binaries
         run: ./hack/install-binaries.sh
       - name: Allocate Cluster
-        run: ./hack/allocate.sh
+        run: |
+          attempt=0
+          max_attempts=5
+          until [ $attempt -ge $max_attempts ]
+          do
+            attempt=$((attempt+1))
+            echo "------------------ Attempt $attempt ------------------"
+            ./hack/allocate.sh && break
+            echo "------------------ failed, retrying... ------------------"
+            if [ $attempt -ge $max_attempts ]; then
+              echo "------------------ max # of retries reached, exiting ------------------"
+              exit 1
+            fi
+            ./hack/delete.sh
+          done
+          echo "------------------ finished! attempt $attempt ------------------"
       - name: Local Registry
         run: ./hack/registry.sh
       - name: Setup testing images


### PR DESCRIPTION
Add a retry functionality to our current allocate script in the workflows and the e2e runtime test which I saw were the most affected by the flakiness of (probably) not enough resources on the host the runners run on. 
This should ensure that less human resources are needed for maintenance of these tests