### PR TITLE
feat: base image flag for host builds

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -95,6 +95,12 @@ func TestBuild_Authentication(t *testing.T) {
 	testAuthentication(NewBuildCmd, t)
 }
 
+// TestBuild_BaseImage ensures that base image is used only with the right
+// builders and propagates into f.Build.BaseImage
+func TestBuild_BaseImage(t *testing.T) {
+	testBaseImage(NewBuildCmd, t)
+}
+
 // TestBuild_Push ensures that the build command properly pushes and respects
 // the --push flag.
 // - Push triggered after a successful build

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -128,7 +128,11 @@ EXAMPLES
 
 `,
 		SuggestFor: []string{"delpoy", "deplyo"},
-		PreRunE:    bindEnv("build", "build-timestamp", "builder", "builder-image", "confirm", "domain", "env", "git-branch", "git-dir", "git-url", "image", "namespace", "path", "platform", "push", "pvc-size", "service-account", "registry", "registry-insecure", "remote", "username", "password", "token", "verbose", "remote-storage-class"),
+		PreRunE: bindEnv("build", "build-timestamp", "builder", "builder-image",
+			"base-image", "confirm", "domain", "env", "git-branch", "git-dir",
+			"git-url", "image", "namespace", "path", "platform", "push", "pvc-size",
+			"service-account", "registry", "registry-insecure", "remote",
+			"username", "password", "token", "verbose", "remote-storage-class"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDeploy(cmd, newClient)
 		},
@@ -163,6 +167,8 @@ EXAMPLES
 	builderImage := f.Build.BuilderImages[f.Build.Builder]
 	cmd.Flags().String("builder-image", builderImage,
 		"Specify a custom builder image for use by the builder other than its default. ($FUNC_BUILDER_IMAGE)")
+	cmd.Flags().StringP("base-image", "", f.Build.BaseImage,
+		"Override the base image for your function (host builder only)")
 	cmd.Flags().StringP("image", "i", f.Image,
 		"Full image name in the form [registry]/[namespace]/[name]:[tag]@[digest]. This option takes precedence over --registry. Specifying digest is optional, but if it is given, 'build' and 'push' phases are disabled. ($FUNC_IMAGE)")
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -77,7 +77,9 @@ EXAMPLES
 	  $ {{rootCmdUse}} run --json
 `,
 		SuggestFor: []string{"rnu"},
-		PreRunE:    bindEnv("build", "builder", "builder-image", "confirm", "container", "env", "image", "path", "registry", "start-timeout", "verbose", "address", "json"),
+		PreRunE: bindEnv("build", "builder", "builder-image", "base-image",
+			"confirm", "container", "env", "image", "path", "registry",
+			"start-timeout", "verbose", "address", "json"),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runRun(cmd, newClient)
 		},
@@ -109,6 +111,8 @@ EXAMPLES
 	builderImage := f.Build.BuilderImages[f.Build.Builder]
 	cmd.Flags().String("builder-image", builderImage,
 		"Specify a custom builder image for use by the builder other than its default. ($FUNC_BUILDER_IMAGE)")
