### PR TITLE
Run TestInt_PrivateGitRepository from temp directory

### DIFF
--- a/pkg/builders/builders_int_test.go
+++ b/pkg/builders/builders_int_test.go
@@ -39,29 +39,29 @@ import (
 )
 
 func copyDir(src, dst string) error {
-    return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
-        if err != nil {
-            return err
-        }
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 
-        rel, err := filepath.Rel(src, path)
-        if err != nil {
-            return err
-        }
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
 
-        target := filepath.Join(dst, rel)
+		target := filepath.Join(dst, rel)
 
-        if info.IsDir() {
-            return os.MkdirAll(target, info.Mode())
-        }
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
 
-        data, err := os.ReadFile(path)
-        if err != nil {
-            return err
-        }
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
 
-        return os.WriteFile(target, data, info.Mode())
-    })
+		return os.WriteFile(target, data, info.Mode())
+	})
 }
 
 func TestInt_PrivateGitRepository(t *testing.T) {


### PR DESCRIPTION
## fix: #3196 
This PR updates TestInt_PrivateGitRepository to run from a temporary working
directory instead of directly using pkg/builders/testdata. The previous behavior
created a .s2i directory inside testdata during execution, causing unwanted
repository changes.

The test now copies the function source into a temporary directory before
running, consistent with other integration tests.