### PR TITLE
Add typed ErrInvalidRegistry error for registry validation

### DIFF
--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -990,9 +990,12 @@ func testInvalidRegistry(cmdFn commandConstructor, t *testing.T) {
 
 	cmd.SetArgs([]string{"--registry=foo/bar/invald/myfunc"})
 
-	if err := cmd.Execute(); err == nil {
-		// TODO: typed ErrInvalidRegistry
-		t.Fatal("invalid registry did not generate expected error")
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("expected ErrInvalidRegistry, got nil")
+	}
+	if !errors.Is(err, fn.ErrInvalidRegistry) {
+		t.Fatalf("expected ErrInvalidRegistry, got: %v", err)
 	}
 }
 

--- a/pkg/functions/errors.go
+++ b/pkg/functions/errors.go
@@ -48,6 +48,9 @@ var (
 	// ErrInvalidNamespace is returned when a namespace name doesn't meet Kubernetes naming requirements
 	ErrInvalidNamespace = errors.New("invalid namespace")
 
+	// ErrInvalidRegistry is returned when a registry format is invalid
+	ErrInvalidRegistry = errors.New("invalid registry")
+
 	// ErrNotHandled is returned when a handler (describer, remover, ...) was not responsible for the function
 	ErrNotHandled = errors.New("describer does not handle this function")
 )

--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -657,7 +657,7 @@ func (f Function) ImageName() (image string, err error) {
 
 	ref, err := name.ParseReference(refStr)
 	if err != nil {
-		return "", fmt.Errorf("cannot determine function image: %w", err)
+		return "", fmt.Errorf("%w: cannot determine function image: %v", ErrInvalidRegistry, err)
 	}
 
 	return ref.Name(), nil


### PR DESCRIPTION

FIxes #3339 
Add `ErrInvalidRegistry` typed error and use `errors.Is()` check in [testInvalidRegistry](cci:1://file:///home/kunal/Desktop/func/cmd/deploy_test.go:974:0-996:1).