### PR TITLE
fix: use python3 when python not present

### DIFF
--- a/pkg/functions/runner.go
+++ b/pkg/functions/runner.go
@@ -195,7 +195,7 @@ func runPython(ctx context.Context, job *Job) (err error) {
 	if job.verbose {
 		fmt.Printf("python -m venv .venv\n")
 	}
-	cmd := exec.CommandContext(ctx, "python", "-m", "venv", ".venv")
+	cmd := exec.CommandContext(ctx, pythonCmd(), "-m", "venv", ".venv")
 	cmd.Dir = job.Dir()
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
@@ -359,4 +359,12 @@ func choosePort(iface, preferredPort string) (string, error) {
 		return "", fmt.Errorf("cannot parse port: %w", err)
 	}
 	return port, nil
+}
+
+func pythonCmd() string {
+	_, err := exec.LookPath("python")
+	if err != nil {
+		return "python3"
+	}
+	return "python"
 }

--- a/pkg/oci/python_builder.go
+++ b/pkg/oci/python_builder.go
@@ -24,7 +24,7 @@ func (b pythonBuilder) Base(customBase string) string {
 	if customBase != "" {
 		return customBase
 	}
-	cmd := exec.Command("python", "-V")
+	cmd := exec.Command(pythonCmd(), "-V")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return defaultPythonBase
@@ -61,7 +61,7 @@ func (b pythonBuilder) WriteShared(job buildJob) (layers []imageLayer, err error
 	if job.verbose {
 		fmt.Printf("python -m venv .venv\n")
 	}
-	cmd := exec.CommandContext(job.ctx, "python", "-m", "venv", ".venv")
+	cmd := exec.CommandContext(job.ctx, pythonCmd(), "-m", "venv", ".venv")
 	cmd.Dir = job.buildDir()
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
@@ -204,4 +204,12 @@ func newPythonLibTarball(job buildJob, root, target string) error {
 
 func (b pythonBuilder) WritePlatform(ctx buildJob, p v1.Platform) (layers []imageLayer, err error) {
 	return []imageLayer{}, nil
+}
+
+func pythonCmd() string {
+	_, err := exec.LookPath("python")
+	if err != nil {
+		return "python3"
+	}
+	return "python"
 }


### PR DESCRIPTION
# Changes

* fix: use `python3` when `python` not present, sometimes there is missing symlink `python->python3` on some systems.

fixes: #3078

/kind bug

```release-note
fix: fallback to python3 if python not present
```
