### PR TITLE
Changed volume uploader pod image pull policy to "Always"

### DIFF
--- a/pkg/k8s/persistent_volumes.go
+++ b/pkg/k8s/persistent_volumes.go
@@ -128,12 +128,13 @@ func runWithVolumeMounted(ctx context.Context, podImage string, podCommand []str
 			SecurityContext: defaultPodSecurityContext(),
 			Containers: []corev1.Container{
 				{
-					Name:       podName,
-					Image:      podImage,
-					Stdin:      true,
-					StdinOnce:  true,
-					WorkingDir: volumeMntPoint,
-					Command:    podCommand,
+					Name:            podName,
+					Image:           podImage,
+					ImagePullPolicy: corev1.PullAlways,
+					Stdin:           true,
+					StdinOnce:       true,
+					WorkingDir:      volumeMntPoint,
+					Command:         podCommand,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      pVol,


### PR DESCRIPTION
# Changes
 
- :bug: Fix stale func-utils:v2 image usage by changing imagePullPolicy to "Always"

/kind bug

Fixes #2835 

Default image pull policy was "IfNotPresent", therefore the image would be pulled only once, unless manually changed, and builds would not pull new updated images.

Problem described in https://github.com/knative/func/issues/2835#issuecomment-2913756811.
Solved by changing the image pull policy of the volume-uploader pod only.

As the volume uploader pod runs before any tasks in https://github.com/knative/func/blob/main/pkg/pipelines/tekton/tasks.go, if the tasks use the default func-utils:v2 image, then those pods will also use the latest image.

**Release Note**

```release-note
Fixes a bug where remote tekton builds would use a stale image to upload the source directory.
```
