### PR TITLE
fix: python scaffolding

### DIFF
--- a/pkg/builders/buildpacks/scaffolding_injector.go
+++ b/pkg/builders/buildpacks/scaffolding_injector.go
@@ -130,6 +130,7 @@ allow-direct-references = true
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
+function = { path = "fn", develop = true }
 
 [tool.poetry.scripts]
 script = "service.main:main"


### PR DESCRIPTION
# Changes

* fix: python scaffolding -- make "this function" dependency editable, otherwise only first build has effect any subsequent build "does nothing".

fixes: #3079

/kind bug

```release-note
fix: Python pack build/run doesn't pick up code changes (#3079)
```
