### PR TITLE
fix: Python host builder base image version

### DIFF
--- a/pkg/oci/python_builder.go
+++ b/pkg/oci/python_builder.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	slashpath "path"
 	"path/filepath"
+	"regexp"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -23,7 +24,17 @@ func (b pythonBuilder) Base(customBase string) string {
 	if customBase != "" {
 		return customBase
 	}
-	return defaultPythonBase
+	cmd := exec.Command("python", "-V")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return defaultPythonBase
+	}
+	re := regexp.MustCompile(`Python (\d+\.\d+)\.\d+`)
+	subMatches := re.FindSubmatch(out)
+	if len(subMatches) != 2 {
+		return defaultPythonBase
+	}
+	return fmt.Sprintf("python:%s-slim", subMatches[1])
 }
 
 // Configure gives the python builder a chance to mutate the final


### PR DESCRIPTION
# Changes

related to #2964

- :bug: Host builder picks base-image with the same version of Python that is used locally.


/kind bug


```release-note
fix: host builder uses base-image with correct version of Python
```

