### PR TITLE
golangci bump in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ check: $(BIN_GOLANGCI_LINT) ## Check code quality (lint)
 	cd test && $(BIN_GOLANGCI_LINT) run --timeout 300s
 
 $(BIN_GOLANGCI_LINT):
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v1.62.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v1.64.6
 
 .PHONY: generate/zz_filesystem_generated.go
 generate/zz_filesystem_generated.go: clean_templates


### PR DESCRIPTION
bump golangci in our scripts (used in ci.yaml) to match the new version in knative/actions
https://github.com/knative/actions/commit/da50b2717e4c596bc79f7d49aea97b7cd7fc0a68
- failing workflow on main branch (ci) https://github.com/knative/func/actions/runs/13788097455/job/38562329024