### PR TITLE
test: fewer domain levels for knative services domain

### DIFF
--- a/e2e/e2e_core_test.go
+++ b/e2e/e2e_core_test.go
@@ -100,7 +100,7 @@ func TestCore_Deploy_Basic(t *testing.T) {
 		clean(t, name, Namespace)
 	}()
 
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain)) {
+	if !waitFor(t, ksvcUrl(name)) {
 		t.Fatal("function did not deploy correctly")
 	}
 }
@@ -129,7 +129,7 @@ func TestCore_Deploy_Template(t *testing.T) {
 
 	// The default implementation responds with HTTP 200 and the string
 	// "testcore-deploy-template" for all requests.
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain),
+	if !waitFor(t, ksvcUrl(name),
 		withContentMatch(name)) {
 		t.Fatal("function did not update correctly")
 	}
@@ -178,7 +178,7 @@ func TestCore_Update(t *testing.T) {
 	defer func() {
 		clean(t, name, Namespace)
 	}()
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain)) {
+	if !waitFor(t, ksvcUrl(name)) {
 		t.Fatal("function did not deploy correctly")
 	}
 
@@ -198,7 +198,7 @@ func TestCore_Update(t *testing.T) {
 	if err := newCmd(t, "deploy").Run(); err != nil {
 		t.Fatal(err)
 	}
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain),
+	if !waitFor(t, ksvcUrl(name),
 		withContentMatch("UPDATED")) {
 		t.Fatal("function did not update correctly")
 	}
@@ -228,7 +228,7 @@ func TestCore_Describe(t *testing.T) {
 		t.Fatalf("deploy error. %v", err)
 	}
 
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain)) {
+	if !waitFor(t, ksvcUrl(name)) {
 		t.Fatal("function did not deploy correctly")
 	}
 
@@ -308,7 +308,7 @@ func TestCore_Invoke(t *testing.T) {
 	defer func() {
 		clean(t, name, Namespace)
 	}()
-	if !waitFor(t, fmt.Sprintf("http://%s.%s.%s", name, Namespace, Domain)) {
+	if !waitFor(t, ksvcUrl(name)) {
 		t.Fatal("function did not deploy correctly")
 	}
 
@@ -334,7 +334,7 @@ func TestCore_Delete(t *testing.T) {
 	defer func() {
 		clean(t, name, Namespace)
 	}()
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain)) {
+	if !waitFor(t, ksvcUrl(name)) {
 		t.Fatal("function did not deploy correctly")
 	}
 

--- a/e2e/e2e_matrix_test.go
+++ b/e2e/e2e_matrix_test.go
@@ -106,7 +106,7 @@ func TestMatrix_Deploy(t *testing.T) {
 		}
 
 		// Ensure the Function comes up
-		if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain),
+		if !waitFor(t, ksvcUrl(name),
 			withWaitTimeout(timeout),
 			withTemplate(template)) {
 			t.Fatal("function did not deploy correctly")
@@ -142,7 +142,7 @@ func TestMatrix_Remote(t *testing.T) {
 		}
 
 		// Ensure the Function comes up
-		if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain),
+		if !waitFor(t, ksvcUrl(name),
 			withWaitTimeout(timeout),
 			withTemplate(template)) {
 			t.Fatal("function did not deploy correctly")

--- a/e2e/e2e_metadata_test.go
+++ b/e2e/e2e_metadata_test.go
@@ -137,7 +137,7 @@ func TestMetadata_Envs_Add(t *testing.T) {
 	defer func() {
 		clean(t, name, Namespace)
 	}()
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain),
+	if !waitFor(t, ksvcUrl(name),
 		withContentMatch("OK")) {
 		t.Fatal("handler failed")
 	}
@@ -194,7 +194,7 @@ func TestMetadata_Envs_Remove(t *testing.T) {
 	defer func() {
 		clean(t, name, Namespace)
 	}()
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain),
+	if !waitFor(t, ksvcUrl(name),
 		withContentMatch("OK")) {
 		t.Fatal("handler failed")
 	}
@@ -230,7 +230,7 @@ func TestMetadata_Envs_Remove(t *testing.T) {
 	if err := newCmd(t, "deploy").Run(); err != nil {
 		t.Fatal(err)
 	}
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain),
+	if !waitFor(t, ksvcUrl(name),
 		withContentMatch("OK")) {
 		t.Fatal("handler failed")
 	}
@@ -268,7 +268,7 @@ func TestMetadata_Labels_Add(t *testing.T) {
 	defer func() {
 		clean(t, name, Namespace)
 	}()
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain)) {
+	if !waitFor(t, ksvcUrl(name)) {
 		t.Fatal("function did not deploy correctly")
 	}
 
@@ -318,7 +318,7 @@ func TestMetadata_Labels_Remove(t *testing.T) {
 	defer func() {
 		clean(t, name, Namespace)
 	}()
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain)) {
+	if !waitFor(t, ksvcUrl(name)) {
 		t.Fatal("function did not deploy correctly")
 	}
 
@@ -350,7 +350,7 @@ func TestMetadata_Labels_Remove(t *testing.T) {
 	if err := newCmd(t, "deploy").Run(); err != nil {
 		t.Fatal(err)
 	}
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain)) {
+	if !waitFor(t, ksvcUrl(name)) {
 		t.Fatal("function did not redeploy correctly")
 	}
 
@@ -494,7 +494,7 @@ func Handle(w http.ResponseWriter, _ *http.Request) {
 	}()
 
 	// Verify the function has access to all volumes
-	if !waitFor(t, fmt.Sprintf("http://%s.%s.%s", name, Namespace, Domain),
+	if !waitFor(t, ksvcUrl(name),
 		withContentMatch("OK")) {
 		t.Fatal("function failed to access volumes correctly")
 	}
@@ -555,7 +555,7 @@ func Handle(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal(err)
 	}
 
-	if !waitFor(t, fmt.Sprintf("http://%s.%s.%s", name, Namespace, Domain),
+	if !waitFor(t, ksvcUrl(name),
 		withContentMatch("OK")) {
 		t.Fatal("function failed after volume removal")
 	}
@@ -601,7 +601,7 @@ func TestMetadata_Subscriptions(t *testing.T) {
 	}
 	defer clean(t, subscriberName, Namespace)
 
-	subscriberURL := fmt.Sprintf("http://%s.%s.%s", subscriberName, Namespace, Domain)
+	subscriberURL := ksvcUrl(subscriberName)
 	if !waitFor(t, subscriberURL, withTemplate("cloudevents")) {
 		t.Fatal("subscriber not ready")
 	}

--- a/e2e/e2e_podman_test.go
+++ b/e2e/e2e_podman_test.go
@@ -4,7 +4,6 @@
 package e2e
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -32,7 +31,7 @@ func TestPodman_Pack(t *testing.T) {
 		clean(t, name, Namespace)
 	}()
 
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain)) {
+	if !waitFor(t, ksvcUrl(name)) {
 		t.Fatal("function did not deploy correctly")
 	}
 }
@@ -61,7 +60,7 @@ func TestPodman_S2I(t *testing.T) {
 		clean(t, name, Namespace)
 	}()
 
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain)) {
+	if !waitFor(t, ksvcUrl(name)) {
 		t.Fatal("function did not deploy correctly")
 	}
 }

--- a/e2e/e2e_remote_test.go
+++ b/e2e/e2e_remote_test.go
@@ -35,7 +35,7 @@ func TestRemote_Deploy(t *testing.T) {
 		clean(t, name, Namespace)
 	}()
 
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain)) {
+	if !waitFor(t, ksvcUrl(name)) {
 		t.Fatal("function did not deploy correctly")
 	}
 }
