### PR TITLE
Improvements for Go s2i assembler

### DIFF
--- a/pkg/builders/s2i/assemblers.go
+++ b/pkg/builders/s2i/assemblers.go
@@ -73,9 +73,11 @@ if [[ $(go list -f {{.Incomplete}}) == "true" ]]; then
         popd
         exit
     fi
-    exec /$STI_SCRIPTS_PATH/usage
+    /$STI_SCRIPTS_PATH/usage
+    exit 1
 else
     pushd .s2i/builds/last
+    go mod tidy
     go build -o /opt/app-root/gobinary
     popd
     popd


### PR DESCRIPTION
# Changes

- :bug: Return error code when the function was not compiled
- :bug: Run `go mod tidy` on scaffoded code

/kind bug

```release-note
fix: Go s2i build issue with user added dependencies
```

