### PR TITLE
improve error message for func run making it more beginner friendly

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -160,7 +160,17 @@ func runRun(cmd *cobra.Command, newClient ClientFactory) (err error) {
 		return
 	}
 	if !f.Initialized() {
-		return fmt.Errorf("no function found in current directory.\nYou need to be inside a function directory to run it.\n\nTry this:\n  func create --language go myfunction    Create a new function\n  cd myfunction                          Go into the function directory\n  func run                               Run the function locally\n\nOr if you have an existing function:\n  cd path/to/your/function              Go to your function directory\n  func run                              Run the function locally")
+		return fmt.Errorf(`no function found in current directory.
+You need to be inside a function directory to run it.
+
+Try this:
+  func create --language go myfunction    Create a new function
+  cd myfunction                          Go into the function directory
+  func run                               Run the function locally
+
+Or if you have an existing function:
+  cd path/to/your/function              Go to your function directory
+  func run                              Run the function locally`)
 	}
 
 	if err = cfg.Validate(cmd, f); err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -160,7 +160,7 @@ func runRun(cmd *cobra.Command, newClient ClientFactory) (err error) {
 		return
 	}
 	if !f.Initialized() {
-		return fn.NewErrNotInitialized(f.Root)
+		return fmt.Errorf("no function found in current directory.\nYou need to be inside a function directory to run it.\n\nTry this:\n  func create --language go myfunction    Create a new function\n  cd myfunction                          Go into the function directory\n  func run                               Run the function locally\n\nOr if you have an existing function:\n  cd path/to/your/function              Go to your function directory\n  func run                              Run the function locally")
 	}
 
 	if err = cfg.Validate(cmd, f); err != nil {

--- a/hack/component-versions.json
+++ b/hack/component-versions.json
@@ -1,6 +1,6 @@
 {
 	"Contour": {
-		"version": "v1.19.4",
+		"version": "v1.19.5",
 		"owner": "knative-extensions",
 		"repo": "net-contour"
 	},

--- a/hack/component-versions.sh
+++ b/hack/component-versions.sh
@@ -13,7 +13,7 @@ set_versions() {
 	# find source-of-truth in component-versions.json to add/modify components
 	knative_serving_version="v1.19.1"
 	knative_eventing_version="v1.19.1"
-	contour_version="v1.19.4"
+	contour_version="v1.19.5"
 	tekton_version="v1.1.0"
 	pac_version="v0.35.2"
 }


### PR DESCRIPTION
**Changes**

- :broom: Update error message shown when `func run` is run outside a function directory.
- Made the message more user-friendly and easier for beginners to understand.
- Added step-by-step workflow guidance with examples for both new and existing functions.
- Provides context-specific guidance that `func run` runs functions locally for testing.

/kind enhancement

Fixes #3021 

**Release Note**
```release-note
Improve error message when `func run` is run outside function directory
to be more beginner-friendly, include step-by-step workflow guidance, and 
explain that func run is used for local testing.
```
