### PR TITLE
feat: add labels to func describe

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -81,6 +82,9 @@ func runDescribe(cmd *cobra.Command, args []string, newClient ClientFactory) (er
 		if err != nil {
 			return err
 		}
+		if !f.Initialized() {
+			return errors.New("function not found at this path and no name provided")
+		}
 		details, err = client.Describe(cmd.Context(), "", "", f)
 		if err != nil {
 			return err
@@ -153,6 +157,13 @@ func (i info) Human(w io.Writer) error {
 			fmt.Fprintf(w, "  %v %v %v\n", s.Source, s.Type, s.Broker)
 		}
 	}
+
+	if len(i.Labels) > 0 {
+		fmt.Fprintln(w, "Labels:")
+		for k, v := range i.Labels {
+			fmt.Fprintf(w, "  %v: %v\n", k, v)
+		}
+	}
 	return nil
 }
 
@@ -168,6 +179,12 @@ func (i info) Plain(w io.Writer) error {
 	if len(i.Subscriptions) > 0 {
 		for _, s := range i.Subscriptions {
 			fmt.Fprintf(w, "Subscription %v %v %v\n", s.Source, s.Type, s.Broker)
+		}
+	}
+
+	if len(i.Labels) > 0 {
+		for k, v := range i.Labels {
+			fmt.Fprintf(w, "Label %v %v\n", k, v)
 		}
 	}
 	return nil

--- a/pkg/functions/client.go
+++ b/pkg/functions/client.go
@@ -973,16 +973,19 @@ func (c *Client) Describe(ctx context.Context, name, namespace string, f Functio
 		return c.describer.Describe(ctx, name, namespace)
 	}
 
-	// If the function's not initialized, then we can save some time and
-	// fail fast.
+	// Desribe Current Function
+	// ------------------------
 	if !f.Initialized() {
-		return d, fmt.Errorf("function not initialized: %v", f.Root)
+		return d, NewErrNotInitialized(f.Root)
 	}
 
 	// If the function is undeployed, we can't describe it either.
 	if f.Name == "" {
 		return d, fmt.Errorf("unable to describe without a name. %v", ErrNameRequired)
 	}
+
+	// If it has a populated deployed namespace, we can presume it's deployed
+	// and attempt to describe.
 
 	return c.describer.Describe(ctx, f.Name, f.Deploy.Namespace)
 }

--- a/pkg/knative/describer.go
+++ b/pkg/knative/describer.go
@@ -98,5 +98,10 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (descr
 
 	description.Subscriptions = subscriptions
 
+	// Populate labels from the service
+	if service.Labels != nil {
+		description.Labels = service.Labels
+	}
+
 	return
 }


### PR DESCRIPTION
Adds a "Labels" section to describe command's output.

/kind enhancement

Note that, as with the other `func config ...` commands, adding unit tests is not possible without a refactor.  The forthcoming E2E tests do test these features, and unit tests will be added when these subcommands are refactored to match the testability of the other commands.

```release-note
Function describe subcommand now includes labels.
```