### PR TITLE
test: expose eventing broker for testing

### DIFF
--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -287,6 +287,28 @@ eventing() {
   sleep 5
   $KUBECTL wait pod --for=condition=Ready -l '!job-name' -n knative-eventing --timeout=5m
 
+  echo "Exposing broker at broker.localtest.me"
+  $KUBECTL apply -f - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: broker-ingress
+  namespace: knative-eventing
+spec:
+  ingressClassName: contour-external
+  rules:
+    - host: broker.localtest.me
+      http:
+        paths:
+          - backend:
+              service:
+                name: broker-ingress
+                port:
+                  number: 80
+            pathType: Prefix
+            path: /
+EOF
+
   echo "${green}✅ Eventing${reset}"
 }
 


### PR DESCRIPTION
# Changes

-  Expose eventing broker for testing as `http://broker.localtest.me/`.
This allows tests to easily send event to broker by doing HTTP POST to `http://broker.localtest.me/<ns>/<broker>`.
Note that if we want to use this the test should **not** hardcode `http://broker.localtest.me` but rather use some test envvar (e.g. `FUNC_E2E_BROKER_EXTERNAL_URL`).
Also we should consider not exposing this (not merging this PR) and rather just using our [custom tunneling transport](https://github.com/knative/func/blob/504b40b/pkg/http/transport.go#L53-L57) to call the broker as internal service.