### PR TITLE
Improve error message when `func invoke` is run outside function directory

### DIFF
--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -154,7 +154,7 @@ func runInvoke(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 		return err
 	}
 	if !f.Initialized() {
-		return fn.NewErrNotInitialized(f.Root)
+		return fmt.Errorf("No function found in current directory.\nYou need to be inside a function directory to invoke it.\n\nTry this:\n  func create --language go myfunction    Create a new function\n  cd myfunction                          Go into the function directory\n  func invoke                            Now you can invoke it\n\nOr if you have an existing function:\n  cd path/to/your/function              Go to your function directory\n  func invoke                           Invoke the function")
 	}
 
 	// Client instance from env vars, flags, args and user prompts (if --confirm)

--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -154,7 +154,7 @@ func runInvoke(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 		return err
 	}
 	if !f.Initialized() {
-		return fmt.Errorf("No function found in current directory.\nYou need to be inside a function directory to invoke it.\n\nTry this:\n  func create --language go myfunction    Create a new function\n  cd myfunction                          Go into the function directory\n  func invoke                            Now you can invoke it\n\nOr if you have an existing function:\n  cd path/to/your/function              Go to your function directory\n  func invoke                           Invoke the function")
+		return fmt.Errorf("no function found in current directory.\nYou need to be inside a function directory to invoke it.\n\nTry this:\n  func create --language go myfunction    Create a new function\n  cd myfunction                          Go into the function directory\n  func invoke                            Now you can invoke it\n\nOr if you have an existing function:\n  cd path/to/your/function              Go to your function directory\n  func invoke                           Invoke the function")
 	}
 
 	// Client instance from env vars, flags, args and user prompts (if --confirm)


### PR DESCRIPTION
**Changes**

- :broom: Update error message shown when `func invoke` is run outside a function directory.
- Made the message more user-friendly and easier for beginners to understand.
- Added step-by-step workflow guidance with examples for both new and existing functions.

/kind enhancement

Fixes #3017 

**Release Note**
```release-note
Improve error message when `func invoke` is run outside function directory
to be more beginner-friendly, include step-by-step workflow guidance.
```