### PR TITLE
add test cases to defaultNamespace testing

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -301,7 +301,7 @@ func Test_defaultNamespace(t *testing.T) {
 					Namespace: "deployns",
 				},
 			},
-		},{
+		}, {
 			name:     "function already deployed override",
 			context:  true,
 			global:   true,
@@ -311,7 +311,7 @@ func Test_defaultNamespace(t *testing.T) {
 					Namespace: "deployns",
 				},
 			},
-		},{
+		}, {
 			name:     "static default",
 			context:  false,            // no active kube context
 			global:   false,            // no global


### PR DESCRIPTION
Update defaultNamespace testing to include latest deployed and user-forced namespace (`f.Deploy.Namespace` and `f.Namespace` respectively)