### PR TITLE
fix: push perm check for gitlab image registry

### DIFF
--- a/pkg/creds/credentials.go
+++ b/pkg/creds/credentials.go
@@ -241,6 +241,9 @@ func NewCredentialsProvider(configPath string, opts ...Opt) oci.CredentialsProvi
 			if err != nil {
 				return oci.Credentials{}, err
 			}
+			if creds.Username == "" || creds.Password == "" {
+				return oci.Credentials{}, ErrCredentialsNotFound
+			}
 			return oci.Credentials{
 				Username: creds.Username,
 				Password: creds.Password,

--- a/pkg/k8s/keychains.go
+++ b/pkg/k8s/keychains.go
@@ -18,7 +18,7 @@ func GetGoogleCredentialLoader() []creds.CredentialsCallback {
 	return []creds.CredentialsCallback{
 		func(registry string) (oci.Credentials, error) {
 			if registry != "gcr.io" {
-				return oci.Credentials{}, nil // skip if not GCR
+				return oci.Credentials{}, creds.ErrCredentialsNotFound // skip if not GCR
 			}
 
 			res, err := name.NewRegistry(registry)
@@ -52,7 +52,7 @@ func GetACRCredentialLoader() []creds.CredentialsCallback {
 	return []creds.CredentialsCallback{
 		func(registry string) (oci.Credentials, error) {
 			if !strings.HasSuffix(registry, ".azurecr.io") {
-				return oci.Credentials{}, nil
+				return oci.Credentials{}, creds.ErrCredentialsNotFound
 			}
 
 			f, err := os.Open(path.Join(os.Getenv("HOME"), ".azure", "accessTokens.json"))
@@ -79,7 +79,7 @@ func GetACRCredentialLoader() []creds.CredentialsCallback {
 					}, nil
 				}
 			}
-			return oci.Credentials{}, nil
+			return oci.Credentials{}, creds.ErrCredentialsNotFound
 		},
 	}
 }


### PR DESCRIPTION
# Changes 

fixes #3183

- fix: push perm check for gitlab image registry
For whatever reason the gitlab integrated image registry returns 403 instead of 401 when password is empty.

/kind bug

```release-note
fix: push permission check with gitlab image registry
```