+	cmd.Flags().StringP("base-image", "", f.Build.BaseImage,
+		"Override the base image for your function (host builder only)")
 	cmd.Flags().StringP("image", "i", f.Image,
 		"Full image name in the form [registry]/[namespace]/[name]:[tag]. This option takes precedence over --registry. Specifying tag is optional. ($FUNC_IMAGE)")
 	cmd.Flags().StringArrayP("env", "e", []string{},

--- a/docs/reference/func_build.md
+++ b/docs/reference/func_build.md
@@ -57,6 +57,7 @@ func build
 ### Options
 
 ```
+      --base-image string      Override the base image for your function (host builder only)
       --build-timestamp        Use the actual time as the created time for the docker image. This is only useful for buildpacks builder.
   -b, --builder string         Builder to use when creating the function's container. Currently supported builders are "host", "pack" and "s2i". ($FUNC_BUILDER) (default "pack")
       --builder-image string   Specify a custom builder image for use by the builder other than its default. ($FUNC_BUILDER_IMAGE)

--- a/docs/reference/func_deploy.md
+++ b/docs/reference/func_deploy.md
@@ -113,6 +113,7 @@ func deploy
 ### Options
 
 ```
+      --base-image string             Override the base image for your function (host builder only)
       --build string[="true"]         Build the function. [auto|true|false]. ($FUNC_BUILD) (default "auto")
       --build-timestamp               Use the actual time as the created time for the docker image. This is only useful for buildpacks builder.
   -b, --builder string                Builder to use when creating the function's container. Currently supported builders are "host", "pack" and "s2i". (default "pack")

--- a/docs/reference/func_run.md
+++ b/docs/reference/func_run.md
@@ -67,6 +67,7 @@ func run
 
 ```
       --address string          Interface and port on which to bind and listen. Default is 127.0.0.1:8080, or an available port if 8080 is not available. ($FUNC_ADDRESS)
+      --base-image string       Override the base image for your function (host builder only)
       --build string[="true"]   Build the function. [auto|true|false]. ($FUNC_BUILD) (default "auto")
   -b, --builder string          Builder to use when creating the function's container. Currently supported builders are "host", "pack" and "s2i". (default "pack")
       --builder-image string    Specify a custom builder image for use by the builder other than its default. ($FUNC_BUILDER_IMAGE)

--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -152,6 +152,9 @@ type BuildSpec struct {
 	// in .func/built-image
 	Image string `yaml:"-"`
 
+	// BaseImage defines an override for the function to be built upon (host bulder only)
+	BaseImage string `yaml:"baseImage,omitempty"`
+
 	// Mounts used in build phase. This is useful in particular for paketo bindings.
 	Mounts []MountSpec `yaml:"volumes,omitempty"`
 }

--- a/pkg/oci/builder.go
+++ b/pkg/oci/builder.go
@@ -64,7 +64,7 @@ type languageBuilder interface {
 	// Base returns the base image (if any) to use.  Ideally this is a
 	// multi-arch base image with a corresponding platform image for
 	// each requested to be built.
-	Base() string
+	Base(customBase string) string
 
 	// WriteShared layers (not platform-specific) which need to be genearted
 	// on demand per language, such as shared dependencies.
@@ -568,12 +568,13 @@ func newCertsTarball(source, target string, verbose bool) error {
 // Its layers are automatically downloaded into the local cache if this is
 // the first fetch and their blobs linked into the final OCI image.
 func pullBase(job buildJob, p v1.Platform) (image v1.Image, err error) {
-	if job.languageBuilder.Base() == "" {
+	baseImage := job.function.Build.BaseImage
+	if job.languageBuilder.Base(baseImage) == "" {
 		return // FROM SCRATCH
 	}
 
 	// Parse the base into a reference
-	ref, err := name.ParseReference(job.languageBuilder.Base())
+	ref, err := name.ParseReference(job.languageBuilder.Base(baseImage))
 	if err != nil {
 		return
 	}

--- a/pkg/oci/builder_test.go
+++ b/pkg/oci/builder_test.go
@@ -461,7 +461,7 @@ func TestBuilder_StaticEnvs(t *testing.T) {
 // OCI builder for each language, and can be overridden for testing
 type TestLanguageBuilder struct {
 	BaseInvoked bool
-	BaseFn      func() string
+	BaseFn      func(customImage string) string
 
 	WriteSharedInvoked bool
 	WriteSharedFn      func(buildJob) ([]imageLayer, error)
@@ -475,7 +475,7 @@ type TestLanguageBuilder struct {
 
 func NewTestLanguageBuilder() *TestLanguageBuilder {
 	return &TestLanguageBuilder{
-		BaseFn:          func() string { return "" },
+		BaseFn:          func(customImage string) string { return "" },
 		WriteSharedFn:   func(buildJob) ([]imageLayer, error) { return []imageLayer{}, nil },
 		WritePlatformFn: func(buildJob, v1.Platform) ([]imageLayer, error) { return []imageLayer{}, nil },
 		ConfigureFn: func(buildJob, v1.Platform, v1.ConfigFile) (v1.ConfigFile, error) {
@@ -484,9 +484,9 @@ func NewTestLanguageBuilder() *TestLanguageBuilder {
 	}
 }
 
-func (l *TestLanguageBuilder) Base() string {
+func (l *TestLanguageBuilder) Base(customImage string) string {
 	l.BaseInvoked = true
-	return l.BaseFn()
+	return l.BaseFn(customImage)
 }
 
 func (l *TestLanguageBuilder) WriteShared(job buildJob) ([]imageLayer, error) {

--- a/pkg/oci/go_builder.go
+++ b/pkg/oci/go_builder.go
@@ -18,8 +18,9 @@ import (
 
 type goBuilder struct{}
 
-func (b goBuilder) Base() string {
-	return "" // scratch
+func (b goBuilder) Base(customImage string) string {
+	// if not defined -> return "", meaning building from scratch
+	return customImage
 }
 
 func (b goBuilder) Configure(_ buildJob, _ v1.Platform, cf v1.ConfigFile) (v1.ConfigFile, error) {

--- a/pkg/oci/python_builder.go
+++ b/pkg/oci/python_builder.go
@@ -19,7 +19,10 @@ var defaultPythonBase = "python:3.13-slim" // Moving from docker.io.  See issue 
 
 type pythonBuilder struct{}
 
-func (b pythonBuilder) Base() string {
+func (b pythonBuilder) Base(customBase string) string {
+	if customBase != "" {
+		return customBase
+	}
 	return defaultPythonBase
 }
 

--- a/schema/func_yaml-schema.json
+++ b/schema/func_yaml-schema.json
@@ -49,6 +49,10 @@
 					"type": "string",
 					"description": "RemoteStorageClass specifies the storage class to use for the volume used\non-cluster during when built remotely."
 				},
+				"baseImage": {
+					"type": "string",
+					"description": "BaseImage defines an override for the function to be built upon (host bulder only)"
+				},
 				"volumes": {
 					"items": {
 						"$schema": "http://json-schema.org/draft-04/schema#",


### PR DESCRIPTION

# Changes
- add `--base-image` flag for `build/deploy/run` for specifying the base image that function will be built upon (host builder only)

/kind enhancement

**Release Note**

```release-note
add --base-image flag to override the base image for host builds
```
