### PR TITLE
Improve func deploy UX by checking function existence before prompting

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -241,24 +241,20 @@ func runDeploy(cmd *cobra.Command, newClient ClientFactory) (err error) {
 		cfg deployConfig
 		f   fn.Function
 	)
-	if cfg, err = newDeployConfig(cmd).Prompt(); err != nil {
-		return
-	}
-	if err = cfg.Validate(cmd); err != nil {
-		return
-	}
+	
+	// Initialize config first
+	cfg = newDeployConfig(cmd)
+	
+	// Create function object to check if initialized
 	if f, err = fn.NewFunction(cfg.Path); err != nil {
 		return
 	}
-	if f, err = cfg.Configure(f); err != nil { // Updates f with deploy cfg
-		return
-	}
-	cmd.SetContext(cfg.WithValues(cmd.Context())) // Some optional settings are passed via context
-
+	
+	// Check if function exists BEFORE prompting for config
 	if !f.Initialized() {
 		if !cfg.Remote || f.Build.Git.URL == "" {
 			// Only error if this is not a fully remote build
-			return fn.NewErrNotInitialized(f.Root)
+			return fmt.Errorf("no function found in current directory.\nYou need to be inside a function directory to deploy it.\n\nTry this:\n  func create --language go myfunction    Create a new function\n  cd myfunction                          Go into the function directory\n  func deploy --registry <registry>      Deploy to the cloud\n\nOr if you have an existing function:\n  cd path/to/your/function              Go to your function directory\n  func deploy --registry <registry>     Deploy the function\n\nFor more detailed deployment options, run 'func deploy --help'.")
 		} else {
 			// TODO: this case is not supported because the pipeline
 			// implementation requires the function's name, which is in the
@@ -267,6 +263,18 @@ func runDeploy(cmd *cobra.Command, newClient ClientFactory) (err error) {
 			return errors.New("please ensure the function's source is also available locally")
 		}
 	}
+	
+	// Now that we know function exists, proceed with prompting
+	if cfg, err = cfg.Prompt(); err != nil {
+		return
+	}
+	if err = cfg.Validate(cmd); err != nil {
+		return
+	}
+	if f, err = cfg.Configure(f); err != nil { // Updates f with deploy cfg
+		return
+	}
+	cmd.SetContext(cfg.WithValues(cmd.Context())) // Some optional settings are passed via context
 
 	changingNamespace := func(f fn.Function) bool {
 		// We're changing namespace if:


### PR DESCRIPTION

# Changes
- :broom: Fix confusing UX flow in `func deploy` when no function exists
- :broom: Check function initialization before prompting for registry configuration  
- :broom: Provide educational error message with workflow guidance and help pointer

/kind enhancement

Fixes #3041 

Previously, `func deploy` would prompt for registry info even when no function existed, 
forcing users to cancel manually before seeing the real error. Now it immediately shows 
clear guidance on how to create and deploy functions properly. 

**Release Note**

```release-note
Improve func deploy user experience by showing clear error guidance immediately when run outside a function directory, instead of prompting for registry configuration first.
```