### PR TITLE
:bug: Populate image field in `func describe`

### DIFF
--- a/pkg/k8s/describer.go
+++ b/pkg/k8s/describer.go
@@ -57,6 +57,14 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (fn.In
 
 	primaryRouteURL := fmt.Sprintf("http://%s.%s.svc", name, namespace) // TODO: get correct scheme?
 
+	// get image
+	image := ""
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name == "user-container" {
+			image = container.Image
+		}
+	}
+
 	description := fn.Instance{
 		Name:      name,
 		Namespace: namespace,
@@ -64,6 +72,7 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (fn.In
 		Labels:    deployment.Labels,
 		Route:     primaryRouteURL,
 		Routes:    []string{primaryRouteURL},
+		Image:     image,
 	}
 
 	return description, nil


### PR DESCRIPTION
# Changes

Currently the image field in `func describe` is not set:
```
{
  "Route": "http://func-go-hello-world.default.svc",
  "routes": [
    "http://func-go-hello-world.default.svc"
  ],
  "name": "func-go-hello-world",
  "image": "",
  "namespace": "default",
  "deployer": "raw",
  "subscriptions": null,
  "labels": {
    "boson.dev/function": "true",
    "function.knative.dev/name": "func-go-hello-world",
    "function.knative.dev/runtime": "go"
  }
}
```

This PR addressed it and populates the field:
```
{
  "Route": "http://func-go-hello-world.default.svc",
  "routes": [
    "http://func-go-hello-world.default.svc"
  ],
  "name": "func-go-hello-world",
  "image": "localhost:5001/func-go-hello-world@sha256:805b29c3ff6a379ebab4ddc27e974734d2e23baee3454c38abea9fccfc9b061c",
  "namespace": "default",
  "deployer": "raw",
  "subscriptions": null,
  "labels": {
    "boson.dev/function": "true",
    "function.knative.dev/name": "func-go-hello-world",
    "function.knative.dev/runtime": "go"
  }
}
```

/kind bug

**Release Note**
```release-note
fix: populate image field in func describe
```