### PR TITLE
Fix: Go scaffolding uses correct module name

### DIFF
--- a/pkg/scaffolding/scaffold.go
+++ b/pkg/scaffolding/scaffold.go
@@ -1,9 +1,11 @@
 package scaffolding
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"knative.dev/func/pkg/filesystem"
 )
@@ -53,6 +55,33 @@ func Write(out, src, runtime, invoke string, fs filesystem.Filesystem) (err erro
 	// Copy from d -> out from the filesystem
 	if err := filesystem.CopyFromFS(d, out, fs); err != nil {
 		return ScaffoldingError{"filesystem copy failed", err}
+	}
+
+	// Not my proudest moment
+	if runtime == "go" {
+		var data []byte
+		data, err = os.ReadFile(filepath.Join(src, "go.mod"))
+		if err != nil {
+			return fmt.Errorf("cannot read go.mod: %w", err)
+		}
+		r := regexp.MustCompile(`module\s+(\w+)`)
+		matches := r.FindSubmatch(data)
+		if len(matches) != 2 {
+			return fmt.Errorf("cannot parse go.mod")
+		}
+		moduleName := string(matches[1])
+		for _, n := range []string{"go.mod", "main.go"} {
+			p := filepath.Join(out, n)
+			data, err = os.ReadFile(p)
+			if err != nil {
+				return fmt.Errorf("cannot read scaffolding file: %w", err)
+			}
+			data = bytes.ReplaceAll(data, []byte("function"), []byte(moduleName))
+			err = os.WriteFile(p, data, 0644)
+			if err != nil {
+				return fmt.Errorf("cannot patch scaffolding code: %w", err)
+			}
+		}
 	}
 
 	// Copy the certs from the filesystem to the build directory

--- a/pkg/scaffolding/scaffold_test.go
+++ b/pkg/scaffolding/scaffold_test.go
@@ -82,6 +82,11 @@ func New() *F { return nil }
 		t.Fatal(err)
 	}
 
+	err = os.WriteFile(filepath.Join(root, "go.mod"), []byte("module foo"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// The output destination for the scaffolding
 	out := filepath.Join(root, "out")
 

--- a/pkg/scaffolding/testdata/testwrite/go/scaffolding/instanced-http/go.mod
+++ b/pkg/scaffolding/testdata/testwrite/go/scaffolding/instanced-http/go.mod
@@ -1,0 +1,3 @@
+module s
+
+go 1.22


### PR DESCRIPTION
Using incorrect name works for a functions with flat structure -- no sub-packages. When sub-packages are used we need to refer the user module by its true name.

```release
fix: allow sub-modules for Go functions
```