### PR TITLE
Fix silent fallback to random ports when invalid, privileged, or in-use ports are specified

### DIFF
--- a/pkg/functions/errors.go
+++ b/pkg/functions/errors.go
@@ -3,6 +3,7 @@ package functions
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -86,4 +87,32 @@ type ErrEnvNotExist struct {
 
 func (e ErrEnvNotExist) Error() string {
 	return fmt.Sprintf("environment variable %q does not exist", e.Name)
+}
+
+// ErrPortUnavailableError indicates that a port cannot be bound
+type ErrPortUnavailableError struct {
+	Port string
+	Err  error
+}
+
+func (e *ErrPortUnavailableError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("port %s is not available: %v", e.Port, e.Err)
+	}
+	return fmt.Sprintf("port %s is not available", e.Port)
+}
+
+func (e *ErrPortUnavailableError) Unwrap() error {
+	return e.Err
+}
+
+// IsPermissionDenied checks if the underlying error is a permission error
+func (e *ErrPortUnavailableError) IsPermissionDenied() bool {
+	if e.Err == nil {
+		return false
+	}
+	errStr := strings.ToLower(e.Err.Error())
+	return strings.Contains(errStr, "permission denied") ||
+		strings.Contains(errStr, "access denied") ||
+		strings.Contains(errStr, "operation not permitted")
 }


### PR DESCRIPTION
# Changes

- :bug: Prevent silent fallback when explicit ports are invalid, privileged, or already in use
- :sparkles: Validate `--address` inputs (hostless, non-numeric, out-of-range) with clear guidance
- :gift: Explain privileged-port failures with actionable sudo/non-privileged hints

Adds strict validation and helpful CLI messages when `func run --builder=host` receives explicit ports that can’t be bound. Users now see why the port failed instead of having the CLI silently pick a random port.

**Implementation**

- Added explicit-port handling in `choosePort` that returns `*ErrPortUnavailableError`
- Expanded `runConfig.Validate` to reject hostless addresses and invalid port ranges with examples
- Wrapped port binding errors in `runRun` to provide tailored guidance (permission denied vs. port in use)

/kind bug

Fixes #3175 

**Release Note**

```release-note
func run --builder=host now fails fast with helpful guidance when explicit ports are invalid, privileged, or already in use instead of silently choosing a random port
```
