### PR TITLE
Fix: do not override uid/git in buildpack builder

### DIFF
--- a/pkg/builders/builders_int_test.go
+++ b/pkg/builders/builders_int_test.go
@@ -65,7 +65,7 @@ func TestPrivateGitRepository(t *testing.T) {
 	}
 
 	gitCredsDir := t.TempDir()
-	err := os.WriteFile(filepath.Join(gitCredsDir, "type"), []byte(`git-credentials`), 0600)
+	err := os.WriteFile(filepath.Join(gitCredsDir, "type"), []byte(`git-credentials`), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func TestPrivateGitRepository(t *testing.T) {
 username=developer
 password=nbusr123
 `
-	err = os.WriteFile(filepath.Join(gitCredsDir, "credentials"), []byte(gitCred), 0600)
+	err = os.WriteFile(filepath.Join(gitCredsDir, "credentials"), []byte(gitCred), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/builders/buildpacks/builder.go
+++ b/pkg/builders/buildpacks/builder.go
@@ -153,6 +153,8 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 	}
 	// Pack build options
 	opts := pack.BuildOptions{
+		GroupID:        -1,
+		UserID:         -1,
 		AppPath:        f.Root,
 		Image:          f.Build.Image,
 		LifecycleImage: DefaultLifecycleImage,


### PR DESCRIPTION
Zero value implies override (to root presumably),
we must set it to negative value.

I really dislike that zero value is not neutral here.

fixes: #2516

```release-note
fix: error "failed to write group file" when using untrusted builder (#2516)
```