### PR TITLE
Feature: Add remote build and workflow dispatch options to CI workflows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ __pycache__
 # E2E Tests
 /e2e/testdata/default_home/go
 /e2e/testdata/default_home/.cache
- 
+
 # Editors
 .vscode
 .idea

--- a/cmd/ci/config.go
+++ b/cmd/ci/config.go
@@ -38,6 +38,12 @@ const (
 	UseRegistryLoginFlag    = "use-registry-login"
 	DefaultUseRegistryLogin = true
 
+	WorkflowDispatchFlag    = "workflow-dispatch"
+	DefaultWorkflowDispatch = false
+
+	UseRemoteBuildFlag    = "remote"
+	DefaultUseRemoteBuild = false
+
 	UseSelfHostedRunnerFlag    = "self-hosted-runner"
 	DefaultUseSelfHostedRunner = false
 )
@@ -55,7 +61,9 @@ type CIConfig struct {
 	registryPassSecret,
 	registryUrlVar string
 	useRegistryLogin,
-	useSelfHostedRunner bool
+	useSelfHostedRunner,
+	useRemoteBuild,
+	useWorkflowDispatch bool
 }
 
 func NewCIGitHubConfig() CIConfig {
@@ -72,6 +80,8 @@ func NewCIGitHubConfig() CIConfig {
 		registryUrlVar:         viper.GetString(RegistryUrlVariableNameFlag),
 		useRegistryLogin:       viper.GetBool(UseRegistryLoginFlag),
 		useSelfHostedRunner:    viper.GetBool(UseSelfHostedRunnerFlag),
+		useRemoteBuild:         viper.GetBool(UseRemoteBuildFlag),
+		useWorkflowDispatch:    viper.GetBool(WorkflowDispatchFlag),
 	}
 }
 
