### PR TITLE
chore: remove deprecated DSA support

### DIFF
--- a/pkg/ssh/ssh_dialer.go
+++ b/pkg/ssh/ssh_dialer.go
@@ -344,7 +344,6 @@ func NewSSHClientConfig(url *urlPkg.URL, credentialsConfig Config) (*ssh.ClientC
 			ssh.KeyAlgoRSASHA256,
 			ssh.KeyAlgoRSASHA512,
 			ssh.KeyAlgoRSA,
-			ssh.KeyAlgoDSA,
 		},
 		Timeout: sshTimeout * time.Second,
 	}


### PR DESCRIPTION
Fixes: 
```
> make check
pkg/ssh/ssh_dialer.go:347:4: SA1019: ssh.KeyAlgoDSA is deprecated: DSA is only supported at insecure key sizes, and was removed from major implementations. (staticcheck)
                        ssh.KeyAlgoDSA,
                        ^

```