### PR TITLE
Feature: Add registry login to CI workflows.

### DIFF
--- a/cmd/ci/config.go
+++ b/cmd/ci/config.go
@@ -14,17 +14,32 @@ const (
 	DefaultGitHubWorkflowDir      = ".github/workflows"
 	DefaultGitHubWorkflowFilename = "func-deploy.yaml"
 
-	WorkflowNameFlag    = "workflow-name"
-	DefaultWorkflowName = "Func Deploy"
-
 	BranchFlag    = "branch"
 	DefaultBranch = "main"
+
+	WorkflowNameFlag    = "workflow-name"
+	DefaultWorkflowName = "Func Deploy"
 
 	KubeconfigSecretNameFlag    = "kubeconfig-secret-name"
 	DefaultKubeconfigSecretName = "KUBECONFIG"
 
+	RegistryLoginUrlVariableNameFlag    = "registry-login-url-variable-name"
+	DefaultRegistryLoginUrlVariableName = "REGISTRY_LOGIN_URL"
+
+	RegistryUserVariableNameFlag    = "registry-user-variable-name"
+	DefaultRegistryUserVariableName = "REGISTRY_USERNAME"
+
+	RegistryPassSecretNameFlag    = "registry-pass-secret-name"
+	DefaultRegistryPassSecretName = "REGISTRY_PASSWORD"
+
 	RegistryUrlVariableNameFlag    = "registry-url-variable-name"
 	DefaultRegistryUrlVariableName = "REGISTRY_URL"
+
+	UseRegistryLoginFlag    = "use-registry-login"
+	DefaultUseRegistryLogin = true
+
+	UseSelfHostedRunnerFlag    = "self-hosted-runner"
+	DefaultUseSelfHostedRunner = false
 )
 
 // CIConfig readonly configuration
@@ -32,10 +47,15 @@ type CIConfig struct {
 	githubWorkflowDir,
 	githubWorkflowFilename,
 	path,
-	workflowName,
 	branch,
+	workflowName,
 	kubeconfigSecret,
+	registryLoginUrlVar,
+	registryUserVar,
+	registryPassSecret,
 	registryUrlVar string
+	useRegistryLogin,
+	useSelfHostedRunner bool
 }
 
 func NewCIGitHubConfig() CIConfig {
@@ -43,10 +63,15 @@ func NewCIGitHubConfig() CIConfig {
 		githubWorkflowDir:      DefaultGitHubWorkflowDir,
 		githubWorkflowFilename: DefaultGitHubWorkflowFilename,
 		path:                   viper.GetString(PathFlag),
-		workflowName:           viper.GetString(WorkflowNameFlag),
 		branch:                 viper.GetString(BranchFlag),
+		workflowName:           viper.GetString(WorkflowNameFlag),
 		kubeconfigSecret:       viper.GetString(KubeconfigSecretNameFlag),
+		registryLoginUrlVar:    viper.GetString(RegistryLoginUrlVariableNameFlag),
+		registryUserVar:        viper.GetString(RegistryUserVariableNameFlag),
+		registryPassSecret:     viper.GetString(RegistryPassSecretNameFlag),
 		registryUrlVar:         viper.GetString(RegistryUrlVariableNameFlag),
+		useRegistryLogin:       viper.GetBool(UseRegistryLoginFlag),
+		useSelfHostedRunner:    viper.GetBool(UseSelfHostedRunnerFlag),
 	}
 }
 
@@ -70,8 +95,28 @@ func (cc *CIConfig) Branch() string {
 	return cc.branch
 }
 
