### PR TITLE
dapr install upgrade

### DIFF
--- a/hack/install-binaries.sh
+++ b/hack/install-binaries.sh
@@ -28,7 +28,7 @@ install_binaries() {
 
   local kubectl_version=1.33.1
   local kind_version=0.29.0
-  local dapr_version=1.14.1
+  local dapr_version=1.16.0
   local helm_version=3.18.0
   local stern_version=1.32.0
   local kn_version=1.18.0

--- a/pkg/pipelines/tekton/gitlab_int_test.go
+++ b/pkg/pipelines/tekton/gitlab_int_test.go
@@ -503,7 +503,7 @@ func getAPIToken(baseURL, username, password string) (string, error) {
 	}
 
 	data := struct {
-		NewToken string `json:"new_token,omitempty"`
+		NewToken string `json:"token,omitempty"`
 	}{}
 	e := json.NewDecoder(resp.Body)
 	err = e.Decode(&data)


### PR DESCRIPTION
- Update Dapr to 1.16
- Install Dapr's Redis using docs-suggested standard deployment

Fixes some problems with the dapr installation which was causing knative services to never become ready due to their Dapr sidecars' hangups