### PR TITLE
Fix non-containerized build/run with external deps

### DIFF
--- a/pkg/functions/runner.go
+++ b/pkg/functions/runner.go
@@ -110,12 +110,25 @@ func runGo(ctx context.Context, job *Job) (err error) {
 		fmt.Printf("cd %v && go build -o f.bin\n", job.Dir())
 	}
 
-	// Build
-	args := []string{"build", "-o", "f.bin"}
+	args := []string{"mod", "tidy"}
 	if job.verbose {
 		args = append(args, "-v")
 	}
 	cmd := exec.CommandContext(ctx, "go", args...)
+	cmd.Dir = job.Dir()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return
+	}
+
+	// Build
+	args = []string{"build", "-o", "f.bin"}
+	if job.verbose {
+		args = append(args, "-v")
+	}
+	cmd = exec.CommandContext(ctx, "go", args...)
 	cmd.Dir = job.Dir()
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/oci/go_builder.go
+++ b/pkg/oci/go_builder.go
@@ -89,8 +89,18 @@ func goBuild(cfg buildJob, p v1.Platform) (binPath string, err error) {
 		fmt.Printf("   %v\n", filepath.Base(outpath))
 	}
 
+	cmd := exec.CommandContext(cfg.ctx, gobin, "mod", "tidy")
+	cmd.Env = envs
+	cmd.Dir = cfg.buildDir()
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	err = cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("cannot sync deps: %w", err)
+	}
+
 	// Build the function
-	cmd := exec.CommandContext(cfg.ctx, gobin, args...)
+	cmd = exec.CommandContext(cfg.ctx, gobin, args...)
 	cmd.Env = envs
 	cmd.Dir = cfg.buildDir()
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
# Changes

Fix non-containerized build/run with external deps.
It's necessary to call "go mod tidy" on scaffolded code.


/kind bug


```release-note
fix: non-containerized build/run with external dependencies
```
