### PR TITLE
Improve func build UX: check function exists before prompting for registry

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -169,8 +169,8 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 
 	// Check if function exists BEFORE prompting for config
 	if !f.Initialized() {
-		return fmt.Errorf(`no function found in current directory.
-You need to be inside a function directory to build it.
+		return fmt.Errorf(`no function found in current directory (or --path not specified).
+You need to point to a function directory to build.
 
 Try this:
   func create --language go myfunction    Create a new function
@@ -180,6 +180,9 @@ Try this:
 Or if you have an existing function:
   cd path/to/your/function              Go to your function directory
   func build                            Build using previous settings
+
+Or build from anywhere using --path:
+  func build --path /path/to/your/function --registry <registry>
 
 Common build scenarios:
   func build --registry registry.example.com/alice    Build with registry

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -158,15 +158,15 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 		cfg buildConfig
 		f   fn.Function
 	)
-	
+
 	// Initialize config first
 	cfg = newBuildConfig()
-	
+
 	// Create function object to check if initialized
 	if f, err = fn.NewFunction(cfg.Path); err != nil {
 		return
 	}
-	
+
 	// Check if function exists BEFORE prompting for config
 	if !f.Initialized() {
 		return fmt.Errorf(`no function found in current directory.
@@ -186,9 +186,9 @@ Common build scenarios:
   func build --push                                   Build and push to registry
   func build --builder=s2i                           Build with S2I builder
 
-For more detailed build options, run 'func build --help'.`)
+For more detailed build options, run 'func build --help'`)
 	}
-	
+
 	// Now that we know function exists, proceed with prompting
 	if cfg, err = cfg.Prompt(); err != nil { // gather values into a single instruction set
 		return


### PR DESCRIPTION
# Changes
- :broom: Fix confusing UX flow in `func build` when no function exists
- :broom: Check function initialization before prompting for registry configuration  
- :broom: Provide educational error message with build workflow guidance and help pointer

/kind enhancement

Fixes #3047

Previously, `func build` would prompt for registry info even when no function existed, 
forcing users to cancel manually before seeing the real error. Now it immediately shows 
clear guidance on how to create and build functions properly with common build scenarios.

**Release Note**

```release-note
Improve func build user experience by showing clear error guidance immediately when run outside a function directory, instead of prompting for registry configuration first.
```
