### PR TITLE
feat: adds command for mcp server

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+	"knative.dev/func/pkg/mcp"
+)
+
+func NewMCPServerCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mcp",
+		Short: "Start MCP server",
+		Long: `
+NAME
+	{{rootCmdUse}} mcp - start a Model Context Protocol (MCP) server
+
+SYNOPSIS
+	{{rootCmdUse}} mcp [flags]
+
+DESCRIPTION
+	Starts a Model Context Protocol (MCP) server over standard input/output (stdio) transport.
+	This implementation aims to support tools for deploying and creating serverless functions.
+	
+	Note: This command is still under development.
+
+EXAMPLES
+
+	o Run an MCP server:
+		{{rootCmdUse}} mcp
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMCPServer(cmd, args)
+		},
+	}
+	return cmd
+}
+
+func runMCPServer(cmd *cobra.Command, args []string) error {
+	s := mcp.NewServer()
+	if err := s.Start(); err != nil {
+		log.Fatalf("Server error: %v", err)
+		return err
+	}
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,6 +108,12 @@ Learn more about Knative at: https://knative.dev`, cfg.Name),
 			},
 		},
 		{
+			Header: "MCP Commands:",
+			Commands: []*cobra.Command{
+				NewMCPServerCmd(),
+			},
+		},
+		{
 			Header: "Other Commands:",
 			Commands: []*cobra.Command{
 				NewCompletionCmd(),

--- a/docs/reference/func.md
+++ b/docs/reference/func.md
@@ -34,6 +34,7 @@ Learn more about Knative at: https://knative.dev
 * [func invoke](func_invoke.md)	 - Invoke a local or remote function
 * [func languages](func_languages.md)	 - List available function language runtimes
 * [func list](func_list.md)	 - List deployed functions
+* [func mcp](func_mcp.md)	 - Start MCP server
 * [func repository](func_repository.md)	 - Manage installed template repositories
 * [func run](func_run.md)	 - Run the function locally
 * [func subscribe](func_subscribe.md)	 - Subscribe a function to events

--- a/docs/reference/func_mcp.md
+++ b/docs/reference/func_mcp.md
@@ -1,0 +1,39 @@
+## func mcp
+
+Start MCP server
+
+### Synopsis
+
+
+NAME
+	func mcp - start a Model Context Protocol (MCP) server
+
+SYNOPSIS
+	func mcp [flags]
+
+DESCRIPTION
+	Starts a Model Context Protocol (MCP) server over standard input/output (stdio) transport.
+	This implementation aims to support tools for deploying and creating serverless functions.
+
+	Note: This command is still under development.
+
+EXAMPLES
+
+	o Run an MCP server:
+		func mcp
+
+
+```
+func mcp
+```
+
+### Options
+
+```
+  -h, --help   help for mcp
+```
+
+### SEE ALSO
+
+* [func](func.md)	 - func manages Knative Functions
+

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/hinshun/vt10x v0.0.0-20220228203356-1ab2cad5fd82
 	github.com/manifestival/client-go-client v0.6.0
 	github.com/manifestival/manifestival v0.7.2
+	github.com/mark3labs/mcp-go v0.30.0
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/openshift-pipelines/pipelines-as-code v0.31.0
 	github.com/openshift/source-to-image v1.5.0
@@ -246,7 +247,7 @@ require (
 	github.com/skeema/knownhosts v1.3.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
-	github.com/spf13/cast v1.6.0 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.18.2 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
@@ -264,6 +265,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -717,6 +717,8 @@ github.com/manifestival/client-go-client v0.6.0/go.mod h1:2x6VHJ9/2It3TknttgiDgr
 github.com/manifestival/manifestival v0.7.1/go.mod h1:nl3T6HlfHCeidooWVTMI9vYNTBkQ1GdhLNb+smozbdk=
 github.com/manifestival/manifestival v0.7.2 h1:l4uFdWX/xQK4QcRfqGoMtBvaZeWPEuwD6hVsCwUqZY4=
 github.com/manifestival/manifestival v0.7.2/go.mod h1:nl3T6HlfHCeidooWVTMI9vYNTBkQ1GdhLNb+smozbdk=
+github.com/mark3labs/mcp-go v0.30.0 h1:Taz7fiefkxY/l8jz1nA90V+WdM2eoMtlvwfWforVYbo=
+github.com/mark3labs/mcp-go v0.30.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -1004,8 +1006,8 @@ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
-github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
+github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
+github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/cobra v1.6.0/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
@@ -1106,6 +1108,8 @@ github.com/xhit/go-str2duration v1.2.0/go.mod h1:3cPSlfZlUHVlneIVfePFWcJZsuwf+P1
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -1,0 +1,43 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+type MCPServer struct {
+	server *server.MCPServer
+}
+
+func NewServer() *MCPServer {
+	mcpServer := server.NewMCPServer(
+		"func-mcp",
+		"1.0.0",
+		server.WithToolCapabilities(true),
+	)
+	mcpServer.AddTool(
+		mcp.NewTool("healthcheck",
+			mcp.WithDescription("Checks if the server is running"),
+		),
+		handleHealthCheckTool,
+	)
+
+	return &MCPServer{
+		server: mcpServer,
+	}
+}
+
+func (s *MCPServer) Start() error {
+	return server.ServeStdio(s.server)
+}
+
+func handleHealthCheckTool(
+	ctx context.Context,
+	request mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	body := []byte(fmt.Sprintf(`{"message": "%s"}`, "The MCP server is running!"))
+	return mcp.NewToolResultText(string(body)), nil
+}


### PR DESCRIPTION
This PR aims to add `func mcp` command which can be used to start a MCP (Model Context Protocol) server.

Part of #2690 