### PR TITLE
Test adjustments

### DIFF
--- a/pkg/builders/builders_int_test.go
+++ b/pkg/builders/builders_int_test.go
@@ -91,7 +91,9 @@ func createCertificate(t *testing.T) string {
 	ski := sha1.Sum(x509.MarshalPKCS1PublicKey(&certPrivKey.PublicKey))
 
 	cert := &x509.Certificate{
-		SerialNumber: randSN(),
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		SerialNumber:          randSN(),
 		// openssl hash of this subject is 712d4c9d
 		// do not update the subject without also updating the hash referred from another places (e.g. Dockerfile)
 		// See also: https://github.com/paketo-buildpacks/ca-certificates/blob/v1.0.1/cacerts/certs.go#L132
@@ -159,7 +161,7 @@ func buildPatchedBuilder(ctx context.Context, t *testing.T, certDir string) stri
 		t.Fatal(err)
 	}
 
-	dockerfile := `FROM ghcr.io/knative/builder-jammy-base:latest
+	dockerfile := `FROM ghcr.io/knative/builder-jammy-tiny:latest
 COPY 712d4c9d.0 /etc/ssl/certs/
 `
 

--- a/pkg/builders/testdata/go-fn-with-private-deps/go.mod
+++ b/pkg/builders/testdata/go-fn-with-private-deps/go.mod
@@ -1,5 +1,5 @@
 module function
 
-go 1.23.4
+go 1.22
 
-require git-private.127.0.0.1.sslip.io/foo.git v0.0.0-20250312185939-e7bf19abfd77 // indirect
+require git-private.127.0.0.1.sslip.io/foo.git v0.0.0-20250319130200-b1126104a200 // indirect

--- a/pkg/builders/testdata/go-fn-with-private-deps/go.sum
+++ b/pkg/builders/testdata/go-fn-with-private-deps/go.sum
@@ -1,2 +1,4 @@
 git-private.127.0.0.1.sslip.io/foo.git v0.0.0-20250312185939-e7bf19abfd77 h1:IJ6SiucMsd0bjPwuj3VIGCHN225+0lCU1OZSmsg3Rjk=
 git-private.127.0.0.1.sslip.io/foo.git v0.0.0-20250312185939-e7bf19abfd77/go.mod h1:rG9yzCHOSu2zUBmaB7GEu7RBsjiJZRUP1hy26O5CLsc=
+git-private.127.0.0.1.sslip.io/foo.git v0.0.0-20250319130200-b1126104a200 h1:moO2xbNMRhtKOUjzkXNgtv0y3k2Xo+xP9N4MagWSXe0=
+git-private.127.0.0.1.sslip.io/foo.git v0.0.0-20250319130200-b1126104a200/go.mod h1:8MJdyAVONQdluGP17pXr5Lu//oVu7YHyXBE29FDEEng=


### PR DESCRIPTION
* Use tiny instead of base BP builder (since it has smaller footprint).
* Decrease minimal required Go version (S2I images are on Go 1.22 supported by RH).
* Make the self-signed certificate CA==true so it works with `update-ca-trust` utility.
