### PR TITLE
refactor typed-error-describe

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -16,6 +16,8 @@ import (
 	fn "knative.dev/func/pkg/functions"
 )
 
+var ErrNameAndPathConflict = errors.New("cannot specify both name and path")
+
 func NewDescribeCmd(newClient ClientFactory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe <name>",
@@ -128,7 +130,7 @@ func newDescribeConfig(cmd *cobra.Command, args []string) (cfg describeConfig, e
 		// logically inconsistent to provide both a name and a path to source.
 		// Either use the function's local state on disk (--path), or specify
 		// a name and a namespace to ignore any local function source.
-		err = fmt.Errorf("only one of --path and [NAME] should be provided")
+		err = ErrNameAndPathConflict
 	}
 	return
 }

--- a/cmd/describe_test.go
+++ b/cmd/describe_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -126,8 +127,9 @@ func TestDescribe_NameAndPathExclusivity(t *testing.T) {
 	cmd := NewDescribeCmd(NewTestClient(fn.WithDescriber(d)))
 	cmd.SetArgs([]string{"-p", "./testpath", "testname"})
 	if err := cmd.Execute(); err == nil {
-		// TODO(lkingland): use a typed error
 		t.Fatalf("expected error on conflicting flags not received")
+	} else if !errors.Is(err, ErrNameAndPathConflict) {
+		t.Fatalf("expected ErrNameAndPathExclusivity, got %v", err)
 	}
 	if d.DescribeInvoked {
 		t.Fatal("describer was invoked when conflicting flags were provided")


### PR DESCRIPTION
Replaced the string-based error with a typed error `ErrNameAndPathConflict`.
