### PR TITLE
fix: e2e scenarion config test errorf format for go 1.24 

### DIFF
--- a/test/e2e/scenario_config-envs_test.go
+++ b/test/e2e/scenario_config-envs_test.go
@@ -210,7 +210,7 @@ func TestConfigEnvs(t *testing.T) {
 		}
 		if result != "" {
 			t.Logf("Response received:\n%v", responseBody)
-			return fmt.Errorf(result)
+			return fmt.Errorf("%v", result)
 		}
 		return nil
 	}


### PR DESCRIPTION
e2e scenarion config test errorf format fix

This new format is for go 1.24 which is introduced in the next open deps PR