### PR TITLE
feat: add noninteractive path to func config envs remove

### DIFF
--- a/docs/reference/func_config_envs_remove.md
+++ b/docs/reference/func_config_envs_remove.md
@@ -18,6 +18,7 @@ func config envs remove
 
 ```
   -h, --help          help for remove
+      --name string   Name of the environment variable.
   -p, --path string   Path to the function.  Default is current directory ($FUNC_PATH)
   -v, --verbose       Print verbose logs ($FUNC_VERBOSE)
 ```


### PR DESCRIPTION
/kind enhancement

```release-note
func config remove now supports noninteractive usecases via a --name flag
```