### PR TITLE
fix: linter reporting xml unsupported type

### DIFF
--- a/pkg/functions/client.go
+++ b/pkg/functions/client.go
@@ -181,7 +181,7 @@ type Instance struct {
 	Image         string            `json:"image" yaml:"image"`
 	Namespace     string            `json:"namespace" yaml:"namespace"`
 	Subscriptions []Subscription    `json:"subscriptions" yaml:"subscriptions"`
-	Labels        map[string]string `json:"labels" yaml:"labels"`
+	Labels        map[string]string `json:"labels" yaml:"labels" xml:"-"`
 }
 
 // Subscriptions currently active to event sources


### PR DESCRIPTION
linter failing in main https://github.com/knative/func/actions/runs/16489108500/job/46619720738#step:4:12
- Labels (map[string]string) type is unsupported in xml, exclude it