### PR TITLE
Fix InsecureSSL default for GitHub webhooks

### DIFF
--- a/pkg/git/github/github.go
+++ b/pkg/git/github/github.go
@@ -26,7 +26,7 @@ func (c Client) CreateWebHook(ctx context.Context, repoOwner, repoName, payloadU
 		Config: &github.HookConfig{
 			URL:         github.Ptr(payloadURL),
 			ContentType: github.Ptr("json"),
-			InsecureSSL: github.Ptr("1"), // TODO fix insecure (default should be 0)
+			InsecureSSL: github.Ptr("0"),
 			Secret:      github.Ptr(webhookSecret),
 		},
 	}


### PR DESCRIPTION
Changed `InsecureSSL` from "1" (insecure) to "0" (secure) to ensure SSL certificates
are properly verified by default. 