### PR TITLE
Issue #2835 - Fix Tekton task "func-buildpacks" prepare/results steps use non-multi-arch bash:5.1.4 image, causing exec format errors on ARM64

### DIFF
--- a/pkg/pipelines/tekton/tasks.go
+++ b/pkg/pipelines/tekton/tasks.go
@@ -101,7 +101,7 @@ spec:
 
   steps:
     - name: prepare
-      image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
+      image: docker.io/library/bash:5.1
       args:
         - "--env-vars"
         - "$(params.ENV_VARS[*])"
@@ -207,7 +207,7 @@ spec:
         runAsGroup: 0
 
     - name: results
-      image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
+      image: docker.io/library/bash:5.1
       script: |
         #!/usr/bin/env bash
         set -e


### PR DESCRIPTION
# Changes

- :bug: Tekton task "func-buildpacks" prepare/results steps use non-multi-arch bash:5.1.4 image, causing exec format errors on ARM64

/kind bug

Fixes #2835


```
fix: fixes issue with func in-cluster build/deploy pipelines to work on ARM64
```

