### PR TITLE
Improve func build/deploy UX: validate registry before prompting

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -159,6 +159,51 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 		f   fn.Function
 	)
 	if cfg, err = newBuildConfig().Prompt(); err != nil { // gather values into a single instruction set
+		// Layer 2: Catch technical errors and provide CLI-specific user-friendly messages
+		
+		// Check if it's a "not initialized" error (no function found)
+		var errNotInit *fn.ErrNotInitialized
+		if errors.As(err, &errNotInit) {
+			return fmt.Errorf(`%w
+
+To build a function, you need to point to a function directory or use a --path flag approach.
+
+Try this:
+  func create --language go myfunction    Create a new function
+  cd myfunction                          Go into the function directory
+  func build --registry <registry>       Build the function container
+
+Or navigate to an existing function:
+  cd path/to/your/function
+  func build --registry <registry>
+
+Or use --path flag:
+  func build --path /path/to/function --registry <registry>
+
+For more options, run 'func build --help'`, err)
+		}
+		
+		// Check if it's a registry required error (function exists but no registry)
+		if errors.Is(err, fn.ErrRegistryRequired) {
+			return fmt.Errorf(`%w
+
+Try this:
+  func build --registry ghcr.io/myuser    Build with registry
+  
+Or set the FUNC_REGISTRY environment variable:
+  export FUNC_REGISTRY=ghcr.io/myuser
+  func build
+
+Common registries:
+  ghcr.io/myuser       GitHub Container Registry
+  docker.io/myuser     Docker Hub
+  quay.io/myuser       Quay.io
+
+Or specify full image name:
+  func build --image ghcr.io/myuser/myfunction:latest
+
+For more options, run 'func build --help'`, err)
+		}
 		return
 	}
 	if err = cfg.Validate(); err != nil { // Perform any pre-validation
@@ -312,7 +357,21 @@ func (c buildConfig) Prompt() (buildConfig, error) {
 	if err != nil {
 		return c, err
 	}
-	if (f.Registry == "" && c.Registry == "" && c.Image == "") || c.Confirm {
+	
+	// Check if function exists first
+	if !f.Initialized() {
+		// Return a specific error for uninitialized function
+		return c, fn.NewErrNotInitialized(f.Root)
+	}
+	
+	// Check if registry/image is missing BEFORE prompting
+	if (f.Registry == "" && c.Registry == "" && c.Image == "") {
+		// Return error immediately - don't prompt
+		return c, fn.ErrRegistryRequired
+	}
+	
+	// Only prompt if in confirm mode and registry exists
+	if c.Confirm {
 		fmt.Println("A registry for function images is required. For example, 'docker.io/tigerteam'.")
 		err := survey.AskOne(
 			&survey.Input{Message: "Registry for function images:", Default: c.Registry},

--- a/pkg/functions/errors.go
+++ b/pkg/functions/errors.go
@@ -27,7 +27,7 @@ var (
 	// TODO: change the wording of this error to not be CLI-specific;
 	// eg "registry required".  Then catch the error in the CLI and add the
 	// cli-specific usage hints there
-	ErrRegistryRequired = errors.New("registry required to build function, please set with `--registry` or the FUNC_REGISTRY environment variable")
+	ErrRegistryRequired = errors.New("registry required to build or deploy function, please set with `--registry` or the FUNC_REGISTRY environment variable")
 )
 
 // ErrNotInitialized indicates that a function is uninitialized


### PR DESCRIPTION
# Changes

- :bug: Fix confusing UX in func build/deploy commands
- :broom: Implement 2-layer error system for better user guidance
- :broom: Validate registry requirement before prompting users

/kind enhancement

Fixes #3057 


**Solution:**
Validate the missing registry error first before asking for a registry prompt! Use a 2-layer approach as discussed!


## **Implementation Details:**
- Refactored `func build` and `func deploy` commands to validate registry requirement before prompting
- Implemented 2-layer error system for both "no function found" and "registry required" scenarios
- Enhanced error messages with actionable guidance and examples
- Improved UX by preventing unnecessary interactive prompts

**Release Note**

```release-note
func build and func deploy commands now provide clearer error messages when registry is missing, with actionable guidance instead of confusing prompts.
```