### PR TITLE
Add StartTimeout handling to Docker Runner

### DIFF
--- a/pkg/docker/runner.go
+++ b/pkg/docker/runner.go
@@ -119,7 +119,7 @@ func (n *Runner) Run(ctx context.Context, f fn.Function, address string, startTi
 			}
 		}
 	}()
-	
+
 	if err = c.ContainerStart(ctx, id, container.StartOptions{}); err != nil {
 		return job, errors.Wrap(err, "runner unable to start container")
 	}


### PR DESCRIPTION
## Description
This PR adds `StartTimeout` support to the Docker Runner (`pkg/docker/runner.go`).  
The Runner now waits for the container to become ready within a configurable timeout and returns an error if it does not start in time.