### PR TITLE
refactor(mcp): add newSuccessResult helper and update resources

### DIFF
--- a/pkg/mcp/resources.go
+++ b/pkg/mcp/resources.go
@@ -19,3 +19,15 @@ func newErrorResult(uri string, err error) *mcp.ReadResourceResult {
 		},
 	}
 }
+
+func newSuccessResult(uri, mime string, text []byte) *mcp.ReadResourceResult {
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{
+			{
+				URI:      uri,
+				MIMEType: mime,
+				Text:     string(text),
+			},
+		},
+	}
+}

--- a/pkg/mcp/resources_language.go
+++ b/pkg/mcp/resources_language.go
@@ -19,9 +19,5 @@ func (s *Server) languagesHandler(ctx context.Context, r *mcp.ReadResourceReques
 		return result, err
 	}
 
-	return &mcp.ReadResourceResult{Contents: []*mcp.ResourceContents{{
-		URI:      "func://languages",
-		MIMEType: "text/plain",
-		Text:     string(out),
-	}}}, nil
+	return newSuccessResult("func://languages", "text/plain", out), nil
 }

--- a/pkg/mcp/resources_templates.go
+++ b/pkg/mcp/resources_templates.go
@@ -19,9 +19,5 @@ func (s *Server) templatesHandler(ctx context.Context, r *mcp.ReadResourceReques
 		return result, err
 	}
 
-	return &mcp.ReadResourceResult{Contents: []*mcp.ResourceContents{{
-		URI:      "func://templates",
-		MIMEType: "text/plain",
-		Text:     string(out),
-	}}}, nil
+	return newSuccessResult("func://templates", "text/plain", out), nil
 }


### PR DESCRIPTION
Add newSuccessResult helper and update resources

- Introduced newSuccessResult for consistent success responses
- Replaced duplicated result construction across resource_* files