### PR TITLE
upgrade podman-next packages to fedora 41 for nightly podman test

### DIFF
--- a/.github/workflows/test-podman-next.yaml
+++ b/.github/workflows/test-podman-next.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Install Podman Next (Nightly Build)
         env:
-          FEDORA_RELEASE: 40
+          FEDORA_RELEASE: 41
           BASE_ARCH: x86_64
         run: |
           sudo apt update 


### PR DESCRIPTION
# Changes

- :broom: Update podman next install to use fedora 41 packages

