### PR TITLE
Enable local volume mounts in func run for ConfigMaps, Secrets, EmptyDirs, and PVCs

### DIFF
--- a/pkg/docker/runner.go
+++ b/pkg/docker/runner.go
@@ -282,7 +282,6 @@ func newHostConfig(f fn.Function, host, port string) (c container.HostConfig, er
 			continue
 		}
 
-
 		// Security: only allow .func folder
 		absHostPath, _ := filepath.Abs(hostPath)
 		absFuncPath, _ := filepath.Abs(".func")

--- a/pkg/docker/runner.go
+++ b/pkg/docker/runner.go
@@ -2,12 +2,12 @@ package docker
 
 import (
 	"context"
-	"strings"
-	"path/filepath"
 	"fmt"
 	"io"
 	"net"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -304,7 +304,7 @@ func newHostConfig(f fn.Function, host, port string) (c container.HostConfig, er
 		if vol.Path != nil {
 			c.Binds = append(c.Binds, fmt.Sprintf("%s:%s", hostPath, *vol.Path))
 		}
-		
+
 	}
 	return c, nil
 }


### PR DESCRIPTION
fix: #2940 
### Changes
- Updated `pkg/docker/runner.go -> newHostConfig()` to mount the following volume types:
  - **ConfigMap** → `.func/run/configmaps/<name>` directory
  - **Secret** → `.func/run/secrets/<name>` directory
  - **EmptyDir** → Docker tmpfs
  - **PersistentVolumeClaim** → `.func/run/pvcs/<claimName>` directory
- Added warnings for volumes that attempt to map outside of `.func` to prevent accidental access to sensitive host directories.
- Preserves existing behavior for port bindings and other container settings.