### PR TITLE
fix-components

### DIFF
--- a/hack/component-versions.json
+++ b/hack/component-versions.json
@@ -6,7 +6,7 @@
 	},
 	"Eventing": {
 		"version": "v1.19.1",
-		"owner": "knative",
+		"owner": "",
 		"repo": "eventing"
 	},
 	"KindNode": {
@@ -17,7 +17,7 @@
 	},
 	"Serving": {
 		"version": "v1.19.1",
-		"owner": "knative",
+		"owner": "",
 		"repo": "serving"
 	},
 	"Tekton": {


### PR DESCRIPTION
temporarily fix components to prevent downgrading because 1.19 was marked as pre-release