### PR TITLE
Revert to go1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/func
 
-go 1.25.0
+go 1.24.4
 
 // this is required bacause of bad dep in github.com/openshift-pipelines/pipelines-as-code
 replace github.com/imdario/mergo => dario.cat/mergo v1.0.1


### PR DESCRIPTION
Reverting to go 1.24 for the midstream/downstream to match the rest of the components