### PR TITLE
test: fix python e2e http test

### DIFF
--- a/test/e2e/scenario_runtime-http_test.go
+++ b/test/e2e/scenario_runtime-http_test.go
@@ -121,8 +121,8 @@ var httpFuncValidatorMap = map[string]FuncResponsivenessValidator{
 		expects: "message=hello",
 	},
 	"python": {
-		urlMask: "%s?message=hello",
-		expects: `{"message": "hello"}`,
+		urlMask: "%s",
+		expects: `OK`,
 	},
 	"quarkus": {
 		urlMask: "%s?message=hello",


### PR DESCRIPTION
# Changes

- :broom: Fix python test.

Default python functions no longer echoes as response what it receives from request. It just returns "OK", so this fix python tests used on midstream