### PR TITLE
Improve error message when `func subscribe` is run outside function directory

### DIFF
--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -54,10 +54,7 @@ func runSubscribe(cmd *cobra.Command) (err error) {
 		return
 	}
 	if !f.Initialized() {
-		return fn.NewErrNotInitialized(f.Root)
-	}
-	if !f.Initialized() {
-		return fn.NewErrNotInitialized(f.Root)
+		return fmt.Errorf("no function found in current directory.\nYou need to be inside a function directory to subscribe to events.\n\nTry this:\n  func create --language go myfunction    Create a new function\n  cd myfunction                          Go into the function directory\n  func subscribe --filter type=example   Subscribe to events\n\nOr if you have an existing function:\n  cd path/to/your/function              Go to your function directory\n  func subscribe --filter type=example  Subscribe to events")
 	}
 
 	// add subscription	to function


### PR DESCRIPTION
**Changes**

- :broom: Update error message shown when `func subscribe` is run outside a function directory.
- Made the message more user-friendly and easier for beginners to understand.
- Replaced cryptic technical error with clear, actionable guidance.
- Provides context-specific information about event subscription workflow.

/kind enhancement

Fixes #3024 

**Release Note**
```release-note
Improve error message when `func subscribe` is run outside function directory
to be more beginner-friendly and provide clear guidance on creating functions
before subscribing to events.
```