### PR TITLE
fix: force container=true for pack/s2i builders when not explicitly set

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -179,12 +179,12 @@ func runRun(cmd *cobra.Command, newClient ClientFactory) (err error) {
 
 	// Smart auto-fix logic for builder/container compatibility
 	// This fixes the original bug where --builder=pack doesn't default to container=true
-	
+
 	// Case 1: Containerized builders (pack/s2i) should force container=true when not explicitly set
 	if (f.Build.Builder == "pack" || f.Build.Builder == "s2i") && !cfg.Container && !cmd.Flags().Changed("container") {
 		cfg.Container = true
 	}
-	
+
 	// Case 2: container=false should auto-select host builder when no builder explicitly set
 	if !cfg.Container && cmd.Flags().Changed("container") && !cmd.Flags().Changed("builder") {
 		f.Build.Builder = "host"

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -705,6 +705,4 @@ func TestSmartBuilderSelection(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	
-	
 }


### PR DESCRIPTION
- Added logic to automatically set `container=true` for containerized builders (pack/s2i) when `--container` flag is not explicitly provided by user
- Added smart auto-selection to choose host builder when `--container=false` is specified without explicit builder
- Fixes issue where `func run --builder=pack` would incorrectly run on host instead of container
- Solution checks if builder is pack/s2i and `--container` flag wasn't changed by user
- Resolves #2955


# Changes

- :bug: Fix pack/s2i builders incorrectly running on host instead of container
- :sparkles: Add smart auto-selection for --container=false to choose host builder
- :test_tube: Add comprehensive unit tests (`TestCtrBuilder`, `TestCtrBuilderConflict`, `TestSmartBuilderSelection`)
- Add automatic container=true enforcement for containerized builders when flag not explicitly set
- Preserve user choice when --container flag is explicitly provided

/kind bug

Fixes #2955

**Release Note**

```release-note
Enhanced builder/container flag handling: pack/s2i builders now default to container mode, --container=false automatically selects host builder, with validation for incompatible combinations.
```