### PR TITLE
refactor: Extract scaffolding as per-builder, new buildpacks default builder and sync Go version

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -226,6 +226,11 @@ For more options, run 'func build --help'`, err)
 	if err != nil {
 		return
 	}
+
+	if err = client.Scaffold(cmd.Context(), f, ""); err != nil {
+		return
+	}
+
 	if f, err = client.Build(cmd.Context(), f, buildOptions...); err != nil {
 		return
 	}
@@ -479,6 +484,7 @@ func (c buildConfig) clientOptions() ([]fn.Option, error) {
 	switch c.Builder {
 	case builders.Host:
 		o = append(o,
+			fn.WithScaffolder(oci.NewScaffolder(c.Verbose)),
 			fn.WithBuilder(oci.NewBuilder(builders.Host, c.Verbose)),
 			fn.WithPusher(oci.NewPusher(c.RegistryInsecure, false, c.Verbose,
 				oci.WithTransport(newTransport(c.RegistryInsecure)),
@@ -487,6 +493,7 @@ func (c buildConfig) clientOptions() ([]fn.Option, error) {
 		)
 	case builders.Pack:
 		o = append(o,
+			fn.WithScaffolder(buildpacks.NewScaffolder(c.Verbose)),
 			fn.WithBuilder(buildpacks.NewBuilder(
 				buildpacks.WithName(builders.Pack),
 				buildpacks.WithTimestamp(c.WithTimestamp),
@@ -497,6 +504,7 @@ func (c buildConfig) clientOptions() ([]fn.Option, error) {
 				docker.WithVerbose(c.Verbose))))
 	case builders.S2I:
 		o = append(o,
+			fn.WithScaffolder(s2i.NewScaffolder(c.Verbose)),
 			fn.WithBuilder(s2i.NewBuilder(
 				s2i.WithName(builders.S2I),
 				s2i.WithVerbose(c.Verbose))),

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -66,6 +66,7 @@ func NewClient(cfg ClientConfig, options ...fn.Option) (*fn.Client, func()) {
 			fn.WithVerbose(cfg.Verbose),
 			fn.WithTransport(t),
 			fn.WithRepositoriesPath(config.RepositoriesPath()),
+			fn.WithScaffolder(buildpacks.NewScaffolder(cfg.Verbose)),
 			fn.WithBuilder(buildpacks.NewBuilder(buildpacks.WithVerbose(cfg.Verbose))),
 			fn.WithRemovers(knative.NewRemover(cfg.Verbose), k8s.NewRemover(cfg.Verbose)),
 			fn.WithDescribers(knative.NewDescriber(cfg.Verbose), k8s.NewDescriber(cfg.Verbose)),

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -227,8 +227,18 @@ Or if you have an existing function:
 
 		// actual build step
 		if !digested {
-			if f, _, err = build(cmd, cfg.Build, f, client, buildOptions); err != nil {
+			shouldBuild, err := build(cmd, cfg.Build, f)
+			if err != nil {
 				return err
+			}
+			if shouldBuild {
+				if err := client.Scaffold(cmd.Context(), f, ""); err != nil {
+					return err
+				}
+				f, err = client.Build(cmd.Context(), f, buildOptions...)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	} else { // if !container

--- a/pkg/buildpacks/builder.go
+++ b/pkg/buildpacks/builder.go
@@ -28,8 +28,8 @@ import (
 // DefaultName when no WithName option is provided to NewBuilder
 const DefaultName = builders.Pack
 
-var DefaultBaseBuilder = "ghcr.io/knative/builder-jammy-base:latest"
-var DefaultTinyBuilder = "ghcr.io/knative/builder-jammy-tiny:latest"
+var DefaultBaseBuilder = "ghcr.io/knative/builder-jammy-base:v2"
+var DefaultTinyBuilder = "ghcr.io/knative/builder-jammy-tiny:v2"
 
 var (
 	DefaultBuilderImages = map[string]string{
@@ -184,6 +184,11 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 
 	if _, ok := opts.Env["BPE_DEFAULT_LISTEN_ADDRESS"]; !ok {
 		opts.Env["BPE_DEFAULT_LISTEN_ADDRESS"] = "[::]:8080"
+	}
+
+	// set scaffolding path to buildpacks builder
+	if f.Runtime == "go" {
+		opts.Env["BP_GO_WORKDIR"] = ".func/build"
 	}
 
 	var bindings = make([]string, 0, len(f.Build.Mounts))

--- a/pkg/buildpacks/scaffolder.go
+++ b/pkg/buildpacks/scaffolder.go
@@ -1,0 +1,50 @@
+package buildpacks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	fn "knative.dev/func/pkg/functions"
+	"knative.dev/func/pkg/scaffolding"
+)
+
+const defaultPath = ".func/build"
+
+// Scaffolder for buildpacks builder
+type Scaffolder struct {
+	verbose bool
+}
+
+func NewScaffolder(verbose bool) *Scaffolder {
+	return &Scaffolder{verbose: verbose}
+}
+
+// Scaffold the function so that it can be built via buildpacks builder.
+// 'path' is an optional override. Assign "" (empty string) most of the time
+func (s Scaffolder) Scaffold(ctx context.Context, f fn.Function, path string) error {
+	// Because of Python injector we currently dont scaffold python.
+	// Add it here once the injector is removed
+	if f.Runtime != "go" {
+		if s.verbose {
+			fmt.Println("Scaffolding skipped. Currently available for runtime go")
+		}
+		return nil
+	}
+
+	appRoot := path
+	if appRoot == "" {
+		appRoot = filepath.Join(f.Root, defaultPath)
+	}
+	if s.verbose {
+		fmt.Printf("Writing buildpacks scaffolding at path '%v'\n", appRoot)
+	}
+
+	embeddedRepo, err := fn.NewRepository("", "")
+	if err != nil {
+		return fmt.Errorf("unable to load embedded scaffolding: %w", err)
+	}
+	_ = os.RemoveAll(appRoot)
+	return scaffolding.Write(appRoot, f.Root, f.Runtime, f.Invoke, embeddedRepo.FS())
+}

--- a/pkg/deployer/testing/integration_test_helper.go
+++ b/pkg/deployer/testing/integration_test_helper.go
@@ -42,6 +42,7 @@ func TestInt_Deploy(t *testing.T, deployer fn.Deployer, remover fn.Remover, desc
 	t.Cleanup(cancel)
 
 	client := fn.New(
+		fn.WithScaffolder(oci.NewScaffolder(true)),
 		fn.WithBuilder(oci.NewBuilder("", false)),
 		fn.WithPusher(oci.NewPusher(true, true, true)),
 		fn.WithDeployer(deployer),
@@ -62,6 +63,12 @@ func TestInt_Deploy(t *testing.T, deployer fn.Deployer, remover fn.Remover, desc
 	// Not really necessary, but it allows us to reuse the "invoke" method:
 	handlerPath := filepath.Join(root, "handle.go")
 	if err := os.WriteFile(handlerPath, []byte(testHandler), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Scaffold
+	err = client.Scaffold(ctx, f, "")
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -115,6 +122,7 @@ func TestInt_Metadata(t *testing.T, deployer fn.Deployer, remover fn.Remover, de
 	t.Cleanup(cancel)
 
 	client := fn.New(
+		fn.WithScaffolder(oci.NewScaffolder(true)),
 		fn.WithBuilder(oci.NewBuilder("", false)),
 		fn.WithPusher(oci.NewPusher(true, true, true)),
 		fn.WithDeployer(deployer),
@@ -156,6 +164,7 @@ func TestInt_Metadata(t *testing.T, deployer fn.Deployer, remover fn.Remover, de
 		t.Fatal(err)
 	}
 	handlerPath := filepath.Join(root, "handle.go")
+
 	if err := os.WriteFile(handlerPath, []byte(testHandler), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -196,6 +205,12 @@ func TestInt_Metadata(t *testing.T, deployer fn.Deployer, remover fn.Remover, de
 
 	// Deploy
 	// ------
+
+	// Scaffold
+	err = client.Scaffold(ctx, f, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Build
 	f, err = client.Build(ctx, f)
@@ -283,6 +298,7 @@ func TestInt_Events(t *testing.T, deployer fn.Deployer, remover fn.Remover, desc
 	t.Cleanup(cancel)
 
 	client := fn.New(
+		fn.WithScaffolder(oci.NewScaffolder(true)),
 		fn.WithBuilder(oci.NewBuilder("", false)),
 		fn.WithPusher(oci.NewPusher(true, true, true)),
 		fn.WithDeployer(deployer),
@@ -310,6 +326,12 @@ func TestInt_Events(t *testing.T, deployer fn.Deployer, remover fn.Remover, desc
 
 	// Deploy
 	// ------
+
+	// Scaffold
+	err = client.Scaffold(ctx, f, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Build
 	f, err = client.Build(ctx, f)
@@ -361,6 +383,7 @@ func TestInt_Scale(t *testing.T, deployer fn.Deployer, remover fn.Remover, descr
 	t.Cleanup(cancel)
 
 	client := fn.New(
+		fn.WithScaffolder(oci.NewScaffolder(true)),
 		fn.WithBuilder(oci.NewBuilder("", false)),
 		fn.WithPusher(oci.NewPusher(true, true, true)),
 		fn.WithDeployer(deployer),
@@ -386,6 +409,12 @@ func TestInt_Scale(t *testing.T, deployer fn.Deployer, remover fn.Remover, descr
 			Min: &minScale,
 			Max: &maxScale,
 		},
+	}
+
+	// Scaffold
+	err = client.Scaffold(ctx, f, "")
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// Build
@@ -467,6 +496,7 @@ func TestInt_EnvsUpdate(t *testing.T, deployer fn.Deployer, remover fn.Remover, 
 	t.Cleanup(cancel)
 
 	client := fn.New(
+		fn.WithScaffolder(oci.NewScaffolder(true)),
 		fn.WithBuilder(oci.NewBuilder("", false)),
 		fn.WithPusher(oci.NewPusher(true, true, true)),
 		fn.WithDeployer(deployer),
@@ -499,6 +529,12 @@ func TestInt_EnvsUpdate(t *testing.T, deployer fn.Deployer, remover fn.Remover, 
 
 	// Deploy
 	// ------
+
+	// Scaffold
+	err = client.Scaffold(ctx, f, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Build
 	f, err = client.Build(ctx, f)

--- a/pkg/describer/testing/integration_test_helper.go
+++ b/pkg/describer/testing/integration_test_helper.go
@@ -24,6 +24,7 @@ func TestInt_Describe(t *testing.T, describer fn.Describer, deployer fn.Deployer
 	t.Cleanup(cancel)
 
 	client := fn.New(
+		fn.WithScaffolder(oci.NewScaffolder(true)),
 		fn.WithBuilder(oci.NewBuilder("", false)),
 		fn.WithPusher(oci.NewPusher(true, true, true)),
 		fn.WithDescribers(describer),
@@ -38,6 +39,12 @@ func TestInt_Describe(t *testing.T, describer fn.Describer, deployer fn.Deployer
 		Namespace: ns,
 		Registry:  Registry(),
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Scaffold
+	err = client.Scaffold(ctx, f, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/functions/client_int_test.go
+++ b/pkg/functions/client_int_test.go
@@ -125,6 +125,9 @@ func TestInt_Deploy_Defaults(t *testing.T) {
 	if f, err = client.Init(f); err != nil {
 		t.Fatal(err)
 	}
+	if err = client.Scaffold(context.Background(), f, ""); err != nil {
+		t.Fatal(err)
+	}
 	if f, err = client.Build(context.Background(), f); err != nil {
 		t.Fatal(err)
 	}
@@ -657,6 +660,7 @@ func resetEnv() {
 func newClient(verbose bool) *fn.Client {
 	return fn.New(
 		fn.WithRegistry(DefaultIntTestRegistry),
+		fn.WithScaffolder(oci.NewScaffolder(true)),
 		fn.WithBuilder(oci.NewBuilder("", verbose)),
 		fn.WithPusher(oci.NewPusher(true, true, verbose)),
 		fn.WithDeployer(knative.NewDeployer(knative.WithDeployerVerbose(verbose))),
@@ -667,18 +671,15 @@ func newClient(verbose bool) *fn.Client {
 	)
 }
 
-// copy of newClient just builder is s2i instead of buildpacks
+// copy of newClient just with s2i methods instead
 func newClientWithS2i(verbose bool) *fn.Client {
-	builder := s2i.NewBuilder(s2i.WithVerbose(verbose))
-	pusher := docker.NewPusher(docker.WithVerbose(verbose))
-	deployer := knative.NewDeployer(knative.WithDeployerVerbose(verbose))
-
 	return fn.New(
 		fn.WithRegistry(DefaultIntTestRegistry),
 		fn.WithVerbose(verbose),
-		fn.WithBuilder(builder),
-		fn.WithPusher(pusher),
-		fn.WithDeployer(deployer),
+		fn.WithScaffolder(s2i.NewScaffolder(true)),
+		fn.WithBuilder(s2i.NewBuilder(s2i.WithVerbose(verbose))),
+		fn.WithPusher(docker.NewPusher(docker.WithVerbose(verbose))),
+		fn.WithDeployer(knative.NewDeployer(knative.WithDeployerVerbose(verbose))),
 		fn.WithDescribers(knative.NewDescriber(verbose), k8s.NewDescriber(verbose)),
 		fn.WithRemovers(knative.NewRemover(verbose), k8s.NewRemover(verbose)),
 		fn.WithListers(knative.NewLister(verbose), k8s.NewLister(verbose)),

--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -528,7 +528,7 @@ func WithStampJournal() stampOption {
 // stamp is checked before certain operations, and if it has been updated,
 // the build can be skipped.  If in doubt, just use .Write only.
 //
-// Updates the build stamp at ./func/built (and the log
+// Updates the build stamp at .func/built-hash (and the log
 // at .func/built.log) to reflect the current state of the filesystem.
 // Note that the caller should call .Write first to flush any changes to the
 // function in-memory to the filesystem prior to calling stamp.
@@ -736,7 +736,7 @@ func (f Function) Built() bool {
 	return true
 }
 
-// BuildStamp accesses the current (last) build stamp for the function.
+// BuildStamp accesses the current build stamp for the function.
 // Unbuilt functions return empty string.
 func (f Function) BuildStamp() string {
 	path := filepath.Join(f.Root, RunDataDir, BuiltHash)

--- a/pkg/lister/testing/integration_test_helper.go
+++ b/pkg/lister/testing/integration_test_helper.go
@@ -24,6 +24,7 @@ func TestInt_List(t *testing.T, lister fn.Lister, deployer fn.Deployer, describe
 	t.Cleanup(cancel)
 
 	client := fn.New(
+		fn.WithScaffolder(oci.NewScaffolder(true)),
 		fn.WithBuilder(oci.NewBuilder("", false)),
 		fn.WithPusher(oci.NewPusher(true, true, true)),
 		fn.WithDeployer(deployer),
@@ -39,6 +40,12 @@ func TestInt_List(t *testing.T, lister fn.Lister, deployer fn.Deployer, describe
 		Namespace: ns,
 		Registry:  Registry(),
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Scaffold
+	err = client.Scaffold(ctx, f, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/oci/errors.go
+++ b/pkg/oci/errors.go
@@ -10,11 +10,3 @@ type BuildErr struct {
 func (e BuildErr) Error() string {
 	return fmt.Sprintf("error performing host build. %v", e.Err)
 }
-
-type ErrBuildInProgress struct {
-	Dir string
-}
-
-func (e ErrBuildInProgress) Error() string {
-	return fmt.Sprintf("a build for this function is associated with an active PID appears to be already in progress %v", e.Dir)
-}

--- a/pkg/oci/go_builder.go
+++ b/pkg/oci/go_builder.go
@@ -124,7 +124,7 @@ func goBuildCmd(p v1.Platform, cfg buildJob) (gobin string, args []string, outpa
 		gobin = "go"
 	}
 
-	// Build as ./func/builds/$PID/result/f.$OS.$Architecture
+	// Build as ./func/build/result/f.$OS.$Architecture
 	name := fmt.Sprintf("f.%v.%v", p.OS, p.Architecture)
 	if p.Variant != "" {
 		name = name + "." + p.Variant

--- a/pkg/oci/pusher.go
+++ b/pkg/oci/pusher.go
@@ -94,7 +94,7 @@ func (p *Pusher) Push(ctx context.Context, f fn.Function) (digest string, err er
 
 	go p.handleUpdates(ctx)
 	defer func() { p.done <- true }()
-	buildDir, err := getLastBuildDir(f)
+	buildDir, err := getBuildDir(f)
 	if err != nil {
 		return
 	}
@@ -157,11 +157,11 @@ func (p *Pusher) handleUpdates(ctx context.Context) {
 	}
 }
 
-// The last build directory is symlinked upon successful build.
-func getLastBuildDir(f fn.Function) (string, error) {
-	dir := filepath.Join(f.Root, fn.RunDataDir, "builds", "last")
+// getBuildDir returns the build directory
+func getBuildDir(f fn.Function) (string, error) {
+	dir := filepath.Join(f.Root, fn.RunDataDir, "build")
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		return dir, fmt.Errorf("last build directory not found '%v'. Has it been built?", dir)
+		return dir, fmt.Errorf("build directory not found '%v'. Has it been built?", dir)
 	}
 	return dir, nil
 }

--- a/pkg/oci/pusher_test.go
+++ b/pkg/oci/pusher_test.go
@@ -61,12 +61,17 @@ func TestPusher_Push(t *testing.T) {
 
 	// Create and push a function
 	client := fn.New(
+		fn.WithScaffolder(NewScaffolder(false)),
 		fn.WithBuilder(NewBuilder("", false)),
 		fn.WithPusher(NewPusher(insecure, anon, verbose)))
 
 	f := fn.Function{Root: root, Runtime: "go", Name: "f", Registry: l.Addr().String() + "/funcs"}
 
 	if f, err = client.Init(f); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = client.Scaffold(context.Background(), f, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -135,6 +140,7 @@ func TestPusher_BasicAuth(t *testing.T) {
 	// Client
 	// initialized with an OCI builder and pusher.
 	client := fn.New(
+		fn.WithScaffolder(NewScaffolder(verbose)),
 		fn.WithBuilder(NewBuilder("", verbose)),
 		fn.WithPusher(pusher),
 	)
@@ -148,6 +154,9 @@ func TestPusher_BasicAuth(t *testing.T) {
 		Registry: server.Addr().String() + "/funcs"}
 
 	if f, err = client.Init(f); err != nil {
+		t.Fatal(err)
+	}
+	if err = client.Scaffold(context.Background(), f, ""); err != nil {
 		t.Fatal(err)
 	}
 	if f, err = client.Build(context.Background(), f); err != nil {

--- a/pkg/oci/python_builder.go
+++ b/pkg/oci/python_builder.go
@@ -41,8 +41,8 @@ func (b pythonBuilder) Base(customBase string) string {
 // ConfigFile that will be used when building the template.
 func (b pythonBuilder) Configure(job buildJob, _ v1.Platform, cf v1.ConfigFile) (v1.ConfigFile, error) {
 	var (
-		svcRelPath, _ = filepath.Rel(job.function.Root, job.buildDir()) // eg .func/builds/by-hash/$HASH
-		svcPath       = filepath.Join("/func", svcRelPath)              // eg /func/.func/builds/by-hash/$HASH
+		svcRelPath, _ = filepath.Rel(job.function.Root, job.buildDir()) // .func/build
+		svcPath       = filepath.Join("/func", svcRelPath)              // /func/.func/build
 		pythonPathEnv = fmt.Sprintf("PYTHONPATH=%v/lib", svcPath)
 		mainPath      = fmt.Sprintf("%v/service/main.py", svcPath)
 		listenAddrEnv = "LISTEN_ADDRESS=[::]:8080"
@@ -128,7 +128,7 @@ func (b pythonBuilder) WriteShared(job buildJob) (layers []imageLayer, err error
 func newPythonLibTarball(job buildJob, root, target string) error {
 	// Create a tarball of the "build directory"
 	// when extracted, it's root will be /func
-	// all files within should have path prefix .func/builds/by-hash/$hash
+	// all files within should have path prefix .func/build
 
 	targetFile, err := os.Create(target) // final .tar.gz
 	if err != nil {

--- a/pkg/oci/scaffolder.go
+++ b/pkg/oci/scaffolder.go
@@ -1,0 +1,49 @@
+package oci
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	fn "knative.dev/func/pkg/functions"
+	"knative.dev/func/pkg/scaffolding"
+)
+
+const (
+	defaultPath = ".func/build"
+)
+
+// Scaffolder for host (OCI) builder
+type Scaffolder struct {
+	verbose bool
+}
+
+func NewScaffolder(verbose bool) *Scaffolder {
+	return &Scaffolder{verbose: verbose}
+}
+
+// Scaffold the function so that it can be built via oci builder.
+// 'path' is an optional override. Assign "" (empty string) most of the time
+func (s Scaffolder) Scaffold(ctx context.Context, f fn.Function, path string) error {
+	if f.Runtime != "go" && f.Runtime != "python" {
+		if s.verbose {
+			fmt.Println("Scaffolding skipped. Currently available for runtimes go & python")
+		}
+		return nil
+	}
+
+	appRoot := path
+	if appRoot == "" {
+		appRoot = filepath.Join(f.Root, defaultPath)
+	}
+	if s.verbose {
+		fmt.Printf("Writing host scaffolding at path '%v'\n", appRoot)
+	}
+	embeddedRepo, err := fn.NewRepository("", "")
+	if err != nil {
+		return fmt.Errorf("unable to load embedded scaffolding: %w", err)
+	}
+	_ = os.RemoveAll(appRoot)
+	return scaffolding.Write(appRoot, f.Root, f.Runtime, f.Invoke, embeddedRepo.FS())
+}

--- a/pkg/pipelines/tekton/tasks.go
+++ b/pkg/pipelines/tekton/tasks.go
@@ -126,7 +126,7 @@ spec:
     - name: func-scaffold
       image: %s
       workingDir: $(workspaces.source.path)
-      command: ["scaffold", $(params.SOURCE_SUBPATH)]
+      command: ["scaffold", $(params.SOURCE_SUBPATH), "pack"]
 
     - name: prepare
       image: docker.io/library/bash:5.1
@@ -381,7 +381,7 @@ spec:
     - name: func-scaffold
       image: %s
       workingDir: $(workspaces.source.path)
-      command: ["scaffold", $(params.PATH_CONTEXT)]
+      command: ["scaffold", $(params.PATH_CONTEXT), "s2i"]
 
     - name: generate
       image: %s

--- a/pkg/pipelines/tekton/templates.go
+++ b/pkg/pipelines/tekton/templates.go
@@ -347,6 +347,11 @@ func createAndApplyPipelineRunTemplate(f fn.Function, namespace string, labels m
 		}
 	}
 
+	// add BP_GO_WORKDIR for go-build buildpack
+	if f.Runtime == "go" {
+		buildEnvs = append(buildEnvs, "BP_GO_WORKDIR=.func/build")
+	}
+
 	s2iImageScriptsUrl := defaultS2iImageScriptsUrl
 	if f.Runtime == "quarkus" {
 		s2iImageScriptsUrl = quarkusS2iImageScriptsUrl

--- a/pkg/remover/testing/integration_test_helper.go
+++ b/pkg/remover/testing/integration_test_helper.go
@@ -24,6 +24,7 @@ func TestInt_Remove(t *testing.T, remover fn.Remover, deployer fn.Deployer, desc
 	t.Cleanup(cancel)
 
 	client := fn.New(
+		fn.WithScaffolder(oci.NewScaffolder(true)),
 		fn.WithBuilder(oci.NewBuilder("", false)),
 		fn.WithPusher(oci.NewPusher(true, true, true)),
 		fn.WithDeployer(deployer),
@@ -39,6 +40,12 @@ func TestInt_Remove(t *testing.T, remover fn.Remover, deployer fn.Deployer, desc
 		Namespace: ns,
 		Registry:  Registry(),
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Scaffold
+	err = client.Scaffold(ctx, f, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/s2i/assemblers.go
+++ b/pkg/s2i/assemblers.go
@@ -41,7 +41,7 @@ func assembler(f fn.Function) (string, error) {
 // GoAssembler
 //
 // Adapted from /usr/libexec/s2i/assemble within the UBI-8 go-toolchain
-// such that the "go build" command builds subdirectory .s2i/builds/last
+// such that the "go build" command builds subdirectory .s2i/build
 // (where main resides) rather than the root.
 const GoAssembler = `
 #!/bin/bash
