### PR TITLE
Use bundles resolver instead of http for git-clone

### DIFF
--- a/pkg/pipelines/tekton/tasks.go
+++ b/pkg/pipelines/tekton/tasks.go
@@ -109,8 +109,6 @@ spec:
             value: ghcr.io/tektoncd/catalog/upstream/stepactions/git-clone:09f70e6a6485a7d99b01d75610870b13222732e8
           - name: kind
             value: StepAction
-          - name: version
-            value: 0.2
           - name: name
             value: git-clone
       when:
@@ -366,8 +364,6 @@ spec:
             value: ghcr.io/tektoncd/catalog/upstream/stepactions/git-clone:09f70e6a6485a7d99b01d75610870b13222732e8
           - name: kind
             value: StepAction
-          - name: version
-            value: 0.2
           - name: name
             value: git-clone
       when:


### PR DESCRIPTION
# Changes

- Use bundles resolver instead of http for git-clone

