### PR TITLE
Make  docker.io/heroku/ builders trusted

### DIFF
--- a/pkg/builders/buildpacks/builder.go
+++ b/pkg/builders/buildpacks/builder.go
@@ -51,6 +51,7 @@ var (
 		"docker.io/paketobuildpacks/",
 		"gcr.io/buildpacks/",
 		"ghcr.io/knative/",
+		"docker.io/heroku/",
 	}
 
 	defaultBuildpacks = map[string][]string{}


### PR DESCRIPTION
 Make heroku's builders trusted.

fixes #2516

```release-note
feat: make heroku's builders trusted
```