### PR TITLE
Reenable Dapr integration tests

### DIFF
--- a/pkg/functions/client_int_test.go
+++ b/pkg/functions/client_int_test.go
@@ -454,7 +454,9 @@ func Handle(res http.ResponseWriter, req *http.Request) {
 // TestInt_Invoke_ServiceToService ensures that a Function can invoke another
 // service via localhost service discovery api provided by the Dapr sidecar.
 func TestInt_Invoke_ServiceToService(t *testing.T) {
-	t.Skip("TODO: dapr appears to be borked") // https://github.com/knative/func/issues/3210
+	if os.Getenv("FUNC_INT_ENABLE_DAPR_S2S") != "true" {
+		t.Skip("Dapr S2S test disabled; set FUNC_INT_ENABLE_DAPR_S2S=true to run")
+	}
 	resetEnv()
 	var (
 		verbose = true


### PR DESCRIPTION
The `TestInt_Invoke_ServiceToService` test is temporarily disabled due to Dapr having (probably temporary) issues initializing in the test CI cluster.

It should be checked and then reenabled when working again.
