### PR TITLE
fix(tekton): ensure PAC Repository updates labels and annotations

### DIFF
--- a/pkg/pipelines/tekton/resources_pac.go
+++ b/pkg/pipelines/tekton/resources_pac.go
@@ -78,9 +78,9 @@ func ensurePACRepositoryExists(ctx context.Context, f fn.Function, namespace str
 	}
 
 	needsUpdate := repoNotFound ||
-    !equality.Semantic.DeepDerivative(existingRepo.Spec, repo.Spec) ||
-    !equality.Semantic.DeepEqual(existingRepo.Labels, repo.Labels) ||
-    !equality.Semantic.DeepEqual(existingRepo.Annotations, repo.Annotations)
+		!equality.Semantic.DeepDerivative(existingRepo.Spec, repo.Spec) ||
+		!equality.Semantic.DeepEqual(existingRepo.Labels, repo.Labels) ||
+		!equality.Semantic.DeepEqual(existingRepo.Annotations, repo.Annotations)
 
 	if needsUpdate {
 		if repoNotFound {


### PR DESCRIPTION
Previously, ensurePACRepositoryExists only compared the Spec of the Repository CR.
This commit updates the function to also compare Labels and Annotations, ensuring
the repository resource is fully synced with the desired state.