### PR TITLE
fix: refer correct version of schema in func.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ VTAG         := $(shell [ -z $(VTAG) ] && echo $(ETAG) || echo $(VTAG))
 VERS         ?= $(shell git describe --tags --match 'v*')
 KVER         ?= $(shell git describe --tags --match 'knative-*')
 
-LDFLAGS      := -X knative.dev/func/pkg/app.vers=$(VERS) -X knative.dev/func/pkg/app.kver=$(KVER) -X knative.dev/func/pkg/app.hash=$(HASH)
+LDFLAGS      := -X knative.dev/func/pkg/version.Vers=$(VERS) -X knative.dev/func/pkg/version.Kver=$(KVER) -X knative.dev/func/pkg/version.Hash=$(HASH)
 
 FUNC_UTILS_IMG ?= ghcr.io/knative/func-utils:v2
 LDFLAGS += -X knative.dev/func/pkg/k8s.SocatImage=$(FUNC_UTILS_IMG)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/alecthomas/jsonschema v0.0.0-20220216202328-9eeeec9d044b
+	github.com/blang/semver/v4 v4.0.0
 	github.com/buildpacks/pack v0.36.4
 	github.com/chainguard-dev/git-urls v1.0.2
 	github.com/cloudevents/sdk-go/v2 v2.15.2
@@ -111,7 +112,6 @@ require (
 	github.com/aws/smithy-go v1.22.2 // indirect
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20250205235911-d2398ba46815 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
 	github.com/buildpacks/imgutil v0.0.0-20240605145725-186f89b2d168 // indirect
 	github.com/buildpacks/libcnb v1.30.3 // indirect

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -10,11 +10,11 @@ import (
 	"syscall"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
+
 	"knative.dev/func/cmd"
 	"knative.dev/func/pkg/docker"
+	"knative.dev/func/pkg/version"
 )
-
-var vers, kver, hash string
 
 func Main() {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -32,9 +32,9 @@ func Main() {
 	cfg := cmd.RootCommandConfig{
 		Name: "func",
 		Version: cmd.Version{
-			Vers: vers,
-			Kver: kver,
-			Hash: hash,
+			Vers: version.Vers,
+			Kver: version.Kver,
+			Hash: version.Hash,
 		}}
 
 	if err := cmd.NewRootCmd(cfg).ExecuteContext(ctx); err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+var Vers, Kver, Hash string


### PR DESCRIPTION
# Changes

- Refer correct version of schema in func.yaml. Before we erroneously referred `specversion`, *not* `git` reference (branch/tag/hash).
- Moved version info into separate package to break cyclical dependency.

/kind bug

```release-note
fix: refer correct version of schema in func.yaml
```
