### PR TITLE
Fix detection of hostname resolution failure

### DIFF
--- a/pkg/docker/pusher.go
+++ b/pkg/docker/pusher.go
@@ -202,7 +202,9 @@ func (n *Pusher) pushImage(ctx context.Context, f fn.Function, credentials Crede
 		return digest, nil
 	}
 	errStr := err.Error()
-	if strings.Contains(errStr, "no such host") || strings.Contains(errStr, "failure in name resolution") {
+	if strings.Contains(errStr, "no such host") ||
+		strings.Contains(errStr, "failure in name resolution") ||
+		regexp.MustCompile(`lookup .*: server misbehaving`).MatchString(errStr) {
 		// push with custom transport to be able to push into cluster private registries
 		return n.push(ctx, f, credentials, output)
 	}


### PR DESCRIPTION
# Changes

Fix detection of hostname resolution failure.
It appears that newer version of docker outputs different error when registry hostname is not resolvable.
We must account for that otherwise "in cluster dialer" would not kick in when necessary.


/kind bug


```release-note
fix: in-culster-dialer not used when it should be when pushing image to in cluster registry
```
