### PR TITLE
Add Claude code slash command for standardized commit messages.

### DIFF
--- a/.claude/commands/func-commit-message.md
+++ b/.claude/commands/func-commit-message.md
@@ -44,7 +44,7 @@ Create a git commit message following these rules:
 - Explain the "what" and "why" vs. "how" which means:
   - the way things worked before the change (and what was wrong with that),
   - the way they work now,
-  - and why the contributor decided to solve it the way she did,
+  - and why the contributor decided to solve it the way they did,
   - and if you're not sure about the "why" then ask the contributor.
 - Focus on context, not implementation details
 - Find a balance for message length, i.e. analyze the diff and decide if a shorter message is enough or more explanation is needed


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- PR Title: Add slash command for standardized commit messages -->

# Changes

- :gift: Add `/func-commit-message` slash command that guides creation of standardized commit messages following the seven rules of Chris Beams in his "[How to Write a Git Commit Message](https://cbea.ms/git-commit/)" article and conventional commits specification.

/kind enhancement

<!-- This adds developer tooling to help contributors write better commit messages -->

**Release Note**

```release-note

```

**Docs**

```docs

```