### PR TITLE
Git test adjustments

### DIFF
--- a/pkg/builders/builders_int_test.go
+++ b/pkg/builders/builders_int_test.go
@@ -91,7 +91,9 @@ func createCertificate(t *testing.T) string {
 	ski := sha1.Sum(x509.MarshalPKCS1PublicKey(&certPrivKey.PublicKey))
 
 	cert := &x509.Certificate{
-		SerialNumber: randSN(),
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		SerialNumber:          randSN(),
 		// openssl hash of this subject is 712d4c9d
 		// do not update the subject without also updating the hash referred from another places (e.g. Dockerfile)
 		// See also: https://github.com/paketo-buildpacks/ca-certificates/blob/v1.0.1/cacerts/certs.go#L132
@@ -159,7 +161,7 @@ func buildPatchedBuilder(ctx context.Context, t *testing.T, certDir string) stri
 		t.Fatal(err)
 	}
 
-	dockerfile := `FROM ghcr.io/knative/builder-jammy-base:latest
+	dockerfile := `FROM ghcr.io/knative/builder-jammy-tiny:latest
 COPY 712d4c9d.0 /etc/ssl/certs/
 `
 

--- a/pkg/builders/builders_int_test.go
+++ b/pkg/builders/builders_int_test.go
@@ -35,7 +35,6 @@ import (
 )
 
 func TestPrivateGitRepository(t *testing.T) {
-	t.Skip("tested functionality not implemented yet")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -65,6 +64,21 @@ func TestPrivateGitRepository(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
+	gitCredsDir := t.TempDir()
+	err := os.WriteFile(filepath.Join(gitCredsDir, "type"), []byte(`git-credentials`), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gitCred := `url=https://git-private.127.0.0.1.sslip.io
+username=developer
+password=nbusr123
+`
+	err = os.WriteFile(filepath.Join(gitCredsDir, "credentials"), []byte(gitCred), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	builder := buildpacks.NewBuilder(buildpacks.WithVerbose(true))
 	f, err := fn.NewFunction(filepath.Join("testdata", "go-fn-with-private-deps"))
 	if err != nil {
@@ -73,6 +87,14 @@ func TestPrivateGitRepository(t *testing.T) {
 	f.Build.Image = "localhost:50000/go-app:test"
 	f.Build.Builder = "pack"
 	f.Build.BuilderImages = map[string]string{"pack": builderImage}
+	f.Build.BuildEnvs = []fn.Env{{
+		Name:  ptr("SERVICE_BINDING_ROOT"),
+		Value: ptr("/bindings"),
+	}}
+	f.Build.Mounts = []fn.MountSpec{{
+		Source:      gitCredsDir,
+		Destination: "/bindings/git-binding",
+	}}
 	err = builder.Build(ctx, f, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/builders/buildpacks/builder.go
+++ b/pkg/builders/buildpacks/builder.go
@@ -178,6 +178,12 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 	if runtime.GOOS == "linux" {
 		opts.ContainerConfig.Network = "host"
 	}
+	
+	var bindings = make([]string, 0, len(f.Build.Mounts))
+	for _, m := range f.Build.Mounts {
+		bindings = append(bindings, fmt.Sprintf("%s:%s", m.Source, m.Destination))
+	}
+	opts.ContainerConfig.Volumes = bindings
 
 	// only trust our known builders
 	opts.TrustBuilder = TrustBuilder

--- a/pkg/builders/testdata/go-fn-with-private-deps/go.mod
+++ b/pkg/builders/testdata/go-fn-with-private-deps/go.mod
@@ -1,5 +1,5 @@
 module function
 
-go 1.23.4
+go 1.22
 
-require git-private.127.0.0.1.sslip.io/foo.git v0.0.0-20250312185939-e7bf19abfd77 // indirect
+require git-private.127.0.0.1.sslip.io/foo.git v0.0.0-20250319130200-b1126104a200 // indirect

--- a/pkg/builders/testdata/go-fn-with-private-deps/go.sum
+++ b/pkg/builders/testdata/go-fn-with-private-deps/go.sum
@@ -1,2 +1,4 @@
 git-private.127.0.0.1.sslip.io/foo.git v0.0.0-20250312185939-e7bf19abfd77 h1:IJ6SiucMsd0bjPwuj3VIGCHN225+0lCU1OZSmsg3Rjk=
 git-private.127.0.0.1.sslip.io/foo.git v0.0.0-20250312185939-e7bf19abfd77/go.mod h1:rG9yzCHOSu2zUBmaB7GEu7RBsjiJZRUP1hy26O5CLsc=
+git-private.127.0.0.1.sslip.io/foo.git v0.0.0-20250319130200-b1126104a200 h1:moO2xbNMRhtKOUjzkXNgtv0y3k2Xo+xP9N4MagWSXe0=
+git-private.127.0.0.1.sslip.io/foo.git v0.0.0-20250319130200-b1126104a200/go.mod h1:8MJdyAVONQdluGP17pXr5Lu//oVu7YHyXBE29FDEEng=

--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -148,6 +148,14 @@ type BuildSpec struct {
 	// Image stores last built image name NOT in func.yaml, but instead
 	// in .func/built-image
 	Image string `yaml:"-"`
+
+	// Mounts used in build phase. This is useful in particular for paketo bindings.
+	Mounts []MountSpec `yaml:"mounts"`
+}
+
+type MountSpec struct {
+	Source      string `yaml:"source"`
+	Destination string `yaml:"destination"`
 }
 
 // RunSpec

--- a/schema/func_yaml-schema.json
+++ b/schema/func_yaml-schema.json
@@ -3,6 +3,9 @@
 	"$ref": "#/definitions/Function",
 	"definitions": {
 		"BuildSpec": {
+			"required": [
+				"mounts"
+			],
 			"properties": {
 				"git": {
 					"$schema": "http://json-schema.org/draft-04/schema#",
@@ -48,6 +51,14 @@
 				"remoteStorageClass": {
 					"type": "string",
 					"description": "RemoteStorageClass specifies the storage class to use for the volume used\non-cluster during when built remotely."
+				},
+				"mounts": {
+					"items": {
+						"$schema": "http://json-schema.org/draft-04/schema#",
+						"$ref": "#/definitions/MountSpec"
+					},
+					"type": "array",
+					"description": "Mounts used in build phase. This is useful in particular for paketo bindings."
 				}
 			},
 			"additionalProperties": false,
@@ -263,6 +274,22 @@
 				},
 				"value": {
 					"pattern": "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$",
+					"type": "string"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"MountSpec": {
+			"required": [
+				"source",
+				"destination"
+			],
+			"properties": {
+				"source": {
+					"type": "string"
+				},
+				"destination": {
 					"type": "string"
 				}
 			},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
