### PR TITLE
chore: fix build and test tags

### DIFF
--- a/pkg/docker/creds/credentials_test.go
+++ b/pkg/docker/creds/credentials_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package creds_test
 
 import (

--- a/pkg/docker/pusher_test.go
+++ b/pkg/docker/pusher_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package docker_test
 
 import (

--- a/pkg/docker/runner_test.go
+++ b/pkg/docker/runner_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package docker_test
 
 import (

--- a/pkg/functions/client_test.go
+++ b/pkg/functions/client_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package functions_test
 
 import (

--- a/pkg/functions/config_test.go
+++ b/pkg/functions/config_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package functions_test
 
 // Config tests do not have private access, as they are testing manifest

--- a/pkg/functions/function_envs_unit_test.go
+++ b/pkg/functions/function_envs_unit_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package functions
 
 import (

--- a/pkg/functions/function_git_unit_test.go
+++ b/pkg/functions/function_git_unit_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package functions
 
 import (

--- a/pkg/functions/function_labels_unit_test.go
+++ b/pkg/functions/function_labels_unit_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package functions
 
 import (

--- a/pkg/functions/function_migrations_unit_test.go
+++ b/pkg/functions/function_migrations_unit_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package functions
 
 import (

--- a/pkg/functions/function_options_unit_test.go
+++ b/pkg/functions/function_options_unit_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package functions
 
 import (

--- a/pkg/functions/function_test.go
+++ b/pkg/functions/function_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package functions_test
 
 import (

--- a/pkg/functions/function_unit_test.go
+++ b/pkg/functions/function_unit_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package functions
 
 import (

--- a/pkg/functions/function_volumes_unit_test.go
+++ b/pkg/functions/function_volumes_unit_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package functions
 
 import (

--- a/pkg/functions/instances_test.go
+++ b/pkg/functions/instances_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package functions
 
 import (

--- a/pkg/functions/job_test.go
+++ b/pkg/functions/job_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package functions
 
 import (

--- a/pkg/functions/repositories_test.go
+++ b/pkg/functions/repositories_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package functions_test
 
 import (

--- a/pkg/functions/repository_test.go
+++ b/pkg/functions/repository_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package functions_test
 
 import (

--- a/pkg/functions/runner_test.go
+++ b/pkg/functions/runner_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package functions
 
 import (

--- a/pkg/functions/templates_test.go
+++ b/pkg/functions/templates_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package functions_test
 
 import (

--- a/pkg/knative/deployer_test.go
+++ b/pkg/knative/deployer_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package knative
 
 import (

--- a/pkg/pipelines/tekton/validate_test.go
+++ b/pkg/pipelines/tekton/validate_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package tekton
 
 import (

--- a/pkg/scaffolding/detectors_test.go
+++ b/pkg/scaffolding/detectors_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package scaffolding
 
 import (

--- a/pkg/scaffolding/scaffold_test.go
+++ b/pkg/scaffolding/scaffold_test.go
@@ -1,6 +1,3 @@
-//go:build !integration
-// +build !integration
-
 package scaffolding
 
 import (


### PR DESCRIPTION
removes !integration build tags

The current build tagging system was predicated on the idea that
integraion, e2e and unit tests are entirely separate.  The correct way
to treat these is as inclusive with unit tests.  Thus this pr removes
the exclusion of unit test from integration tests runs, treating `-tags
integration` as indicating "unit tests plus integration tests".


/kind cleanup