### PR TITLE
fix: remove redundant initialized check

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -304,9 +304,6 @@ func (c buildConfig) Prompt() (buildConfig, error) {
 	if err != nil {
 		return c, err
 	}
-	if !f.Initialized() {
-		return c, fmt.Errorf("no function has been initialized in %q. Please initialize a function by running:\n- func init --language <your language>", c.Path)
-	}
 	if (f.Registry == "" && c.Registry == "" && c.Image == "") || c.Confirm {
 		fmt.Println("A registry for function images is required. For example, 'docker.io/tigerteam'.")
 		err := survey.AskOne(


### PR DESCRIPTION
This initialized check is redundant, and leads to an error in a forthcoming E2E test case, and is thus removed here preemptively.

/kind cleanup