### PR TITLE
replace realpath in scripts for cross-platform support

### DIFF
--- a/hack/delete.sh
+++ b/hack/delete.sh
@@ -3,7 +3,7 @@
 # Suitable for use locally during development.
 # CI/CD uses the very similar knative-kind action
 
-source "$(dirname "$(realpath "$0")")/common.sh"
+source "$(cd "$(dirname "$0")" && pwd)/common.sh"
 
 delete_resources() {
   echo "${blue}Deleting Cluster and Registry${reset}"

--- a/hack/install-binaries.sh
+++ b/hack/install-binaries.sh
@@ -16,14 +16,14 @@
 # Installs binaries on linux systems.
 #
 
-source "$(dirname "$(realpath "$0")")/common.sh"
+source "$(cd "$(dirname "$0")" && pwd)/common.sh"
 
 install_binaries() {
   assert_supported_os
   set_os_arch_vars
   warn_architecture
 
-  local root="$(dirname "$(realpath "$0")")"
+  local root="$(cd "$(dirname "$0")" && pwd)"
   local bin="${root}/bin"
 
   local kubectl_version=1.33.1

--- a/hack/install-gitlab.sh
+++ b/hack/install-gitlab.sh
@@ -16,7 +16,7 @@
 # Install GitLab
 #
 
-source "$(dirname "$(realpath "$0")")/common.sh"
+source "$(cd "$(dirname "$0")" && pwd)/common.sh"
 
 function install_gitlab() {
   echo "${blue}Installing GitLab${reset}"

--- a/hack/patch-hosts.sh
+++ b/hack/patch-hosts.sh
@@ -16,7 +16,7 @@
 # Create DNS A records for 'localtest.me' and '*.localtest.me' pointing to the cluster node.
 #
 
-source "$(dirname "$(realpath "$0")")/common.sh"
+source "$(cd "$(dirname "$0")" && pwd)/common.sh"
 
 function patch_hosts() {
   echo "${blue}Configuring Magic DNS${reset}"

--- a/hack/registry.sh
+++ b/hack/registry.sh
@@ -20,7 +20,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-source "$(dirname "$(realpath "$0")")/common.sh"
+source "$(cd "$(dirname "$0")" && pwd)/common.sh"
 
 registry() {
   echo "${blue}Enabling Insecure Local Registry${reset}"

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -5,7 +5,7 @@
 # invoking an http echoing server.
 #
 
-source "$(dirname "$(realpath "$0")")/common.sh"
+source "$(cd "$(dirname "$0")" && pwd)/common.sh"
 
 echo_test() {
   echo "${blue}Testing Cluster via Echo Service${reset}"


### PR DESCRIPTION
Replaces `realpath` with `dirname` in tests for greater cross-platform support.