### PR TITLE
Prevent 503 on e2e subscriber test

### DIFF
--- a/test/e2e/scenario_subscribe_test.go
+++ b/test/e2e/scenario_subscribe_test.go
@@ -200,7 +200,7 @@ func TestFunctionSubscribeEvents(t *testing.T) {
 		}
 		waitChan <- true
 	}()
-	time.Sleep(2 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	// Invoke Producer func to force Event A to be emitted. The event should be received by func
 	testhttp.TestGet(t, funcSubTest.FuncProducerUrl+"?type="+funcSubTest.SubscribeToEventType+"&message=EVENT_A_CATCH_ME")


### PR DESCRIPTION
# Changes

Preventing 503 error on e2e subscriber test, by ginving a little more time before assertion.