### PR TITLE
fix: Make check upgrades & .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,8 @@
-testdata/repository-a.git/objects/*/* ignore-lint=true
-testdata/repository.git/objects/*/* ignore-lint=true
+**/testdata/repository-a.git/objects/*/* ignore-lint=true
+**/testdata/repository.git/objects/*/* ignore-lint=true
 templates/node/*/package-lock.json ignore-lint=true
 templates/typescript/*/package-lock.json ignore-lint=true
-version.txt linguist-generated=true
 zz_filesystem_generated.go linguist-generated=true
-docker/zz_close_guarding_client_generated.go linguist-generated=true
+pkg/docker/zz_close_guarding_client_generated.go linguist-generated=true
 pkg/oci/testdata/test-links/* ignore-lint=true
 

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ check-whitespace: ## Check for trailing whitespace
 		grep -Ev '(vendor/|third_party/|\.git)' | \
 		grep -v '\.svg$$' | \
 		while IFS= read -r file; do [ -f "$$file" ] && echo "$$file"; done | \
-		xargs grep -nE " +$$" 2>&1 | grep -v "Binary file" && \
+		xargs grep -nE " +$$" 2>&1 | grep -vi "binary file" && \
 		(echo "Error: Trailing whitespace found"; exit 1) || true
 
 .PHONY: check-eof
@@ -125,7 +125,7 @@ check-eof: ## Check files end with newlines
 		git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$$' | cut -d: -f1 | \
 		git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$$' | cut -d: -f1 | \
 		grep -Ev '(vendor/|third_party/|\.git)' | \
-		grep -Ev '\.(ai|svg)$$' | \
+		grep -Ev '\.(ai|svg|tar|tgz|zip)$$' | \
 		while IFS= read -r file; do \
 			if [ -f "$$file" ] && [ -n "$$(tail -c 1 "$$file" 2>/dev/null)" ]; then \
 				echo "$$file: missing newline at EOF"; \


### PR DESCRIPTION
### `.gitattributes` 
- removed old `version.txt` file, fixed pathing for testdata git objects and zz file

###  `Makefile`: 
 - tailing whitespace - in `check-whitespace` - fixed binary matching (on my linux i get "binary" with a lowercase) which wasnt excluded and caused to match some binary files (tar) which caused `"Error: Trailing whitespace found"` to be printed.
 - eof warnings - `"command substitution: ignored null byte in input"` printed - caused by `tar|gzp|zip` files not excluded in `check-eof` target
  files in question: `- pkg/k8s/testdata/content.tar`, `func-util-symlinks.tgz`, `pkg/filesystem/testdata/fs.zip`