### PR TITLE
mcp: adds labels and envs config tools and resources

### DIFF
--- a/pkg/mcp/help.go
+++ b/pkg/mcp/help.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -44,6 +45,11 @@ func handleCmdHelpPrompt(ctx context.Context, request mcp.GetPromptRequest) (*mc
 		return nil, fmt.Errorf("cmd is required")
 	}
 
+	parts := strings.Fields(cmd)
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("invalid cmd: %s", cmd)
+	}
+
 	return mcp.NewGetPromptResult(
 		"Cmd Help Prompt",
 		[]mcp.PromptMessage{
@@ -54,7 +60,7 @@ func handleCmdHelpPrompt(ctx context.Context, request mcp.GetPromptRequest) (*mc
 			mcp.NewPromptMessage(
 				mcp.RoleAssistant,
 				mcp.NewEmbeddedResource(mcp.TextResourceContents{
-					URI:      fmt.Sprintf("func://%s/docs", cmd),
+					URI:      fmt.Sprintf("func://%s/docs", strings.Join(parts, "/")),
 					MIMEType: "text/plain",
 				}),
 			),

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -177,6 +177,47 @@ func NewServer() *MCPServer {
 		),
 		handleConfigVolumesTool,
 	)
+
+	mcpServer.AddTool(
+		mcp.NewTool("config_labels",
+			mcp.WithDescription("Lists and manages labels for a function"),
+			mcp.WithString("action",
+				mcp.Required(),
+				mcp.Description("The action to perform: 'add' to add a label, 'remove' to remove a label, 'list' to list labels"),
+			),
+			mcp.WithString("path",
+				mcp.Required(),
+				mcp.Description("Path to the function. Default is current directory ($FUNC_PATH)"),
+			),
+
+			// Optional flags
+			mcp.WithString("name", mcp.Description("Name of the label.")),
+			mcp.WithString("value", mcp.Description("Value of the label.")),
+			mcp.WithBoolean("verbose", mcp.Description("Print verbose logs ($FUNC_VERBOSE)")),
+		),
+		handleConfigLabelsTool,
+	)
+
+	mcpServer.AddTool(
+		mcp.NewTool("config_envs",
+			mcp.WithDescription("Lists and manages environment variables for a function"),
+			mcp.WithString("action",
+				mcp.Required(),
+				mcp.Description("The action to perform: 'add' to add an env var, 'remove' to remove, 'list' to list env vars"),
+			),
+			mcp.WithString("path",
+				mcp.Required(),
+				mcp.Description("Path to the function. Default is current directory ($FUNC_PATH)"),
+			),
+
+			// Optional flags
+			mcp.WithString("name", mcp.Description("Name of the environment variable.")),
+			mcp.WithString("value", mcp.Description("Value of the environment variable.")),
+			mcp.WithBoolean("verbose", mcp.Description("Print verbose logs ($FUNC_VERBOSE)")),
+		),
+		handleConfigEnvsTool,
+	)
+
 	mcpServer.AddResource(mcp.NewResource(
 		"func://docs",
 		"Root Help Command",
@@ -245,7 +286,43 @@ func NewServer() *MCPServer {
 		mcp.WithResourceDescription("--help output of the 'config volumes remove' command"),
 		mcp.WithMIMEType("text/plain"),
 	), func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
-		return runHelpCommand([]string{"config", "volumes", "remove"}, "func://config/volumes/add/docs")
+		return runHelpCommand([]string{"config", "volumes", "remove"}, "func://config/volumes/remove/docs")
+	})
+
+	mcpServer.AddResource(mcp.NewResource(
+		"func://config/labels/add/docs",
+		"Config Labels Add Command Help",
+		mcp.WithResourceDescription("--help output of the 'config labels add' command"),
+		mcp.WithMIMEType("text/plain"),
+	), func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		return runHelpCommand([]string{"config", "labels", "add"}, "func://config/labels/add/docs")
+	})
+
+	mcpServer.AddResource(mcp.NewResource(
+		"func://config/labels/remove/docs",
+		"Config Labels Remove Command Help",
+		mcp.WithResourceDescription("--help output of the 'config labels remove' command"),
+		mcp.WithMIMEType("text/plain"),
+	), func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		return runHelpCommand([]string{"config", "labels", "remove"}, "func://config/labels/remove/docs")
+	})
+
+	mcpServer.AddResource(mcp.NewResource(
+		"func://config/envs/add/docs",
+		"Config Envs Add Command Help",
+		mcp.WithResourceDescription("--help output of the 'config envs add' command"),
+		mcp.WithMIMEType("text/plain"),
+	), func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		return runHelpCommand([]string{"config", "envs", "add"}, "func://config/envs/add/docs")
+	})
+
+	mcpServer.AddResource(mcp.NewResource(
+		"func://config/envs/remove/docs",
+		"Config Envs Remove Command Help",
+		mcp.WithResourceDescription("--help output of the 'config envs remove' command"),
+		mcp.WithMIMEType("text/plain"),
+	), func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		return runHelpCommand([]string{"config", "envs", "remove"}, "func://config/envs/remove/docs")
 	})
 
 	mcpServer.AddPrompt(mcp.NewPrompt("help",

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -293,7 +293,6 @@ func handleConfigVolumesTool(
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	if action == "list" {
-		// For 'list' action, we don't need other parameters, only --path
 		args := []string{"config", "volumes", "--path", path}
 		if request.GetBool("verbose", false) {
 			args = append(args, "--verbose")
@@ -344,6 +343,110 @@ func handleConfigVolumesTool(
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("func config volumes failed: %s", out)), nil
+	}
+
+	body := []byte(fmt.Sprintf(`{"result": "%s"}`, out))
+	return mcp.NewToolResultText(string(body)), nil
+}
+
+func handleConfigLabelsTool(
+	ctx context.Context,
+	request mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	action, err := request.RequireString("action")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	path, err := request.RequireString("path")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	if action == "list" {
+		args := []string{"config", "labels", "--path", path}
+		if request.GetBool("verbose", false) {
+			args = append(args, "--verbose")
+		}
+
+		cmd := exec.Command("func", args...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("func config labels list failed: %s", out)), nil
+		}
+		body := []byte(fmt.Sprintf(`{"result": "%s"}`, out))
+		return mcp.NewToolResultText(string(body)), nil
+	}
+
+	args := []string{"config", "labels", action, "--path", path}
+
+	// Optional flags
+	if name := request.GetString("name", ""); name != "" {
+		args = append(args, "--name", name)
+	}
+	if value := request.GetString("value", ""); value != "" {
+		args = append(args, "--value", value)
+	}
+	if request.GetBool("verbose", false) {
+		args = append(args, "--verbose")
+	}
+
+	cmd := exec.Command("func", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("func config labels %s failed: %s", action, out)), nil
+	}
+
+	body := []byte(fmt.Sprintf(`{"result": "%s"}`, out))
+	return mcp.NewToolResultText(string(body)), nil
+}
+
+func handleConfigEnvsTool(
+	ctx context.Context,
+	request mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	action, err := request.RequireString("action")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	path, err := request.RequireString("path")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// Handle 'list' action separately
+	if action == "list" {
+		args := []string{"config", "envs", "--path", path}
+		if request.GetBool("verbose", false) {
+			args = append(args, "--verbose")
+		}
+
+		cmd := exec.Command("func", args...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("func config envs list failed: %s", out)), nil
+		}
+		body := []byte(fmt.Sprintf(`{"result": "%s"}`, out))
+		return mcp.NewToolResultText(string(body)), nil
+	}
+
+	// Handle 'add' and 'remove' actions
+	args := []string{"config", "envs", action, "--path", path}
+
+	// Optional flags
+	if name := request.GetString("name", ""); name != "" {
+		args = append(args, "--name", name)
+	}
+	if value := request.GetString("value", ""); value != "" {
+		args = append(args, "--value", value)
+	}
+	if request.GetBool("verbose", false) {
+		args = append(args, "--verbose")
+	}
+
+	cmd := exec.Command("func", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("func config envs %s failed: %s", action, out)), nil
 	}
 
 	body := []byte(fmt.Sprintf(`{"result": "%s"}`, out))


### PR DESCRIPTION
## Changes 

- This PR adds the remainder of config commands (`labels` and `envs`) to the MCP server

Related Epic #2806 