### PR TITLE
fix: func templates reference in mcp

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -8,7 +8,7 @@ import (
 )
 
 var TEMPLATE_RESOURCE_URIS = []string{
-	"https://github.com/gauron99/func-templates",
+	"https://github.com/functions-dev/templates",
 }
 
 type MCPServer struct {


### PR DESCRIPTION
- fix the url now that repo has been transfered