@@ -67,7 +67,7 @@ func TestRemote_Source(t *testing.T) {
 		clean(t, name, Namespace)
 	}()
 
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain),
+	if !waitFor(t, ksvcUrl(name),
 		withContentMatch(name)) {
 		t.Fatal("function did not deploy correctly")
 	}
@@ -112,7 +112,7 @@ func TestRemote_Ref(t *testing.T) {
 		clean(t, name, Namespace)
 	}()
 
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain),
+	if !waitFor(t, ksvcUrl(name),
 		withContentMatch(name)) {
 		t.Fatal("function did not deploy correctly")
 	}
@@ -159,7 +159,7 @@ func TestRemote_Dir(t *testing.T) {
 		clean(t, name, Namespace)
 	}()
 
-	if !waitFor(t, fmt.Sprintf("http://%v.%s.%s", name, Namespace, Domain),
+	if !waitFor(t, ksvcUrl(name),
 		withContentMatch(name)) {
 		t.Fatal("function did not deploy correctly")
 	}

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -255,6 +255,9 @@ networking() {
     --type merge \
     --patch '{"data":{"ingress-class":"contour.ingress.networking.knative.dev"}}'
 
+  echo "Patch domain-template"
+  $KUBECTL patch -n knative-serving cm/config-network --patch '{"data":{"domain-template":"{{.Name}}-{{.Namespace}}-ksvc.{{.Domain}}"}}'
+
   echo "Patching contour to prefer duals-tack"
   kubectl patch -n contour-external svc/envoy --type merge --patch '{"spec":{"ipFamilyPolicy":"PreferDualStack"}}'
 


### PR DESCRIPTION
# Changes

- Fewer domain levels for knative services url. Now test ksvc will be direct sub-domain of the cluster domain. This is useful when using wild-card certificate (one can have a cert like `*.localtest.me` but not like `*.*.localtest.me`).
- Refactor: move logic for determining ksvc url into a function instead or having code littered with `fmt.Sprintf(…)`.