### PR TITLE
Add Claude Code slash command for func PR description generation.

### DIFF
--- a/.claude/commands/func-pull-reguest.md
+++ b/.claude/commands/func-pull-reguest.md
@@ -1,0 +1,33 @@
+---
+allowed-tools: Bash(git log:*), Bash(git diff:*)
+description: Create a pull request description for Knative func
+---
+
+# Knative Func PR Guidelines
+
+Analyze the git commits on the current branch since it diverged from the main branch and create a pull request description following the Knative func PR template below.
+
+## Steps
+
+1. Run `git log main..HEAD` to get all commits on this branch.
+2. Run `git diff main...HEAD --stat` to understand the scope of changes.
+3. Analyze the commits to determine:
+   - What changes were made => extract from commit messages.
+   - The /kind label => bug, enhancement, cleanup, documentation, etc..
+   - Any issue numbers referenced in commits (for "Fixes #").
+   - Whether changes are user-facing (for release notes).
+
+4. Format the PR description using the template in `.github/pull-request-template.md` and do the following:
+   - Add a PR title in a comment above `# Changes` like so: `<!-- PR Title: <pull-request-title> -->`.
+      - Use correct English capitalization and grammar for the PR title.
+      - Replace `<pull-request-title>` with the actual title.
+   - Update the "Changes" section with bullet points using appropriate emoji: :gift: :bug: :broom: :wastebasket:.
+   - Add a /kind label
+   - Add "Fixes #" if issue is referenced or "Relates to #" if issue is not supposed to be closed by this PR.
+   - Fill in the "Release Note" if the changes are user-facing otherwise leave it empty.
+   - Leave docs section as is.
+   - Remove the comments from the final PR description except the comment with the PR title: `<!-- PR Title: ...`.
+
+5. Write the PR description in a file in `./.claude/pr/<pull-request-name>.md` for review and:
+   - Create the directory if it does not exist.
+   - Replace `<pull-request-name>` in the filename with a short, descriptive pull request name.

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,73 @@
+<!-- Thanks for sending a pull request! -->
+
+<!--
+Are you using Knative? If you do, we would love to know!
+https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
+-->
+
+# Changes
+
+<!--
+Describe your changes here- ideally you can get that description straight from
+your descriptive commit message(s)!
+
+- :gift: Add new feature
+- :bug: Fix bug
+- :broom: Update or clean up current behavior
+- :wastebasket: Remove feature or internal logic
+-->
+
+-
+-
+-
+
+<!--
+In addition, categorize the changes you're making using the "/kind" Prow command, example:
+
+/kind <kind>
+
+Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance
+
+-->
+/kind <kind>
+
+<!--
+*Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or Relates to #<issue number>.
+_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
+-->
+Fixes #
+
+<!-- Please include the 'why' behind your changes if no issue exists -->
+
+**Release Note**
+
+<!--
+:page_facing_up: If this change has user-visible impact, write a release note in the block
+below. Include the string "action required" if additional action is required of
+users switching to the new release, for example in case of a breaking change.
+
+Write as if you are speaking to users, not other Knative contributors. If this
+change has no user-visible impact, no release-note is needed.
+-->
+```release-note
+
+```
+
+**Docs**
+
+<!--
+:book: If this change has user-visible impact, link to an issue or PR in
+https://github.com/knative/docs.
+
+See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files
+
+Please use the following format for linking documentation:
+- [knative/docs]: <issue or pr link>
+- [Feature Track]: <link>
+- [Usage]: <link>
+- [Other doc]: <link>
+-->
+```docs
+
+```

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ __pycache__
 # AI
 AGENTS.override.md
 .claude/*.local.*
+.claude/pr/*
 
 # E2E Tests
 /e2e/testdata/default_home/go
@@ -49,3 +50,4 @@ AGENTS.override.md
 # TODO: Update this test to be from a temp directory with a hard-coded impl:
 # https://github.com/knative/func/issues/3196
 /pkg/builders/testdata/go-fn-with-private-deps/.s2i
+


### PR DESCRIPTION
<!-- PR Title: Add Claude Code slash command for func PR description generation -->

# Changes

- :gift: Add new Claude Code slash command `/func-pull-reguest` for automated PR description generation
- :broom: Move CLAUDE.md to .claude/CLAUDE.md to align with Claude Code conventions

The new command analyzes commits since main branch divergence and formats them according to the Knative func PR template, including change categorization, issue linking, and release notes.

/kind enhancement

This enhancement streamlines the PR creation process for contributors by automating the formatting of PR descriptions according to project conventions.

**Release Note**

```release-note

```

**Docs**

```docs

```
