### PR TITLE
fix the platform restriction error providing more educational guidance 

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -162,6 +162,25 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 		return
 	}
 	if err = cfg.Validate(); err != nil { // Perform any pre-validation
+		// Layer 2: Catch platform validation error and provide CLI-specific guidance
+		if errors.Is(err, fn.ErrPlatformNotSupported) {
+			return fmt.Errorf(`%w
+
+The --platform flag is only supported with the S2I builder.
+
+Try this:
+  func build --registry <registry> --builder=s2i --platform linux/amd64
+
+Or remove the --platform flag:
+  func build --registry <registry>
+
+Builder capabilities:
+  s2i   Supports --platform (Source-to-Image)
+  pack  Does not support --platform (uses default)
+  host  Does not support --platform (uses host architecture)
+
+For more options, run 'func build --help'`, err)
+		}
 		return
 	}
 	if f, err = fn.NewFunction(cfg.Path); err != nil { // Read in the Function
@@ -364,7 +383,7 @@ func (c buildConfig) Validate() (err error) {
 
 	// Platform is only supported with the S2I builder at this time
 	if c.Platform != "" && c.Builder != builders.S2I {
-		err = errors.New("only S2I builds currently support specifying platform")
+		err = fn.ErrPlatformNotSupported
 		return
 	}
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -174,11 +174,6 @@ Try this:
 Or remove the --platform flag:
   func build --registry <registry>
 
-Builder capabilities:
-  s2i   Supports --platform (Source-to-Image)
-  pack  Does not support --platform (uses default)
-  host  Does not support --platform (uses host architecture)
-
 For more options, run 'func build --help'`, err)
 		}
 		return

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -293,11 +293,6 @@ Try this:
 Or remove the --platform flag:
   func deploy --registry <registry>
 
-Builder capabilities:
-  s2i   Supports --platform (Source-to-Image)
-  pack  Does not support --platform (uses default)
-  host  Does not support --platform (uses host architecture)
-
 For more options, run 'func deploy --help'`, err)
 		}
 		return

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -281,6 +281,25 @@ For more detailed deployment options, run 'func deploy --help'`)
 		return
 	}
 	if err = cfg.Validate(cmd); err != nil {
+		// Layer 2: Catch platform validation error and provide CLI-specific guidance
+		if errors.Is(err, fn.ErrPlatformNotSupported) {
+			return fmt.Errorf(`%w
+
+The --platform flag is only supported with the S2I builder.
+
+Try this:
+  func deploy --registry <registry> --builder=s2i --platform linux/amd64
+
+Or remove the --platform flag:
+  func deploy --registry <registry>
+
+Builder capabilities:
+  s2i   Supports --platform (Source-to-Image)
+  pack  Does not support --platform (uses default)
+  host  Does not support --platform (uses host architecture)
+
+For more options, run 'func deploy --help'`, err)
+		}
 		return
 	}
 	if f, err = cfg.Configure(f); err != nil { // Updates f with deploy cfg

--- a/pkg/functions/errors.go
+++ b/pkg/functions/errors.go
@@ -28,6 +28,9 @@ var (
 	// eg "registry required".  Then catch the error in the CLI and add the
 	// cli-specific usage hints there
 	ErrRegistryRequired = errors.New("registry required to build function, please set with `--registry` or the FUNC_REGISTRY environment variable")
+	
+	// ErrPlatformNotSupported is returned when a platform is specified for a builder that doesn't support it
+	ErrPlatformNotSupported = errors.New("platform not supported by builder")
 )
 
 // ErrNotInitialized indicates that a function is uninitialized

--- a/pkg/functions/errors.go
+++ b/pkg/functions/errors.go
@@ -28,7 +28,7 @@ var (
 	// eg "registry required".  Then catch the error in the CLI and add the
 	// cli-specific usage hints there
 	ErrRegistryRequired = errors.New("registry required to build function, please set with `--registry` or the FUNC_REGISTRY environment variable")
-	
+
 	// ErrPlatformNotSupported is returned when a platform is specified for a builder that doesn't support it
 	ErrPlatformNotSupported = errors.New("platform not supported by builder")
 )


### PR DESCRIPTION
# Changes

- :bug: Fix confusing UX when using --platform flag without S2I builder
- :broom: Implement 2-layer error system for platform restriction errors
- :gift: Add educational guidance about builder capabilities

/kind enhancement

Fixes #3061 


## **Solution:**
Implement a 2-layer error system 
- **Layer 1** (Technical): Return `ErrPlatformNotSupported` from validation in `pkg/functions/errors.go`
- **Layer 2** (CLI): Catch the error in `cmd/build.go` and `cmd/deploy.go` and wrap with user-friendly guidance


**Release Note**

```release-note
func build and func deploy commands now provide clearer, more educational error messages when the --platform flag is used without the S2I builder, with actionable guidance and builder capability explanations.
```
