### PR TITLE
Create bin directory if needed before running `golangci-lint` check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ check-eof: ## Check files end with newlines
 		done | grep . && exit 1 || true
 
 $(BIN_GOLANGCI_LINT):
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v2.5.0
+	mkdir -p ./bin && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v2.5.0
 
 $(BIN_MISSPELL):
 	@echo "Installing misspell..."


### PR DESCRIPTION
`make check` is currently failing in CI (e.g. [here](https://github.com/knative/func/actions/runs/20134900638/job/57785443858)). It seems to have issues, when the `./bin` directory doesn't exists. So making it it exists...

/kind bug