### PR TITLE
Fix link to CONTRIBUTING Guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We use GitHub issues and project to track our roadmap. Please see our roadmap [h
 
 ## Contributing
 
-We are always looking for contributions from the Function Developer community.  For more information on how to participate, see the [Contribuiting Guide](docs/CONTRIBUTING.md).
+We are always looking for contributions from the Function Developer community.  For more information on how to participate, see the [Contribuiting Guide](/CONTRIBUTING.md).
 For a list of all help wanted issues in Knative, take a look at [CLOTRIBUTOR](https://clotributor.dev/search?project=knative&page=1).
 
 The `func` Working Group meets @ 10:00 US Eastern every Tuesday, we'd love to have you! For more information, see the invitation on the [Knative Team Calendar](https://calendar.google.com/calendar/u/0/embed?src=knative.team_9q83bg07qs5b9rrslp5jor4l6s@group.calendar.google.com).


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Changed the contribution link in the readme which fixed the broken link


/documentation <documentation>


Fixes #3325 


