### PR TITLE
fix pod security context fs permissions

### DIFF
--- a/pkg/k8s/security_context.go
+++ b/pkg/k8s/security_context.go
@@ -14,11 +14,12 @@ func defaultPodSecurityContext() *corev1.PodSecurityContext {
 		return nil
 	}
 	runAsUser := int64(1001)
-	runAsGroup := int64(1002)
+	runAsGroup := int64(0) // Match Tekton buildpack task group
+	fsGroup := int64(1002) // Keep FSGroup for volume ownership
 	return &corev1.PodSecurityContext{
 		RunAsUser:  &runAsUser,
 		RunAsGroup: &runAsGroup,
-		FSGroup:    &runAsGroup,
+		FSGroup:    &fsGroup,
 	}
 }
 


### PR DESCRIPTION
Fixes a mismatch in container file permissions, surfacing during local E2E testing when switching between local, remote, and builders.

```
$ func deploy --remote --builder=pack --registry=registry.default.svc.cluster.local:5000/func -v
  Error: cannot upload sources to the PVC: cannot start the pod: pod prematurely exited (output: "ERROR: cannot purge dest dir: unlinkat
  /tmp/volume_mnt/source/.s2i/bin/assemble: permission denied\n", exitcode: 1)
      e2e_test.go:1249: exit status 1
```