@@ -76,7 +76,7 @@ if [[ $(go list -f {{.Incomplete}}) == "true" ]]; then
     /$STI_SCRIPTS_PATH/usage
     exit 1
 else
-    pushd .s2i/builds/last
+    pushd .s2i/build
     go mod tidy
     go build -o /opt/app-root/gobinary
     popd
@@ -89,7 +89,7 @@ fi
 // Adapted from /usr/libexec/s2i/assemble within the UBI-8 python-toolchain
 // such that the script executes from subdirectory .s2i/builds/last
 // (where main resides) rather than the root, and indicates the main is
-// likewise in .s2i/builds/last/service/main.py via Procfile.  See the comment
+// likewise in .s2i/build/service/main.py via Procfile.  See the comment
 // inline on line 50 of the script for where the directory change instruction
 // was added.
 const PythonAssembler = `
@@ -151,12 +151,12 @@ echo "---> (Functions) Writing app.sh ..."
 cat << 'EOF' > app.sh
 #!/bin/bash
 set -e
-exec python .s2i/builds/last/service/main.py
+exec python .s2i/build/service/main.py
 EOF
 chmod +x app.sh
 
-echo "---> (Functions) Changing directory to .s2i/builds/last ..."
-cd .s2i/builds/last
+echo "---> (Functions) Changing directory to .s2i/build ..."
+cd .s2i/build
 # END MODIFICATION FOR FUNCTIONS
 # ------------------------------
 

--- a/pkg/s2i/scaffolder.go
+++ b/pkg/s2i/scaffolder.go
@@ -1,0 +1,66 @@
+package s2i
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	fn "knative.dev/func/pkg/functions"
+	"knative.dev/func/pkg/scaffolding"
+)
+
+const (
+	defaultPath = ".s2i/build"
+)
+
+// Scaffolder for S2I builder
+type Scaffolder struct {
+	verbose bool
+}
+
+func NewScaffolder(verbose bool) *Scaffolder {
+	return &Scaffolder{verbose: verbose}
+}
+
+// Scaffold the function so that it can be built via s2i builder.
+// 'path' is an optional override. Assign "" (empty string) most of the time
+func (s Scaffolder) Scaffold(ctx context.Context, f fn.Function, path string) error {
+	if f.Runtime != "go" && f.Runtime != "python" {
+		if s.verbose {
+			fmt.Println("Scaffolding skipped. Currently available for runtimes go & python")
+		}
+		return nil
+	}
+	appRoot := path
+	if appRoot == "" {
+		appRoot = filepath.Join(f.Root, defaultPath)
+	}
+	if s.verbose {
+		fmt.Printf("Writing s2i scaffolding at path '%v'\n", appRoot)
+	}
+	embeddedRepo, err := fn.NewRepository("", "")
+	if err != nil {
+		return fmt.Errorf("unable to load embedded scaffolding: %w", err)
+	}
+	_ = os.RemoveAll(appRoot)
+	if err := scaffolding.Write(appRoot, f.Root, f.Runtime, f.Invoke, embeddedRepo.FS()); err != nil {
+		return err
+	}
+
+	// Write out an S2I assembler script if the runtime needs to override the
+	// one provided in the S2I image.
+	assemble, err := assembler(f)
+	if err != nil {
+		return err
+	}
+	if assemble != "" {
+		if err := os.MkdirAll(filepath.Join(f.Root, ".s2i", "bin"), 0755); err != nil {
+			return fmt.Errorf("unable to create .s2i bin dir. %w", err)
+		}
+		if err := os.WriteFile(filepath.Join(f.Root, ".s2i", "bin", "assemble"), []byte(assemble), 0700); err != nil {
+			return fmt.Errorf("unable to write assembler script. %w", err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Scaffolding unification
- Introducing new `client.Scaffold` step in build,deploy,run commands
- Extract scaffolding logic into dedicated per-builder components (`Scaffolder` structs)
New scaffolders
```
- `pkg/buildpacks/scaffolder.go`
- `pkg/oci/scaffolder.go`
- `pkg/s2i/scaffolder.go`
```
- Change default pack builders
```diff
- var DefaultBaseBuilder = "ghcr.io/knative/builder-jammy-base:latest"
- var DefaultTinyBuilder = "ghcr.io/knative/builder-jammy-tiny:latest"
+ var DefaultBaseBuilder = "ghcr.io/knative/builder-jammy-base:v2"
+ var DefaultTinyBuilder = "ghcr.io/knative/builder-jammy-tiny:v2"
```
### HOST builder changes
- Removing the "build history" - build hashes & pid links
- Removing the concurrency building protection (It will be part of a followup PR for separation)

## scaffolding file parsing
- Replace regex-based go.mod parsing in scaffolding with `golang.org/x/mod/modfile` 
- Dynamically sync Go version from user's function to scaffolding go.mod

// issue: remove custom buildpack for go, unify scaffolding
/fixes https://github.com/knative/func/issues/3005

// issue: double go bin download for pack
/fixes https://github.com/knative/func/issues/3178

## Follow-ups
- build concurrency protection (locking)
- python buildpack fix (remove injector)
- python remote deployment fix, if still issue