### PR TITLE
oci: refactors the auth for pusher

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -394,9 +394,14 @@ func (c buildConfig) clientOptions() ([]fn.Option, error) {
 	o := []fn.Option{fn.WithRegistry(c.Registry)}
 	switch c.Builder {
 	case builders.Host:
+		t := newTransport(c.RegistryInsecure) // may provide a custom impl which proxies
+		creds := newCredentialsProvider(config.Dir(), t)
 		o = append(o,
 			fn.WithBuilder(oci.NewBuilder(builders.Host, c.Verbose)),
-			fn.WithPusher(oci.NewPusher(c.RegistryInsecure, false, c.Verbose)))
+			fn.WithPusher(oci.NewPusher(c.RegistryInsecure, false, c.Verbose,
+				oci.WithCredentialsProvider(creds),
+				oci.WithVerbose(c.Verbose))),
+		)
 	case builders.Pack:
 		o = append(o,
 			fn.WithBuilder(pack.NewBuilder(

--- a/cmd/prompt/prompt.go
+++ b/cmd/prompt/prompt.go
@@ -11,14 +11,14 @@ import (
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"golang.org/x/term"
 
-	"knative.dev/func/pkg/docker"
-	"knative.dev/func/pkg/docker/creds"
+	"knative.dev/func/pkg/creds"
+	"knative.dev/func/pkg/oci"
 )
 
-func NewPromptForCredentials(in io.Reader, out, errOut io.Writer) func(repository string) (docker.Credentials, error) {
+func NewPromptForCredentials(in io.Reader, out, errOut io.Writer) func(repository string) (oci.Credentials, error) {
 	firstTime := true
-	return func(repository string) (docker.Credentials, error) {
-		var result docker.Credentials
+	return func(repository string) (oci.Credentials, error) {
+		var result oci.Credentials
 		if firstTime {
 			firstTime = false
 			fmt.Fprintf(out, "Please provide credentials for image repository '%s'.\n", repository)
@@ -56,7 +56,7 @@ func NewPromptForCredentials(in io.Reader, out, errOut io.Writer) func(repositor
 		if isTerm {
 			err := survey.Ask(qs, &result, survey.WithStdio(fr, out.(terminal.FileWriter), errOut))
 			if err != nil {
-				return docker.Credentials{}, err
+				return oci.Credentials{}, err
 			}
 		} else {
 			reader := bufio.NewReader(in)
@@ -64,18 +64,18 @@ func NewPromptForCredentials(in io.Reader, out, errOut io.Writer) func(repositor
 			fmt.Fprintf(out, "Username: ")
 			u, err := reader.ReadString('\n')
 			if err != nil {
-				return docker.Credentials{}, err
+				return oci.Credentials{}, err
 			}
 			u = strings.Trim(u, "\r\n")
 
 			fmt.Fprintf(out, "Password: ")
 			p, err := reader.ReadString('\n')
 			if err != nil {
-				return docker.Credentials{}, err
+				return oci.Credentials{}, err
 			}
 			p = strings.Trim(p, "\r\n")
 
-			result = docker.Credentials{Username: u, Password: p}
+			result = oci.Credentials{Username: u, Password: p}
 		}
 
 		return result, nil

--- a/cmd/prompt/prompt_test.go
+++ b/cmd/prompt/prompt_test.go
@@ -12,8 +12,7 @@ import (
 	"github.com/Netflix/go-expect"
 	"github.com/creack/pty"
 	"github.com/hinshun/vt10x"
-
-	"knative.dev/func/pkg/docker"
+	"knative.dev/func/pkg/oci"
 )
 
 const (
@@ -21,7 +20,7 @@ const (
 )
 
 func Test_NewPromptForCredentials(t *testing.T) {
-	expectedCreds := docker.Credentials{
+	expectedCreds := oci.Credentials{
 		Username: "testuser",
 		Password: "testpwd",
 	}

--- a/pkg/creds/credentials_test.go
+++ b/pkg/creds/credentials_test.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/docker/docker-credential-helpers/credentials"
 
-	"knative.dev/func/pkg/docker"
-	"knative.dev/func/pkg/docker/creds"
+	"knative.dev/func/pkg/creds"
+	"knative.dev/func/pkg/oci"
 	. "knative.dev/func/pkg/testing"
 )
 
@@ -162,7 +162,7 @@ func TestCheckAuth(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := docker.Credentials{
+			c := oci.Credentials{
 				Username: tt.args.username,
 				Password: tt.args.password,
 			}
@@ -199,7 +199,7 @@ func TestCheckAuth(t *testing.T) {
 func TestCheckAuthEmptyCreds(t *testing.T) {
 
 	localhost, _, _ := startServer(t, "", "")
-	err := creds.CheckAuth(context.Background(), localhost+"/someorg/someimage:sometag", docker.Credentials{}, http.DefaultTransport)
+	err := creds.CheckAuth(context.Background(), localhost+"/someorg/someimage:sometag", oci.Credentials{}, http.DefaultTransport)
 	if err != nil {
 		t.Error(err)
 	}
@@ -334,7 +334,7 @@ const (
 	quayIoUserPwd   = "goodPwd2"
 )
 
-type Credentials = docker.Credentials
+type Credentials = oci.Credentials
 
 func TestNewCredentialsProvider(t *testing.T) {
 	helperWithQuayIO := newInMemoryHelper()
@@ -460,8 +460,8 @@ func TestNewCredentialsProvider(t *testing.T) {
 func TestNewCredentialsProviderEmptyCreds(t *testing.T) {
 	resetHomeDir(t)
 
-	credentialsProvider := creds.NewCredentialsProvider(testConfigPath(t), creds.WithVerifyCredentials(func(ctx context.Context, image string, credentials docker.Credentials) error {
-		if image == "localhost:5555/someorg/someimage:sometag" && credentials == (docker.Credentials{}) {
+	credentialsProvider := creds.NewCredentialsProvider(testConfigPath(t), creds.WithVerifyCredentials(func(ctx context.Context, image string, credentials oci.Credentials) error {
+		if image == "localhost:5555/someorg/someimage:sometag" && credentials == (oci.Credentials{}) {
 			return nil
 		}
 		t.Fatal("unreachable")
@@ -471,7 +471,7 @@ func TestNewCredentialsProviderEmptyCreds(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if c != (docker.Credentials{}) {
+	if c != (oci.Credentials{}) {
 		t.Error("unexpected credentials")
 	}
 }

--- a/pkg/docker/pusher_test.go
+++ b/pkg/docker/pusher_test.go
@@ -38,6 +38,7 @@ import (
 
 	"knative.dev/func/pkg/docker"
 	fn "knative.dev/func/pkg/functions"
+	"knative.dev/func/pkg/oci"
 )
 
 func TestGetRegistry(t *testing.T) {
@@ -77,8 +78,8 @@ const (
 	imageRepoDigest = "sha256:00af51d125f3092e157a7f8a717029412dc9d266c017e89cecdfeccb4cc3d7a7"
 )
 
-var testCredProvider = docker.CredentialsProvider(func(ctx context.Context, registry string) (docker.Credentials, error) {
-	return docker.Credentials{
+var testCredProvider = oci.CredentialsProvider(func(ctx context.Context, registry string) (oci.Credentials, error) {
+	return oci.Credentials{
 		Username: testUser,
 		Password: testPwd,
 	}, nil

--- a/pkg/k8s/keychains.go
+++ b/pkg/k8s/keychains.go
@@ -1,0 +1,85 @@
+package k8s
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/google"
+
+	"knative.dev/func/pkg/creds"
+	"knative.dev/func/pkg/oci"
+)
+
+func GetGoogleCredentialLoader() []creds.CredentialsCallback {
+	return []creds.CredentialsCallback{
+		func(registry string) (oci.Credentials, error) {
+			if registry != "gcr.io" {
+				return oci.Credentials{}, nil // skip if not GCR
+			}
+
+			res, err := name.NewRegistry(registry)
+			if err != nil {
+				return oci.Credentials{}, fmt.Errorf("parse registry: %w", err)
+			}
+
+			authenticator, err := google.Keychain.Resolve(res)
+			if err != nil {
+				return oci.Credentials{}, fmt.Errorf("resolve google keychain: %w", err)
+			}
+
+			authCfg, err := authenticator.Authorization()
+			if err != nil {
+				return oci.Credentials{}, fmt.Errorf("get authorization: %w", err)
+			}
+
+			return oci.Credentials{
+				Username: authCfg.Username,
+				Password: authCfg.Password,
+			}, nil
+		},
+	}
+}
+
+func GetECRCredentialLoader() []creds.CredentialsCallback {
+	return []creds.CredentialsCallback{} // TODO: Implement ECR credentials loader
+}
+
+func GetACRCredentialLoader() []creds.CredentialsCallback {
+	return []creds.CredentialsCallback{
+		func(registry string) (oci.Credentials, error) {
+			if !strings.HasSuffix(registry, ".azurecr.io") {
+				return oci.Credentials{}, nil
+			}
+
+			f, err := os.Open(path.Join(os.Getenv("HOME"), ".azure", "accessTokens.json"))
+			if err != nil {
+				return oci.Credentials{}, fmt.Errorf("open Azure access tokens: %w", err)
+			}
+			defer f.Close()
+
+			var tokens []struct {
+				AccessToken string `json:"accessToken"`
+				Resource    string `json:"resource"`
+			}
+
+			if err := json.NewDecoder(f).Decode(&tokens); err != nil {
+				return oci.Credentials{}, fmt.Errorf("decode Azure access tokens: %w", err)
+			}
+
+			target := "https://" + registry
+			for _, t := range tokens {
+				if t.Resource == target {
+					return oci.Credentials{
+						Username: "00000000-0000-0000-0000-000000000000",
+						Password: t.AccessToken,
+					}, nil
+				}
+			}
+			return oci.Credentials{}, nil
+		},
+	}
+}

--- a/pkg/k8s/openshift.go
+++ b/pkg/k8s/openshift.go
@@ -14,9 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	"knative.dev/func/pkg/docker"
-	"knative.dev/func/pkg/docker/creds"
+	"knative.dev/func/pkg/creds"
 	fn "knative.dev/func/pkg/functions"
+	"knative.dev/func/pkg/oci"
 )
 
 const (
@@ -106,7 +106,7 @@ func GetOpenShiftDockerCredentialLoaders() []creds.CredentialsCallback {
 	if !ok {
 		return nil
 	}
-	var credentials docker.Credentials
+	var credentials oci.Credentials
 
 	if authInfo := rawConf.AuthInfos[cc.AuthInfo]; authInfo != nil {
 		credentials.Username = "openshift"
@@ -114,11 +114,11 @@ func GetOpenShiftDockerCredentialLoaders() []creds.CredentialsCallback {
 	}
 
 	return []creds.CredentialsCallback{
-		func(registry string) (docker.Credentials, error) {
+		func(registry string) (oci.Credentials, error) {
 			if registry == openShiftRegistryHostPort {
 				return credentials, nil
 			}
-			return docker.Credentials{}, creds.ErrCredentialsNotFound
+			return oci.Credentials{}, creds.ErrCredentialsNotFound
 		},
 	}
 

--- a/pkg/pipelines/tekton/gitlab_int_test.go
+++ b/pkg/pipelines/tekton/gitlab_int_test.go
@@ -37,9 +37,9 @@ import (
 	"knative.dev/pkg/apis"
 
 	"knative.dev/func/pkg/builders/buildpacks"
-	"knative.dev/func/pkg/docker"
 	fn "knative.dev/func/pkg/functions"
 	"knative.dev/func/pkg/k8s"
+	"knative.dev/func/pkg/oci"
 	"knative.dev/func/pkg/pipelines"
 	"knative.dev/func/pkg/pipelines/tekton"
 	"knative.dev/func/pkg/random"
@@ -102,8 +102,8 @@ func TestGitlab(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	credentialsProvider := func(ctx context.Context, image string) (docker.Credentials, error) {
-		return docker.Credentials{
+	credentialsProvider := func(ctx context.Context, image string) (oci.Credentials, error) {
+		return oci.Credentials{
 			Username: "",
 			Password: "",
 		}, nil

--- a/pkg/pipelines/tekton/pipelines_int_test.go
+++ b/pkg/pipelines/tekton/pipelines_int_test.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/func/pkg/k8s"
 	"knative.dev/func/pkg/knative"
+	"knative.dev/func/pkg/oci"
 
 	"knative.dev/func/pkg/builders/buildpacks"
 	pack "knative.dev/func/pkg/builders/buildpacks"
@@ -34,8 +35,8 @@ import (
 	. "knative.dev/func/pkg/testing"
 )
 
-var testCP = func(_ context.Context, _ string) (docker.Credentials, error) {
-	return docker.Credentials{
+var testCP = func(_ context.Context, _ string) (oci.Credentials, error) {
+	return oci.Credentials{
 		Username: "",
 		Password: "",
 	}, nil

--- a/pkg/pipelines/tekton/pipelines_provider.go
+++ b/pkg/pipelines/tekton/pipelines_provider.go
@@ -34,6 +34,7 @@ import (
 	"knative.dev/func/pkg/k8s"
 	fnlabels "knative.dev/func/pkg/k8s/labels"
 	"knative.dev/func/pkg/knative"
+	"knative.dev/func/pkg/oci"
 	"knative.dev/pkg/apis"
 )
 
@@ -54,11 +55,11 @@ type pacURLCallback = func() (string, error)
 type PipelinesProvider struct {
 	verbose             bool
 	getPacURL           pacURLCallback
-	credentialsProvider docker.CredentialsProvider
+	credentialsProvider oci.CredentialsProvider
 	decorator           PipelineDecorator
 }
 
-func WithCredentialsProvider(credentialsProvider docker.CredentialsProvider) Opt {
+func WithCredentialsProvider(credentialsProvider oci.CredentialsProvider) Opt {
 	return func(pp *PipelinesProvider) {
 		pp.credentialsProvider = credentialsProvider
 	}


### PR DESCRIPTION
**Refactor OCI Pusher Authentication**

## Changes

* Reuse `cmd/client`’s `credentialsProvider` instead of relying on the keychain
* Add interactive fallback for the pusher when no credentials are provided by a `credentialsProvider`
* Introduce additional credential loaders (ACR, GCP) for broader registry support
