### PR TITLE
fix: update console output to show both host and port 

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"time"
@@ -282,7 +283,7 @@ func runRun(cmd *cobra.Command, newClient ClientFactory) (err error) {
 		}
 		fmt.Fprintln(cmd.OutOrStdout(), string(jsonData))
 	} else {
-		fmt.Fprintf(cmd.OutOrStderr(), "Running on host port %v\n", job.Port)
+		fmt.Fprintf(cmd.OutOrStderr(), "Function running on %s\n", net.JoinHostPort(job.Host, job.Port))
 	}
 
 	select {

--- a/test/e2e/scenario_extended_flow_test.go
+++ b/test/e2e/scenario_extended_flow_test.go
@@ -67,9 +67,18 @@ func TestFunctionExtendedFlow(t *testing.T) {
 					}
 					return
 				}
-				funcPort = findPort("Running on host port (.*)", stdout.String())
-				if funcPort == "" {
-					funcPort = findPort("Function started on port (.*)", stdout.String())
+
+				address := findPort(`Function running on (.*)`, stdout.String())
+				if address != "" {
+					_, port, err := net.SplitHostPort(address)
+					if err == nil {
+						funcPort = port
+					} else {
+						funcPort = address
+					}
+				} else {
+					// legacy fallback
+					funcPort = findPort("Running on host port (.*)", stdout.String())
 				}
 				attempts++
 				if funcPort == "" {

--- a/test/e2e/scenario_no_container_test.go
+++ b/test/e2e/scenario_no_container_test.go
@@ -43,7 +43,7 @@ func TestFunctionRunWithoutContainer(t *testing.T) {
 			funcPort, attempts := "", 0
 			for funcPort == "" && attempts < 30 { // 15 secs
 				t.Logf("----Function Output:\n%v", stdout.String())
-				matches := regexp.MustCompile("Running on host port (.*)").FindStringSubmatch(stdout.String())
+				matches := regexp.MustCompile("Function running on (.*)").FindStringSubmatch(stdout.String())
 				attempts++
 				if len(matches) > 1 {
 					funcPort = matches[1]

--- a/test/e2e/scenario_no_container_test.go
+++ b/test/e2e/scenario_no_container_test.go
@@ -44,12 +44,18 @@ func TestFunctionRunWithoutContainer(t *testing.T) {
 			for funcPort == "" && attempts < 30 { // 15 secs
 				t.Logf("----Function Output:\n%v", stdout.String())
 				matches := regexp.MustCompile("Function running on (.*)").FindStringSubmatch(stdout.String())
-				attempts++
 				if len(matches) > 1 {
-					funcPort = matches[1]
+					hostPort := matches[1]
+					_, port, err := net.SplitHostPort(hostPort)
+					if err == nil {
+						funcPort = port
+					} else {
+						funcPort = hostPort
+					}
 				} else {
 					time.Sleep(500 * time.Millisecond)
 				}
+				attempts++
 			}
 			// can proceed
 			portChannel <- funcPort


### PR DESCRIPTION
# Changes
fixes #2900 

- Updated the non-JSON console output in [cmd/run.go](cci:7://file:///c:/Users/RAYYAN/Desktop/func/cmd/run.go:0:0-0:0) to use `net.JoinHostPort` for better host:port formatting
- The console output now shows both host and port in a more reliable format

## Why

The previous implementation only showed the port number in the console output, which could be confusing when running in different environments. The new implementation:
- Uses the standard library's `net.JoinHostPort` for consistent host:port formatting


## Testing

The changes were tested by:
1. Running the function locally and verifying the new output format
see the output of  testing 
```txt
rayyan@rayyan-seliya:/mnt/c/Users/RAYYAN/Desktop/func/myfunction$ ../func run --address=127.0.0.1:8081
{"level":"debug","time":1753544409,"message":"func runtime creating function instance"}
{"level":"debug","address":"127.0.0.1:8081","time":1753544409,"message":"function starting"}
{"level":"debug","time":1753544409,"message":"function does not implement Start. Skipping"}
{"level":"debug","time":1753544409,"message":"waiting for stop signals or errors"}
Function running on 127.0.0.1:8081
```

## Release Note

```release-note
Improved function run output to show both host and port when running locally