### PR TITLE
fix(create): Add helpful error messages for hyphen-prefixed function names mis-parsed as flags

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -122,7 +122,7 @@ EXAMPLES
 			} else if strings.HasPrefix(arg, "-") && len(arg) > 1 {
 				firstChar := string(arg[1])
 				shortFlag := cmd.Flags().ShorthandLookup(firstChar)
-				
+
 				if shortFlag != nil && len(arg) > 2 && strings.Contains(arg, "-") {
 					return wrapFlagParsingError(err, arg)
 				} else if strings.Contains(err.Error(), "unknown shorthand flag") && strings.Contains(err.Error(), arg[1:2]) {
@@ -417,7 +417,7 @@ func newInvalidRuntimeError(client *fn.Client, runtime string) error {
 	}
 
 	baseErr := ErrInvalidRuntime(errors.New(b.String()))
-	
+
 	// Check if runtime value indicates mis-parsed function name
 	for _, arg := range os.Args[1:] {
 		if strings.HasPrefix(arg, "-") && len(arg) > 2 && strings.Contains(arg[2:], "-") {
@@ -427,7 +427,7 @@ func newInvalidRuntimeError(client *fn.Client, runtime string) error {
 			}
 		}
 	}
-	
+
 	return baseErr
 }
 
@@ -447,7 +447,7 @@ func newInvalidTemplateError(client *fn.Client, runtime, template string) error 
 	}
 
 	baseErr := ErrInvalidTemplate(errors.New(b.String()))
-	
+
 	// Check if template value indicates mis-parsed function name
 	for _, arg := range os.Args[1:] {
 		if strings.HasPrefix(arg, "-") && len(arg) > 2 && strings.Contains(arg[2:], "-") {
@@ -457,7 +457,7 @@ func newInvalidTemplateError(client *fn.Client, runtime, template string) error 
 			}
 		}
 	}
-	
+
 	return baseErr
 }
 

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -110,7 +110,7 @@ func wrapFlagParsingErrorWithDetails(err error, suspectedName, flagChar, parsedV
 		explanation = fmt.Sprintf("It looks like '%s' was interpreted as a long flag.", suspectedName)
 	} else if len(suspectedName) > 1 && suspectedName[0] == '-' {
 		if flagChar != "" && parsedValue != "" {
-			explanation = fmt.Sprintf("It looks like '%s' was interpreted as the flag '-%s' with value '%s'.", 
+			explanation = fmt.Sprintf("It looks like '%s' was interpreted as the flag '-%s' with value '%s'.",
 				suspectedName, flagChar, parsedValue)
 		} else {
 			explanation = fmt.Sprintf("It looks like '%s' was interpreted as a flag.", suspectedName)
@@ -118,10 +118,10 @@ func wrapFlagParsingErrorWithDetails(err error, suspectedName, flagChar, parsedV
 	} else {
 		return err
 	}
-	
-	return fmt.Errorf("%v\n\n"+
-		"Note: %s\n"+
-		"Function names cannot start with hyphens per DNS-1035 naming rules.\n"+
-		"Valid function names must start with a letter (a-z) and can contain letters, numbers, and hyphens.",
-		err, explanation)
+
+	return fmt.Errorf(`%v
+
+Note: %s
+Function names cannot start with hyphens per DNS-1035 naming rules.
+Valid function names must start with a letter (a-z) and can contain letters, numbers, and hyphens`, err, explanation)
 }


### PR DESCRIPTION
# Changes

- :bug: Fix confusing errors when function names start with hyphens
- :gift: Add DNS-1035 naming guidance for mis-parsed arguments
- :sparkles: Detect hyphen-prefixed names across multiple error paths

Adds detection and helpful error messages when function names starting with hyphens (e.g., `-test-func`, `--production-func`, `-123`) are mis-parsed as CLI flags. Users now receive clear guidance about DNS-1035 naming rules instead of confusing "template not found" or "unknown flag" errors.

**Implementation:**

- Add `wrapFlagParsingError()` and `wrapFlagParsingErrorWithDetails()` helper functions (`cmd/errors.go`)
- Add custom flag error handler in `NewCreateCmd()` to intercept Cobra flag parsing errors (`cmd/create.go`)
- Enhance `newInvalidRuntimeError()` and `newInvalidTemplateError()` to detect mis-parsed names (`cmd/create.go`)

**Error Message Example:**

```txt
Error: The template 'est-func' was not found for language runtime 'go'.
Available templates for this language runtime are:
  cloudevents
  http

Note: It looks like '-test-func' was interpreted as the flag '-t' with value 'est-func'.
Function names cannot start with hyphens per DNS-1035 naming rules.
Valid function names must start with a letter (a-z) and can contain letters, numbers, and hyphens.
```

/kind bug

Fixes #3166 

**Release Note**

```release-note
Function names starting with hyphens now show helpful DNS-1035 naming guidance instead of confusing flag parsing errors
```
