### PR TITLE
Enable arm64 python buildpack

### DIFF
--- a/hack/cmd/update-builder/main.go
+++ b/hack/cmd/update-builder/main.go
@@ -857,6 +857,18 @@ func fixupGoBuildpackARM64(ctx context.Context, config *builder.Config) error {
 		return fmt.Errorf("cannot download Go buildpack source code: %w", err)
 	}
 
+	// Set targets in Go package.toml to linux/arm64
+	f, err := os.OpenFile(filepath.Join(goBuildpackSrcDir, "package.toml"), os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return fmt.Errorf("cannot open package toml: %w", err)
+	}
+	targets := "\n[[targets]]\n  arch = \"arm64\"\n  os = \"linux\"\n"
+	_, err = f.Write([]byte(targets))
+	_ = f.Close()
+	if err != nil {
+		return fmt.Errorf("cannout update package toml: %w", err)
+	}
+
 	cfgReader := buildpackage.NewConfigReader()
 	packageConfig, err := cfgReader.Read(filepath.Join(goBuildpackSrcDir, "package.toml"))
 	if err != nil {

--- a/hack/cmd/update-builder/main.go
+++ b/hack/cmd/update-builder/main.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"syscall"
 
+	"golang.org/x/net/html"
 	"golang.org/x/oauth2"
 	"golang.org/x/term"
 
@@ -105,6 +106,12 @@ func buildBuilderImage(ctx context.Context, variant, version, arch, builderTomlP
 		err = fixupGoBuildpackARM64(ctx, &builderConfig)
 		if err != nil {
 			return "", fmt.Errorf("cannot fix Go buildpack: %w", err)
+		}
+		if variant == "base" {
+			err = fixupPythonBuildpackARM64(ctx, &builderConfig)
+			if err != nil {
+				return "", fmt.Errorf("cannot fix Python buildpack: %w", err)
+			}
 		}
 	}
 
@@ -279,7 +286,7 @@ func buildBuilderImageMultiArch(ctx context.Context, variant string) error {
 		"org.opencontainers.image.version":     *release.Name,
 	}).(v1.ImageIndex)
 	for _, arch := range []string{"arm64", "amd64"} {
-		if arch == "arm64" && variant != "tiny" {
+		if arch == "arm64" && variant == "full" {
 			_, _ = fmt.Fprintf(os.Stderr, "skipping arm64 build for variant: %q\n", variant)
 			continue
 		}
@@ -726,7 +733,10 @@ func downloadTarball(tarballUrl, destDir string) error {
 				return fmt.Errorf("cannot read from tar reader: %w", err)
 			}
 		case tar.TypeSymlink:
-			return fmt.Errorf("symlinks are not supported yet")
+			err = os.Symlink(hdr.Linkname, dest)
+			if err != nil {
+				return fmt.Errorf("cannot create a symlink: %w", err)
+			}
 		case tar.TypeDir:
 			err = os.MkdirAll(dest, 0755)
 			if err != nil {
@@ -1182,4 +1192,291 @@ func patchStack(stackTomlPath string) error {
 	}
 
 	return nil
+}
+
+func fixupPythonBuildpackARM64(ctx context.Context, config *builder.Config) error {
+	var (
+		pythonBuildpackIndex   int
+		pythonBuildpackVersion string
+	)
+	for i, moduleConfig := range config.Buildpacks {
+		uri := moduleConfig.ImageOrURI.URI
+		if strings.Contains(uri, "buildpacks/python:") {
+			pythonBuildpackIndex = i
+			pythonBuildpackVersion = uri[strings.LastIndex(uri, ":")+1:]
+			break
+		}
+	}
+	if pythonBuildpackVersion == "" {
+		return fmt.Errorf("python buildpack not found in the config")
+	}
+
+	buildDir, err := os.MkdirTemp("", "build-dir-*")
+	if err != nil {
+		return fmt.Errorf("cannot create temp dir: %w", err)
+	}
+	// sic! do not defer remove
+
+	pythonBuildpackSrcDir := filepath.Join(buildDir, "python")
+
+	pythonBuildpackRelease, err := getReleaseByVersion(ctx, "python", pythonBuildpackVersion)
+	if err != nil {
+		return fmt.Errorf("cannot get Python release: %w", err)
+	}
+
+	err = downloadTarball(*pythonBuildpackRelease.TarballURL, pythonBuildpackSrcDir)
+	if err != nil {
+		return fmt.Errorf("cannot download Python buildpack source code: %w", err)
+	}
+
+	// Set targets in Python package.toml to linux/arm64
+	f, err := os.OpenFile(filepath.Join(pythonBuildpackSrcDir, "package.toml"), os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return fmt.Errorf("cannot open package toml: %w", err)
+	}
+	targets := "\n[[targets]]\n  arch = \"arm64\"\n  os = \"linux\"\n"
+	_, err = f.Write([]byte(targets))
+	_ = f.Close()
+	if err != nil {
+		return fmt.Errorf("cannout update package toml: %w", err)
+	}
+
+	cfgReader := buildpackage.NewConfigReader()
+	packageConfig, err := cfgReader.Read(filepath.Join(pythonBuildpackSrcDir, "package.toml"))
+	if err != nil {
+		return fmt.Errorf("cannot read Python buildpack config: %w", err)
+	}
+
+	buildBuildpack := func(name, version string) error {
+		srcDir := filepath.Join(buildDir, name)
+		cmd := exec.CommandContext(ctx, "./scripts/package.sh", "--version", version)
+		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+		cmd.Dir = srcDir
+		cmd.Env = append(os.Environ(), "GOARCH=arm64")
+		err = cmd.Run()
+		if err != nil {
+			return fmt.Errorf("build of buildpack %q failed: %w", name, err)
+		}
+		return nil
+	}
+
+	type patchSourceFn = func(srcDir string) error
+	// these buildpacks need rebuild since they are only amd64 in paketo upstream
+	needsRebuild := map[string]patchSourceFn{
+		"cpython": func(srcDir string) error {
+			return fixupCPythonDistPkgRefs(filepath.Join(srcDir, "buildpack.toml"))
+		},
+		"miniconda": func(srcDir string) error {
+			return fixupMinicondaDistPkgRefs(filepath.Join(srcDir, "buildpack.toml"))
+		},
+		"conda-env-update": nil,
+		"pip":              nil,
+		"pip-install":      nil,
+		"pipenv":           nil,
+		"pipenv-install":   nil,
+		"poetry":           nil,
+		"poetry-install":   nil,
+		"poetry-run":       nil,
+		"python":           nil,
+		"python-start":     nil,
+	}
+
+	re := regexp.MustCompile(`^urn:cnb:registry:paketo-buildpacks/([\w-]+)@([\d.]+)$`)
+	for i, dep := range packageConfig.Dependencies {
+		m := re.FindStringSubmatch(dep.BuildpackURI.URI)
+		if len(m) != 3 {
+			return fmt.Errorf("cannot match buildpack name")
+		}
+		buildpackName := m[1]
+		buildpackVersion := m[2]
+
+		patch, ok := needsRebuild[buildpackName]
+		if !ok {
+			// this dependency does not require rebuild for arm64
+			continue
+		}
+
+		var rel *github.RepositoryRelease
+		rel, err = getReleaseByVersion(ctx, buildpackName, buildpackVersion)
+		if err != nil {
+			return fmt.Errorf("cannot get release: %w", err)
+		}
+
+		srcDir := filepath.Join(buildDir, buildpackName)
+
+		err = downloadTarball(*rel.TarballURL, srcDir)
+		if err != nil {
+			return fmt.Errorf("cannot get tarball: %w", err)
+		}
+		if patch != nil {
+			err = patch(srcDir)
+			if err != nil {
+				return fmt.Errorf("cannot patch source code: %w", err)
+			}
+		}
+
+		err = buildBuildpack(buildpackName, buildpackVersion)
+		if err != nil {
+			return err
+		}
+
+		packageConfig.Dependencies[i].URI = "file://" + filepath.Join(srcDir, "build", "buildpackage.cnb")
+
+	}
+
+	bs, err := toml.Marshal(&packageConfig)
+	err = os.WriteFile(filepath.Join(pythonBuildpackSrcDir, "package.toml"), bs, 0644)
+	if err != nil {
+		return fmt.Errorf("cannot update package.toml: %w", err)
+	}
+
+	err = buildBuildpack("python", pythonBuildpackVersion)
+	if err != nil {
+		return err
+	}
+
+	config.Buildpacks[pythonBuildpackIndex].BuildpackURI.URI = "file://" + filepath.Join(pythonBuildpackSrcDir, "build", "buildpackage.cnb")
+	fmt.Println(pythonBuildpackSrcDir)
+	return nil
+}
+
+func fixupCPythonDistPkgRefs(buildpackToml string) error {
+	tomlBytes, err := os.ReadFile(buildpackToml)
+	if err != nil {
+		return err
+	}
+
+	var config any
+	err = toml.Unmarshal(tomlBytes, &config)
+	if err != nil {
+		return err
+	}
+
+	deps := config.(map[string]any)["metadata"].(map[string]any)["dependencies"].([]map[string]any)
+
+	// Since there are no cpython arm64 packages we set uri to source.
+	// This will cause cpython compilation to be done during the build process.
+	// This takes a while, but it's done only once per project.
+	for _, dep := range deps {
+		dep["checksum"] = dep["source-checksum"]
+		dep["uri"] = dep["source"]
+	}
+
+	bs, err := toml.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(buildpackToml, bs, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func fixupMinicondaDistPkgRefs(buildpackToml string) error {
+	tomlBytes, err := os.ReadFile(buildpackToml)
+	if err != nil {
+		return err
+	}
+
+	var config any
+	err = toml.Unmarshal(tomlBytes, &config)
+	if err != nil {
+		return err
+	}
+
+	deps := config.(map[string]any)["metadata"].(map[string]any)["dependencies"].([]map[string]any)
+	for _, dep := range deps {
+		if dep["name"] == "Miniconda.sh" {
+			newURI := strings.ReplaceAll(dep["uri"].(string), "x86_64", "aarch64")
+			dep["uri"] = newURI
+
+			parts := strings.Split(newURI, "/")
+			basename := parts[len(parts)-1]
+			var sum string
+			sum, err = getMinicondaHash(basename)
+			if err != nil {
+				return fmt.Errorf("cannot find hash for the dependency: %w", err)
+			}
+			dep["sha256"] = sum
+		}
+	}
+
+	bs, err := toml.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(buildpackToml, bs, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getMinicondaHash(basename string) (string, error) {
+	resp, err := http.Get("https://repo.anaconda.com/miniconda/")
+	if err != nil {
+		return "", err
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("bad http code: %d", resp.StatusCode)
+	}
+
+	n, err := html.Parse(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	tbody := findNode(n, func(n *html.Node) bool {
+		return n.Data == "tbody"
+	})
+	if tbody == nil {
+		return "", fmt.Errorf("table body not found")
+	}
+
+	for tr := range tbody.ChildNodes() {
+		f, l := firstLastTD(tr)
+		if f != l &&
+			f != nil && f.FirstChild != nil && f.FirstChild.FirstChild != nil &&
+			l != nil && l.FirstChild != nil {
+			if f.FirstChild.FirstChild.Data == basename {
+				return l.FirstChild.Data, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("hash not found")
+}
+
+func findNode(node *html.Node, pred func(*html.Node) bool) *html.Node {
+	if pred(node) {
+		return node
+	}
+	for ch := range node.ChildNodes() {
+		n := findNode(ch, pred)
+		if n != nil {
+			return n
+		}
+	}
+	return nil
+}
+
+func firstLastTD(tr *html.Node) (*html.Node, *html.Node) {
+	var f, l *html.Node
+	for ch := range tr.ChildNodes() {
+		if ch.Data == "td" {
+			if f == nil {
+				f = ch
+			}
+			l = ch
+		}
+	}
+	return f, l
 }

--- a/hack/cmd/update-builder/main.go
+++ b/hack/cmd/update-builder/main.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"sort"
 	"strings"
 	"syscall"
 
@@ -113,6 +114,13 @@ func buildBuilderImage(ctx context.Context, variant, version, arch, builderTomlP
 				return "", fmt.Errorf("cannot fix Python buildpack: %w", err)
 			}
 		}
+		// Sort by URI. This ensures locally build buildpacks (URI starting with 'file://') are last.
+		// This is needed so locally build "sub buildpacks" are not overridden by upstream buildpacks (with bad arch).
+		sort.Slice(builderConfig.Buildpacks, func(i, j int) bool {
+			a := builderConfig.Buildpacks[i].URI
+			b := builderConfig.Buildpacks[j].URI
+			return a < b
+		})
 	}
 
 	err = updateJavaBuildpacks(ctx, &builderConfig, arch)

--- a/hack/cmd/update-builder/main.go
+++ b/hack/cmd/update-builder/main.go
@@ -1220,7 +1220,7 @@ func fixupPythonBuildpackARM64(ctx context.Context, config *builder.Config) erro
 		pythonBuildpackVersion string
 	)
 	for i, moduleConfig := range config.Buildpacks {
-		uri := moduleConfig.ImageOrURI.URI
+		uri := moduleConfig.URI
 		if strings.Contains(uri, "buildpacks/python:") {
 			pythonBuildpackIndex = i
 			pythonBuildpackVersion = uri[strings.LastIndex(uri, ":")+1:]
@@ -1303,7 +1303,7 @@ func fixupPythonBuildpackARM64(ctx context.Context, config *builder.Config) erro
 
 	re := regexp.MustCompile(`^urn:cnb:registry:paketo-buildpacks/([\w-]+)@([\d.]+)$`)
 	for i, dep := range packageConfig.Dependencies {
-		m := re.FindStringSubmatch(dep.BuildpackURI.URI)
+		m := re.FindStringSubmatch(dep.URI)
 		if len(m) != 3 {
 			return fmt.Errorf("cannot match buildpack name")
 		}
@@ -1355,7 +1355,7 @@ func fixupPythonBuildpackARM64(ctx context.Context, config *builder.Config) erro
 		return err
 	}
 
-	config.Buildpacks[pythonBuildpackIndex].BuildpackURI.URI = "file://" + filepath.Join(pythonBuildpackSrcDir, "build", "buildpackage.cnb")
+	config.Buildpacks[pythonBuildpackIndex].URI = "file://" + filepath.Join(pythonBuildpackSrcDir, "build", "buildpackage.cnb")
 	fmt.Println(pythonBuildpackSrcDir)
 	return nil
 }
@@ -1438,6 +1438,7 @@ func fixupMinicondaDistPkgRefs(buildpackToml string) error {
 }
 
 func getMinicondaHash(basename string) (string, error) {
+	//nolint:bodyclose
 	resp, err := http.Get("https://repo.anaconda.com/miniconda/")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
