### PR TITLE
fix: OCI pusher employs in-cluster-dialer

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -9,7 +9,6 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
-
 	"knative.dev/func/pkg/builders"
 	pack "knative.dev/func/pkg/builders/buildpacks"
 	"knative.dev/func/pkg/builders/s2i"
@@ -454,6 +453,7 @@ func (c buildConfig) clientOptions() ([]fn.Option, error) {
 		o = append(o,
 			fn.WithBuilder(oci.NewBuilder(builders.Host, c.Verbose)),
 			fn.WithPusher(oci.NewPusher(c.RegistryInsecure, false, c.Verbose,
+				oci.WithTransport(newTransport(c.RegistryInsecure)),
 				oci.WithCredentialsProvider(creds),
 				oci.WithVerbose(c.Verbose))),
 		)


### PR DESCRIPTION
# Changes

OCI pusher employs in-cluster-dialer, so it can push images to private in cluster OCI registries.

/kind bug


```release-note
fix: host builder can push images to cluster internal registries
```