+func (cc *CIConfig) UseRegistryLogin() bool {
+	return cc.useRegistryLogin
+}
+
+func (cc *CIConfig) UseSelfHostedRunner() bool {
+	return cc.useSelfHostedRunner
+}
+
 func (cc *CIConfig) KubeconfigSecret() string {
 	return cc.kubeconfigSecret
+}
+
+func (cc *CIConfig) RegistryLoginUrlVar() string {
+	return cc.registryLoginUrlVar
+}
+
+func (cc *CIConfig) RegistryUserVar() string {
+	return cc.registryUserVar
+}
+
+func (cc *CIConfig) RegistryPassSecret() string {
+	return cc.registryPassSecret
 }
 
 func (cc *CIConfig) RegistryUrlVar() string {

--- a/cmd/config_ci.go
+++ b/cmd/config_ci.go
@@ -15,9 +15,14 @@ func NewConfigCICmd(loaderSaver common.FunctionLoaderSaver, writer ci.WorkflowWr
 		Short: "Generate a GitHub Workflow for function deployment",
 		PreRunE: bindEnv(
 			ci.PathFlag,
+			ci.UseRegistryLoginFlag,
+			ci.UseSelfHostedRunnerFlag,
 			ci.WorkflowNameFlag,
 			ci.BranchFlag,
 			ci.KubeconfigSecretNameFlag,
+			ci.RegistryLoginUrlVariableNameFlag,
+			ci.RegistryUserVariableNameFlag,
+			ci.RegistryPassSecretNameFlag,
 			ci.RegistryUrlVariableNameFlag,
 		),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
@@ -26,6 +31,18 @@ func NewConfigCICmd(loaderSaver common.FunctionLoaderSaver, writer ci.WorkflowWr
 	}
 
 	addPathFlag(cmd)
+
+	cmd.Flags().Bool(
+		ci.UseRegistryLoginFlag,
+		ci.DefaultUseRegistryLogin,
+		"Add a registry login step in the github workflow",
+	)
+
+	cmd.Flags().Bool(
+		ci.UseSelfHostedRunnerFlag,
+		ci.DefaultUseSelfHostedRunner,
+		"Use a 'self-hosted' runner instead of the default 'ubuntu-latest' for local runner execution",
+	)
 
 	cmd.Flags().String(
 		ci.WorkflowNameFlag,
@@ -43,6 +60,24 @@ func NewConfigCICmd(loaderSaver common.FunctionLoaderSaver, writer ci.WorkflowWr
 		ci.KubeconfigSecretNameFlag,
 		ci.DefaultKubeconfigSecretName,
 		"Use a custom secret name in the workflow, e.g. secret.YOUR_CUSTOM_KUBECONFIG",
+	)
+
+	cmd.Flags().String(
+		ci.RegistryLoginUrlVariableNameFlag,
+		ci.DefaultRegistryLoginUrlVariableName,
+		"Use a custom registry login url variable name in the workflow, e.g. vars.YOUR_REGISTRY_LOGIN_URL",
+	)
+
+	cmd.Flags().String(
+		ci.RegistryUserVariableNameFlag,
+		ci.DefaultRegistryUserVariableName,
+		"Use a custom registry user variable name in the workflow, e.g. vars.YOUR_REGISTRY_USER",
+	)
+
+	cmd.Flags().String(
+		ci.RegistryPassSecretNameFlag,
+		ci.DefaultRegistryPassSecretName,
+		"Use a custom registry pass secret name in the workflow, e.g. secret.YOUR_REGISTRY_PASSWORD",
 	)
 
 	cmd.Flags().String(


### PR DESCRIPTION
<!-- PR Title: feat: add configurable registry login and self-hosted runner support to GitHub workflow -->

# Changes

- :gift: Add `--use-registry-login` flag to enable/disable registry login step in generated workflow (default: true)
- :gift: Add `--self-hosted-runner` flag to use self-hosted runners instead of ubuntu-latest (default: false)
- :gift: Add `--registry-login-url-variable-name` flag to customize the registry URL variable name in the workflow (default: REGISTRY_LOGIN_URL)
- :gift: Add `--registry-user-variable-name` flag to customize the registry username variable name in the workflow (default: REGISTRY_USERNAME)
- :gift: Add `--registry-pass-secret-name` flag to customize the registry password secret name in the workflow (default: REGISTRY_PASSWORD)
- :gift: Add registry login step using `docker/login-action@v3` in generated workflows
- :broom: Refactor workflow generation into separate helper functions for better maintainability
- :broom: Update registry URL construction to use login URL + username when registry login is enabled

/kind enhancement

Relates to #3256

**Release Note**

```release-note
The `func config ci` command now supports configurable registry authentication and runner options with the following new flags:
- `--use-registry-login`: Enable/disable registry login step in generated workflow (default: true)
- `--registry-login-url-variable-name`: Customize registry URL variable name (default: REGISTRY_LOGIN_URL)
- `--registry-user-variable-name`: Customize registry username variable name (default: REGISTRY_USERNAME)
- `--registry-pass-secret-name`: Customize registry password secret name (default: REGISTRY_PASSWORD)
- `--self-hosted-runner`: Use self-hosted runners instead of ubuntu-latest (default: false)
```

**Docs**

```docs

```
