### PR TITLE
feat: warn when func invoke type mismatches declared function type

### DIFF
--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -119,7 +119,7 @@ EXAMPLES
 	}
 
 	// Flags
-	cmd.Flags().StringP("format", "f", "", "Format of message to send, 'http' or 'cloudevent(s)'.  Default is to choose automatically. ($FUNC_FORMAT)")
+	cmd.Flags().StringP("format", "f", "", "Format of message to send, 'http' or 'cloudevent'.  Default is to choose automatically. ($FUNC_FORMAT)")
 	cmd.Flags().StringP("target", "t", "", "Function instance to invoke.  Can be 'local', 'remote' or a URL.  Defaults to auto-discovery if not provided. ($FUNC_TARGET)")
 	cmd.Flags().StringP("id", "", "", "ID for the request data. ($FUNC_ID)")
 	cmd.Flags().StringP("source", "", fn.DefaultInvokeSource, "Source value for the request data. ($FUNC_SOURCE)")


### PR DESCRIPTION
fix: #3083 
This PR improves the developer experience when invoking functions with mismatched types.

Previously, if a user invoked a function with `func invoke -f cloudevents` while the function's `func.yaml` declared `invoke: http`, the command failed silently with a confusing error.  
Now, the CLI detects this mismatch and prints a clear warning before proceeding.

<img width="1092" height="243" alt="image" src="https://github.com/user-attachments/assets/21427303-916a-460a-a3d1-1f7489e22797" />