### PR TITLE
add matrix to podman e2e test

### DIFF
--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -249,6 +249,11 @@ jobs:
     name: E2E - Podman
     needs: precheck
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - "ubuntu-latest"      # x86_64
+          - "ubuntu-24.04-arm"   # ARM64
     env:
       FUNC_CLUSTER_RETRIES: 5
       FUNC_E2E_PODMAN: true


### PR DESCRIPTION
It seems that there are more strict linters now and matrix.os didnt exist for podman test. Adding it to run for `amd` and `arm`