### PR TITLE
Add 'env' alias for 'environment' command

### DIFF
--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -32,7 +32,6 @@ NAME
 
 SYNOPSIS
 	{{rootCmdUse}} environment [-f|--format] [-v|--verbose] [-p|--path]
-	{{rootCmdUse}} env [-f|--format] [-v|--verbose] [-p|--path]
 
 
 DESCRIPTION

--- a/docs/reference/func_environment.md
+++ b/docs/reference/func_environment.md
@@ -10,7 +10,6 @@ NAME
 
 SYNOPSIS
 	func environment [-f|--format] [-v|--verbose] [-p|--path]
-	func env [-f|--format] [-v|--verbose] [-p|--path]
 
 
 DESCRIPTION


### PR DESCRIPTION
# Changes

- :gift: Add `env` alias for `environment` command to improve developer experience

/kind enhancement

Fixes #3218 

**Why:** The `environment` command is the longest command in the CLI (11 characters) and lacks a short alias, making it inconsistent with other commands like `repository` → `repo` and `list` → `ls`. This PR adds the intuitive `env` alias to improve usability and maintain consistency across the CLI.

**What Changed:**
- Added `Aliases: []string{"env"}` to the `environment` command definition
- Updated help text to show both `func environment` and `func env` in SYNOPSIS
- Updated documentation to reflect the new alias


**Release Note**
```release-note
Added `env` as a short alias for the `environment` command. Users can now use `func env` as a convenient shorthand for `func environment`.
```

**Docs**
```docs
Documentation updated in `docs/reference/func_environment.md` to reflect the new alias.
```