### PR TITLE
Improve error message when `func describe` is run outside function directory

### DIFF
--- a/cmd/describe_test.go
+++ b/cmd/describe_test.go
@@ -24,7 +24,7 @@ func TestDescribe_Default(t *testing.T) {
 	if err == nil {
 		t.Fatal("describing a nonexistent function should error")
 	}
-	if !strings.Contains(err.Error(), "no function found in current directory") {
+	if !strings.Contains(err.Error(), "No function found in provided path") {
 		t.Fatalf("Unexpected error text returned: %v", err)
 	}
 	if describer.DescribeInvoked {


### PR DESCRIPTION
**Changes**

- :broom: Update error message shown when `func describe` is run outside a function directory.
- Made the message more user-friendly and easier for beginners to understand.
- Replaced cryptic technical error with clear, actionable guidance.
- Provides context-specific information about function description workflow.


/kind enhancement

Fixes #3026 

**Release Note**
```release-note
Improve error message when `func describe` is run outside function directory
to be more beginner-friendly and provide clear guidance on creating functions
before describing them.
```
