### PR TITLE
Update e2e ci workflow to test against arm for go and quarkus

### DIFF
--- a/.github/workflows/test-e2e-runtime.yaml
+++ b/.github/workflows/test-e2e-runtime.yaml
@@ -12,8 +12,20 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        runtime: ["node", "go", "quarkus", "springboot", "typescript", "rust"]
-    runs-on: ubuntu-latest
+        os: [ "ubuntu-latest", "ubuntu-24.04-arm" ]
+        runtime: ["go", "quarkus"]
+        include:
+          - os: ubuntu-latest
+            runtime: node
+          - os: ubuntu-latest
+            runtime: typescript
+          - os: ubuntu-latest
+            runtime: springboot
+          - os: ubuntu-latest
+            runtime: rust
+          - os: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Set Environment Variables
         run: |
@@ -22,6 +34,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: knative/actions/setup-go@main
       - name: Install Binaries
+        env:
+          ARCH: ${{ matrix.arch }}
         run: ./hack/install-binaries.sh
       - name: Allocate Cluster
         run: |


### PR DESCRIPTION
# Changes


- :gift: Adding test on arm64 for go and quarkus runtimes

/kind cleanup
