### PR TITLE
Removes redundant default labels and annotations

### DIFF
--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -553,10 +553,6 @@ func (f Function) Initialized() bool {
 func (f Function) LabelsMap() (map[string]string, error) {
 	defaultLabels := []Label{
 		{
-			Key:   ptr.String(fnlabels.FunctionKey),
-			Value: ptr.String(fnlabels.FunctionValue),
-		},
-		{
 			Key:   ptr.String(fnlabels.FunctionNameKey),
 			Value: ptr.String(f.Name),
 		},
@@ -564,16 +560,6 @@ func (f Function) LabelsMap() (map[string]string, error) {
 			Key:   ptr.String(fnlabels.FunctionRuntimeKey),
 			Value: ptr.String(f.Runtime),
 		},
-		// --- handle usage of deprecated labels (`boson.dev/function`, `boson.dev/runtime`)
-		{
-			Key:   ptr.String(fnlabels.DeprecatedFunctionKey),
-			Value: ptr.String(fnlabels.FunctionValue),
-		},
-		{
-			Key:   ptr.String(fnlabels.DeprecatedFunctionRuntimeKey),
-			Value: ptr.String(f.Runtime),
-		},
-		// --- end of handling usage of deprecated runtime labels
 	}
 
 	labels := append(defaultLabels, f.Deploy.Labels...)

--- a/pkg/functions/function_unit_test.go
+++ b/pkg/functions/function_unit_test.go
@@ -294,10 +294,7 @@ func Test_LabelsMap(t *testing.T) {
 
 func expectedDefaultLabels(f Function) map[string]string {
 	return map[string]string{
-		fnlabels.FunctionKey:                  fnlabels.FunctionValue,
-		fnlabels.FunctionNameKey:              f.Name,
-		fnlabels.FunctionRuntimeKey:           f.Runtime,
-		fnlabels.DeprecatedFunctionKey:        fnlabels.FunctionValue,
-		fnlabels.DeprecatedFunctionRuntimeKey: f.Runtime,
+		fnlabels.FunctionNameKey:    f.Name,
+		fnlabels.FunctionRuntimeKey: f.Runtime,
 	}
 }

--- a/pkg/k8s/labels/labels.go
+++ b/pkg/k8s/labels/labels.go
@@ -1,13 +1,6 @@
 package labels
 
 const (
-	FunctionKey        = "function.knative.dev"
-	FunctionValue      = "true"
 	FunctionRuntimeKey = "function.knative.dev/runtime"
 	FunctionNameKey    = "function.knative.dev/name"
-
-	// --- handle usage of deprecated labels
-	DeprecatedFunctionKey        = "boson.dev/function"
-	DeprecatedFunctionRuntimeKey = "boson.dev/runtime"
-	// --- end of handling usage of deprecated runtime labels
 )


### PR DESCRIPTION
## Changes

- Removes `function.knative.dev` and `boson.dev` annotations.
- Adds conditional check for `dapr.io` annotations to only add them if `dapr-system` namespace exists.

/kind enhancement


Fixes #2565

## Testing
 
(with dapr installed in cluster)
```
$ kubectl describe --all-namespaces kservice 
Name:         func-test
Namespace:    default
Labels:       <none>
Annotations:  dapr.io/app-id: func-test
              dapr.io/app-port: 8080
              dapr.io/enable-api-logging: true
              dapr.io/enabled: true
              dapr.io/metrics-port: 9092
              serving.knative.dev/creator: kubernetes-admin
              serving.knative.dev/lastModifier: kubernetes-admin
```

(without dapr installed)
```
$ kubectl describe --all-namespaces kservice
Name:         func-test
Namespace:    default
Labels:       <none>
Annotations:  serving.knative.dev/creator: kubernetes-admin
              serving.knative.dev/lastModifier: kubernetes-admin
```