@@ -101,6 +111,14 @@ func (cc *CIConfig) UseRegistryLogin() bool {
 
 func (cc *CIConfig) UseSelfHostedRunner() bool {
 	return cc.useSelfHostedRunner
+}
+
+func (cc *CIConfig) UseRemoteBuild() bool {
+	return cc.useRemoteBuild
+}
+
+func (cc *CIConfig) UseWorkflowDispatch() bool {
+	return cc.useWorkflowDispatch
 }
 
 func (cc *CIConfig) KubeconfigSecret() string {

--- a/cmd/config_ci.go
+++ b/cmd/config_ci.go
@@ -16,6 +16,8 @@ func NewConfigCICmd(loaderSaver common.FunctionLoaderSaver, writer ci.WorkflowWr
 		PreRunE: bindEnv(
 			ci.PathFlag,
 			ci.UseRegistryLoginFlag,
+			ci.WorkflowDispatchFlag,
+			ci.UseRemoteBuildFlag,
 			ci.UseSelfHostedRunnerFlag,
 			ci.WorkflowNameFlag,
 			ci.BranchFlag,
@@ -36,6 +38,19 @@ func NewConfigCICmd(loaderSaver common.FunctionLoaderSaver, writer ci.WorkflowWr
 		ci.UseRegistryLoginFlag,
 		ci.DefaultUseRegistryLogin,
 		"Add a registry login step in the github workflow",
+	)
+
+	cmd.Flags().Bool(
+		ci.WorkflowDispatchFlag,
+		ci.DefaultWorkflowDispatch,
+		"Add a workflow dispatch trigger for manual workflow execution",
+	)
+	_ = cmd.Flags().MarkHidden(ci.WorkflowDispatchFlag)
+
+	cmd.Flags().Bool(
+		ci.UseRemoteBuildFlag,
+		ci.DefaultUseRemoteBuild,
+		"Build the function on a Tekton-enabled cluster",
 	)
 
 	cmd.Flags().Bool(

--- a/cmd/config_ci_test.go
+++ b/cmd/config_ci_test.go
@@ -93,6 +93,33 @@ func TestNewConfigCICmd_WorkflowHasNoRegistryLogin(t *testing.T) {
 	assert.Assert(t, yamlContains(result.gwYamlString, "--registry=${{ vars.REGISTRY_URL }}"))
 }
 
+func TestNewConfigCICmd_RemoteBuildAndDeployWorkflow(t *testing.T) {
+	// GIVEN
+	opts := unitTestOpts()
+	opts.args = append(opts.args, "--remote")
+
+	// WHEN
+	result := runConfigCiCmd(t, opts)
+
+	// THEN
+	assert.NilError(t, result.executeErr)
+	assert.Assert(t, yamlContains(result.gwYamlString, "Remote Func Deploy"))
+	assert.Assert(t, yamlContains(result.gwYamlString, "func deploy --remote"))
+}
+
+func TestNewConfigCICmd_HasWorkflowDispatch(t *testing.T) {
+	// GIVEN
+	opts := unitTestOpts()
+	opts.args = append(opts.args, "--workflow-dispatch")
+
+	// WHEN
+	result := runConfigCiCmd(t, opts)
+
+	// THEN
+	assert.NilError(t, result.executeErr)
+	assert.Assert(t, yamlContains(result.gwYamlString, "workflow_dispatch"))
+}
+
 // ---------------------
 // END: Broad Unit Tests
 
@@ -303,8 +330,8 @@ func assertDefaultWorkflow(t *testing.T, actualGw string) {
 	assert.Assert(t, yamlContains(actualGw, "password: ${{ secrets.REGISTRY_PASSWORD }}"))
 
 	assert.Assert(t, yamlContains(actualGw, "Install func cli"))
-	assert.Assert(t, yamlContains(actualGw, "gauron99/knative-func-action@main"))
-	assert.Assert(t, yamlContains(actualGw, "version: knative-v1.19.1"))
+	assert.Assert(t, yamlContains(actualGw, "functions-dev/action@main"))
+	assert.Assert(t, yamlContains(actualGw, "version: knative-v1.20.1"))
 	assert.Assert(t, yamlContains(actualGw, "name: func"))
 
 	assert.Assert(t, yamlContains(actualGw, "Deploy function"))

--- a/docs/reference/func_config_ci.md
+++ b/docs/reference/func_config_ci.md
@@ -1,6 +1,6 @@
 ## func config ci
 
-Generate a Github Workflow for function deployment
+Generate a GitHub Workflow for function deployment
 
 ```
 func config ci
@@ -9,9 +9,18 @@ func config ci
 ### Options
 
 ```
-  -h, --help                   help for ci
-  -p, --path string            Path to the function.  Default is current directory ($FUNC_PATH)
-      --workflow-name string   Use a custom workflow name (default "Func Deploy")
+      --branch string                             Use a custom branch name in the workflow (default "main")
+  -h, --help                                      help for ci
+      --kubeconfig-secret-name string             Use a custom secret name in the workflow, e.g. secret.YOUR_CUSTOM_KUBECONFIG (default "KUBECONFIG")
+  -p, --path string                               Path to the function.  Default is current directory ($FUNC_PATH)
+      --registry-login-url-variable-name string   Use a custom registry login url variable name in the workflow, e.g. vars.YOUR_REGISTRY_LOGIN_URL (default "REGISTRY_LOGIN_URL")
+      --registry-pass-secret-name string          Use a custom registry pass secret name in the workflow, e.g. secret.YOUR_REGISTRY_PASSWORD (default "REGISTRY_PASSWORD")
+      --registry-url-variable-name string         Use a custom registry url variable name in the workflow, e.g. vars.YOUR_REGISTRY_URL (default "REGISTRY_URL")
+      --registry-user-variable-name string        Use a custom registry user variable name in the workflow, e.g. vars.YOUR_REGISTRY_USER (default "REGISTRY_USERNAME")
+      --remote                                    Build the function on a Tekton-enabled cluster
+      --self-hosted-runner                        Use a 'self-hosted' runner instead of the default 'ubuntu-latest' for local runner execution
+      --use-registry-login                        Add a registry login step in the github workflow (default true)
+      --workflow-name string                      Use a custom workflow name (default "Func Deploy")
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
# Changes

- :gift: Add `--remote` flag for building functions on Tekton-enabled clusters
- :gift: Add `--workflow-dispatch` flag to enable manual workflow execution from GitHub UI or CLI
- :broom: Update func CLI GitHub Action to official `functions-dev/action` source (`knative-v1.20.1`)

/kind enhancement

Relates to #3256

**Release Note**

```release-note
Add `--remote` flag to `func config ci` to build functions on a Tekton enabled cluster and `--workflow-dispatch` to trigger workflows manually via the GitHub CLI or UI.
```

**Docs**

```docs

```