### PR TITLE
docs: Add func Command Reference link to README for better discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 [Try the QuickStart](https://knative.dev/docs/getting-started/about-knative-functions/)
 [Read the Documentation](https://knative.dev/docs/functions/)
 
+## Command Reference
+
+For detailed documentation on all available `func` commands, including usage examples and options, see the [Command Reference Documentation](docs/reference/). This reference covers all commands from creating and deploying functions to managing configurations and repositories.
+
 ## Roadmap
 
 We use GitHub issues and project to track our roadmap. Please see our roadmap [here](https://github.com/orgs/knative/projects/49).


### PR DESCRIPTION
# Changes

- :book: Added a "Command Reference" section to the README that links to the `docs/reference/` directory
- Improves discoverability of CLI command documentation for new users

/kind documentation

The `docs/reference/` directory contains detailed documentation for all `func` CLI commands, but there was no mention of it in the README. This makes it difficult for beginners to discover this valuable resource. Adding a direct link in the README improves the onboarding experience and helps users quickly find command usage information.

**Release Note**

```release-note
Added Command Reference section to README for easier discovery of CLI documentation
```

**Docs**

```docs
This PR adds a link to existing in-repo documentation
```