### PR TITLE
add extension arg for func invoke

### DIFF
--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -166,22 +166,23 @@ func runInvoke(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 		return fmt.Errorf("no function found in current directory.\nYou need to be inside a function directory to invoke it.\n\nTry this:\n  func create --language go myfunction    Create a new function\n  cd myfunction                          Go into the function directory\n  func invoke                            Now you can invoke it\n\nOr if you have an existing function:\n  cd path/to/your/function              Go to your function directory\n  func invoke                           Invoke the function")
 	}
 
+	// If extensions were provided, ensure the format is cloudevent, otherwise return an error.
+	if len(cfg.Extensions) > 0 {
+		effectiveFormat := cfg.Format
+		if effectiveFormat == "" {
+			effectiveFormat = f.Invoke
+		}
+		if effectiveFormat != "cloudevent" {
+			return fmt.Errorf("--extension (-e) is only valid with cloudevents")
+		}
+		if effectiveFormat != "" && effectiveFormat != "cloudevent" {
+			return fmt.Errorf("--extension flag is only valid with cloudevent format")
+		}
+	}
+
 	// Client instance from env vars, flags, args and user prompts (if --confirm)
 	client, done := newClient(ClientConfig{Verbose: cfg.Verbose, InsecureSkipVerify: cfg.Insecure})
 	defer done()
-
-	// Build extensions map
-	if cfg.Extensions == nil {
-		cfg.Extensions = []string{}
-	}
-	extensionsMap := make(map[string]string)
-	for _, ext := range cfg.Extensions {
-		parts := strings.SplitN(ext, "=", 2)
-		if len(parts) != 2 {
-			return fmt.Errorf("invalid extension format: %q, expected key=value", ext)
-		}
-		extensionsMap[parts[0]] = parts[1]
-	}
 
 	// Message to send the running function built from parameters gathered
 	// from the user (or defaults)
@@ -193,7 +194,7 @@ func runInvoke(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 		RequestType: strings.ToUpper(cfg.RequestType),
 		Data:        cfg.Data,
 		Format:      cfg.Format,
-		Extensions:  extensionsMap,
+		Extensions:  cfg.extensionsMap(),
 	}
 
 	// If --file was specified, use its content for message data
@@ -312,6 +313,17 @@ func newInvokeConfig() (cfg invokeConfig, err error) {
 	fmt.Printf("Insecure: %v\n", cfg.Insecure)
 	fmt.Printf("Extensions: %v\n", cfg.Extensions)
 	return
+}
+
+func (c invokeConfig) extensionsMap() map[string]string {
+	extensionsMap := make(map[string]string)
+	for _, ext := range c.Extensions {
+		parts := strings.SplitN(ext, "=", 2)
+		if len(parts) == 2 {
+			extensionsMap[parts[0]] = parts[1]
+		}
+	}
+	return extensionsMap
 }
 
 func (c invokeConfig) prompt() (invokeConfig, error) {

--- a/docs/reference/func_invoke.md
+++ b/docs/reference/func_invoke.md
@@ -99,6 +99,7 @@ func invoke
   -c, --confirm               Prompt to confirm options interactively ($FUNC_CONFIRM)
       --content-type string   Content Type of the data. ($FUNC_CONTENT_TYPE) (default "application/json")
       --data string           Data to send in the request. ($FUNC_DATA) (default "{\"message\":\"Hello World\"}")
+  -e, --extension strings     Extensions as key=value pairs. Can be repeated. cloudevents only ($FUNC_EXTENSION)
       --file string           Path to a file to use as data. Overrides --data flag and should be sent with a correct --content-type. ($FUNC_FILE)
   -f, --format string         Format of message to send, 'http' or 'cloudevent(s)'.  Default is to choose automatically. ($FUNC_FORMAT)
   -h, --help                  help for invoke

--- a/pkg/functions/invoke.go
+++ b/pkg/functions/invoke.go
@@ -35,6 +35,7 @@ type InvokeMessage struct {
 	Data        []byte
 	RequestType string // HTTP Request GET/POST (defaults to POST)
 	Format      string // optional override for function-defined message format
+	Extensions  map[string]string
 }
 
 // NewInvokeMessage creates a new InvokeMessage with fields populated
@@ -168,6 +169,9 @@ func sendEvent(ctx context.Context, route string, m InvokeMessage, t http.RoundT
 	event.SetID(m.ID)
 	event.SetSource(m.Source)
 	event.SetType(m.Type)
+	for extension := range m.Extensions {
+		event.SetExtension(extension, m.Extensions[extension])
+	}
 	err = event.SetData(m.ContentType, (m.Data))
 	if err != nil {
 		return "", fmt.Errorf("cannot set data: %w", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!--
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Introduces a new --extension/-e flag to the invoke command, allowing users to specify CloudEvents extensions as key=value pairs. The extensions are parsed and included in the InvokeMessage, and are set on the outgoing CloudEvent
<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or Relates to #<issue number>.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3346

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Add a new --extension/-e flag to the `func invoke` command, allowing users to specify CloudEvents extensions as key=value pairs. The extensions are parsed and included in the InvokeMessage, and are set on the outgoing CloudEvent
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
