### PR TITLE
feat: Python,Go func listen dual-stack

### DIFF
--- a/pkg/builders/s2i/builder.go
+++ b/pkg/builders/s2i/builder.go
@@ -179,7 +179,7 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 		return err
 	}
 
-	buildEnvs["LISTEN_ADDRESS"] = "0.0.0.0:8080"
+	buildEnvs["LISTEN_ADDRESS"] = "[::]:8080"
 	for k, v := range buildEnvs {
 		cfg.Environment = append(cfg.Environment, api.EnvironmentSpec{Name: k, Value: v})
 	}

--- a/pkg/oci/go_builder.go
+++ b/pkg/oci/go_builder.go
@@ -25,6 +25,7 @@ func (b goBuilder) Base() string {
 func (b goBuilder) Configure(_ buildJob, _ v1.Platform, cf v1.ConfigFile) (v1.ConfigFile, error) {
 	// : Using Cmd rather than Entrypoint due to it being overrideable.
 	cf.Config.Cmd = []string{"/func/f"}
+	cf.Config.Env = append(cf.Config.Env, "LISTEN_ADDRESS=[::]:8080")
 	return cf, nil
 }
 

--- a/pkg/oci/python_builder.go
+++ b/pkg/oci/python_builder.go
@@ -31,7 +31,7 @@ func (b pythonBuilder) Configure(job buildJob, _ v1.Platform, cf v1.ConfigFile) 
 		svcPath       = filepath.Join("/func", svcRelPath)              // eg /func/.func/builds/by-hash/$HASH
 		pythonPathEnv = fmt.Sprintf("PYTHONPATH=%v/lib", svcPath)
 		mainPath      = fmt.Sprintf("%v/service/main.py", svcPath)
-		listenAddrEnv = "LISTEN_ADDRESS=0.0.0.0:8080"
+		listenAddrEnv = "LISTEN_ADDRESS=[::]:8080"
 	)
 
 	cf.Config.Env = append(cf.Config.Env, pythonPathEnv, listenAddrEnv)


### PR DESCRIPTION
# Changes

- :gift: Python and Go function listen dualstack.
           On Linux listening on `[::]` also listen on `0.0.0.0`.


/kind enhancement


```release-note
feat: Python and Go function listen dualstack
```

