### PR TITLE
fix: remote builds defeault to insecure for local registries

### DIFF
--- a/pkg/pipelines/tekton/templates_s2i.go
+++ b/pkg/pipelines/tekton/templates_s2i.go
@@ -44,6 +44,10 @@ spec:
       name: s2iImageScriptsUrl
       type: string
       default: 'image:///usr/libexec/s2i'
+    - description: Verify TLS when pushing to registry
+      name: tlsVerify
+      type: string
+      default: 'true'
   tasks:
     {{.GitCloneTaskRef}}
     - name: scaffold
@@ -70,6 +74,8 @@ spec:
             - '$(params.buildEnvs[*])'
         - name: S2I_IMAGE_SCRIPTS_URL
           value: $(params.s2iImageScriptsUrl)
+        - name: TLSVERIFY
+          value: $(params.tlsVerify)
       runAfter:
         - scaffold
       {{.FuncS2iTaskRef}}
@@ -138,6 +144,8 @@ spec:
         {{end}}
     - name: s2iImageScriptsUrl
       value: {{.S2iImageScriptsUrl}}
+    - name: tlsVerify
+      value: {{.TlsVerify}}
   pipelineRef:
    name: {{.PipelineName}}
   workspaces:
@@ -206,6 +214,8 @@ spec:
         {{end}}
     - name: s2iImageScriptsUrl
       value: {{.S2iImageScriptsUrl}}
+    - name: tlsVerify
+      value: {{.TlsVerify}}
   pipelineRef:
    name: {{.PipelineName}}
   workspaces:

--- a/pkg/pipelines/tekton/templates_test.go
+++ b/pkg/pipelines/tekton/templates_test.go
@@ -19,6 +19,31 @@ const (
 	TestRegistry = "example.com/alice"
 )
 
+func Test_isInsecureRegistry(t *testing.T) {
+	tests := []struct {
+		name     string
+		registry string
+		want     bool
+	}{
+		{"localhost without port", "localhost", true},
+		{"127.0.0.1 without port", "127.0.0.1", true},
+		{"cluster local registry without port", "registry.default.svc.cluster.local", true},
+		{"localhost with port 5000", "localhost:5000", true},
+		{"127.0.0.1 with port 5000", "127.0.0.1:5000", true},
+		{"cluster local registry with port 5000", "registry.default.svc.cluster.local:5000", true},
+		{"external registry", "docker.io", false},
+		{"external registry with port", "quay.io:443", false},
+		{"similar but not matching", "localhost.example.com", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isInsecureRegistry(tt.registry); got != tt.want {
+				t.Errorf("isInsecureRegistry(%q) = %v, want %v", tt.registry, got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_createPipelineTemplatePAC(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Default to insecure connections to local registries for remote builds when registry is a known local name.