### PR TITLE
Feature: Default branch and path flags intelligently.

### DIFF
--- a/cmd/ci/workflow_test.go
+++ b/cmd/ci/workflow_test.go
@@ -6,11 +6,16 @@ import (
 
 	"gotest.tools/v3/assert"
 	"knative.dev/func/cmd/ci"
+	"knative.dev/func/cmd/common"
 )
 
 func TestGitHubWorkflow_Export(t *testing.T) {
 	// GIVEN
-	gw := ci.NewGitHubWorkflow(ci.NewCIGitHubConfig())
+	cfg, _ := ci.NewCIGitHubConfig(
+		common.CurrentBranchStub("", nil),
+		common.WorkDirStub("", nil),
+	)
+	gw := ci.NewGitHubWorkflow(cfg)
 	bufferWriter := ci.NewBufferWriter()
 
 	// WHEN

--- a/cmd/ci/writer.go
+++ b/cmd/ci/writer.go
@@ -14,17 +14,17 @@ const (
 var DefaultWorkflowWriter = &fileWriter{}
 
 type WorkflowWriter interface {
-	Write(path string, p []byte) error
+	Write(path string, raw []byte) error
 }
 
 type fileWriter struct{}
 
-func (fw *fileWriter) Write(path string, p []byte) error {
+func (fw *fileWriter) Write(path string, raw []byte) error {
 	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
 		return err
 	}
 
-	if err := os.WriteFile(path, p, filePerm); err != nil {
+	if err := os.WriteFile(path, raw, filePerm); err != nil {
 		return err
 	}
 
@@ -32,6 +32,7 @@ func (fw *fileWriter) Write(path string, p []byte) error {
 }
 
 type bufferWriter struct {
+	Path   string
 	Buffer *bytes.Buffer
 }
 
@@ -39,7 +40,8 @@ func NewBufferWriter() *bufferWriter {
 	return &bufferWriter{Buffer: &bytes.Buffer{}}
 }
 
-func (bw *bufferWriter) Write(_ string, p []byte) error {
-	_, err := bw.Buffer.Write(p)
+func (bw *bufferWriter) Write(path string, raw []byte) error {
+	bw.Path = path
+	_, err := bw.Buffer.Write(raw)
 	return err
 }

--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -1,7 +1,11 @@
 package common
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"strings"
 
 	fn "knative.dev/func/pkg/functions"
 )
@@ -74,4 +78,89 @@ func (m MockLoaderSaver) Load(path string) (fn.Function, error) {
 // Save invokes the configured SaveFn to persist the given function.
 func (m MockLoaderSaver) Save(f fn.Function) error {
 	return m.SaveFn(f)
+}
+
+// CurrentBranchFunc is a function type that retrieves the current git branch for a given path.
+type CurrentBranchFunc func(path string) (string, error)
+
+// DefaultCurrentBranch is the default implementation for getting the current git branch.
+var DefaultCurrentBranch CurrentBranchFunc = NewGitCliWrapper().CurrentBranch
+
+type gitCliWrapper struct {
+	gitCmd string
+}
+
+// NewGitCliWrapper creates a new git CLI wrapper using FUNC_GIT env var or "git" as default.
+func NewGitCliWrapper() *gitCliWrapper {
+	gitCmd := os.Getenv("FUNC_GIT")
+	if gitCmd == "" {
+		gitCmd = "git"
+	}
+
+	return &gitCliWrapper{gitCmd}
+}
+
+// CurrentBranch returns the current git branch name for the repository at the given path.
+func (g *gitCliWrapper) CurrentBranch(path string) (string, error) {
+	if _, err := os.Stat(path); err != nil {
+		return "", err
+	}
+
+	branch, err := g.execGitCmdWith("-C", path, "symbolic-ref", "--short", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("could not detect git branch for '%s'. "+
+			"Has git been initialized for this Function? %w", path, err)
+	}
+
+	return branch, nil
+}
+
+// Init initializes a new git repository at the given path with the specified branch.
+func (g *gitCliWrapper) Init(path, branch string) (string, error) {
+	if _, err := os.Stat(path); err != nil {
+		return "", err
+	}
+
+	if branch == "" {
+		return "", fmt.Errorf("branch cannot be empty")
+	}
+
+	return g.execGitCmdWith("init", "-b", branch, path)
+}
+
+func (g *gitCliWrapper) execGitCmdWith(args ...string) (string, error) {
+	result, err := exec.Command(g.gitCmd, args...).Output()
+	if err == nil {
+		return strings.TrimSpace(string(result)), nil
+	}
+
+	var exitErr *exec.ExitError
+	argsJoined := strings.Join(args, " ")
+	if errors.As(err, &exitErr) {
+		return "", fmt.Errorf("git %s failed: %w\nstderr: %s", argsJoined, err, string(exitErr.Stderr))
+	}
+
+	return "", fmt.Errorf("git %s failed: %w", argsJoined, err)
+}
+
+// CurrentBranchStub creates a stub CurrentBranchFunc that returns the provided output or error.
+var CurrentBranchStub = func(output string, err error) CurrentBranchFunc {
+	return func(_ string) (string, error) {
+		if err != nil {
+			return "", err
+		}
+
+		return output, nil
+	}
+}
+
+// WorkDirFunc is a function type that retrieves the current working directory.
+type WorkDirFunc func() (string, error)
+
+// DefaultWorkDir is the default implementation for getting the current working directory.
+var DefaultWorkDir WorkDirFunc = os.Getwd
+
+// WorkDirStub creates a stub WorkDirFunc that returns the provided directory or error.
+var WorkDirStub = func(dir string, err error) WorkDirFunc {
+	return func() (string, error) { return dir, err }
 }

--- a/cmd/common/common_test.go
+++ b/cmd/common/common_test.go
@@ -1,6 +1,9 @@
 package common_test
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -10,8 +13,10 @@ import (
 	fnTest "knative.dev/func/pkg/testing"
 )
 
+const mainBranch = "main"
+
 func TestDefaultLoaderSaver_SuccessfulLoad(t *testing.T) {
-	existingFunc := cmdTest.CreateFuncInTempDir(t, "ls-func")
+	existingFunc := cmdTest.CreateFuncWithGitInTempDir(t, "ls-func")
 
 	actualFunc, err := common.DefaultLoaderSaver.Load(existingFunc.Root)
 
@@ -34,7 +39,7 @@ func TestDefaultLoaderSaver_IsNotInitializedError_WhenNoFuncAtPath(t *testing.T)
 }
 
 func TestDefaultLoaderSaver_SuccessfulSave(t *testing.T) {
-	existingFunc := cmdTest.CreateFuncInTempDir(t, "")
+	existingFunc := cmdTest.CreateFuncWithGitInTempDir(t, "")
 	name := "environment"
 	value := "test"
 	existingFunc.Run.Envs.Add(name, value)
@@ -51,4 +56,65 @@ func TestDefaultLoaderSaver_ForwardsSaveError(t *testing.T) {
 	err := common.DefaultLoaderSaver.Save(fn.Function{})
 
 	assert.Error(t, err, "function root path is required")
+}
+
+func TestGitCliWrapper_Init_InitializesRepo(t *testing.T) {
+	tempDir := fnTest.FromTempDirectory(t)
+
+	_, err := common.NewGitCliWrapper().Init(tempDir, mainBranch)
+	_, statErr := os.Stat(filepath.Join(tempDir, ".git"))
+
+	assert.NilError(t, err)
+	assert.NilError(t, statErr)
+}
+
+func TestGitCliWrapper_Init_ErrorForNonExistentPath(t *testing.T) {
+	_, err := common.NewGitCliWrapper().Init("/non-existing-path", mainBranch)
+
+	assert.Assert(t, os.IsNotExist(err))
+}
+
+func TestGitCliWrapper_Init_ErrorForEmptyBranch(t *testing.T) {
+	_, err := common.NewGitCliWrapper().Init(t.TempDir(), "")
+
+	assert.Error(t, err, "branch cannot be empty")
+}
+
+func TestGitCliWrapper_CurrentBranch_ReturnsBranchName(t *testing.T) {
+	tempDir := fnTest.FromTempDirectory(t)
+	_, initErr := common.NewGitCliWrapper().Init(tempDir, mainBranch)
+
+	actualBranch, err := common.NewGitCliWrapper().CurrentBranch(tempDir)
+
+	assert.NilError(t, initErr)
+	assert.NilError(t, err)
+	assert.Assert(t, actualBranch == mainBranch)
+}
+
+func TestGitCliWrapper_CurrentBranch_ErrorForNonExistentPath(t *testing.T) {
+	_, err := common.NewGitCliWrapper().CurrentBranch("/non-existing-path")
+
+	assert.Assert(t, os.IsNotExist(err))
+}
+
+func TestGitCliWrapper_CurrentBranch_ErrorForNonGitDirectory(t *testing.T) {
+	tempDir := fnTest.FromTempDirectory(t)
+	expectedErrMsg := fmt.Errorf("could not detect git branch for '%s'. "+
+		"Has git been initialized for this Function?", tempDir)
+
+	_, err := common.NewGitCliWrapper().CurrentBranch(tempDir)
+
+	assert.ErrorContains(t, err, expectedErrMsg.Error())
+	assert.ErrorContains(t, err, "failed")
+	assert.ErrorContains(t, err, "stderr")
+}
+
+func TestGitCliWrapper_CurrentBranch_ErrorWhenCommandNotFound(t *testing.T) {
+	tempDir := fnTest.FromTempDirectory(t)
+	t.Setenv("FUNC_GIT", "nonexistent-git-command")
+
+	_, err := common.NewGitCliWrapper().CurrentBranch(tempDir)
+
+	assert.ErrorContains(t, err, "failed")
+	assert.ErrorContains(t, err, "nonexistent-git-command")
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -14,7 +14,13 @@ import (
 	fn "knative.dev/func/pkg/functions"
 )
 
-func NewConfigCmd(loaderSaver common.FunctionLoaderSaver, writer ci.WorkflowWriter, newClient ClientFactory) *cobra.Command {
+func NewConfigCmd(
+	loaderSaver common.FunctionLoaderSaver,
+	writer ci.WorkflowWriter,
+	currentBranch common.CurrentBranchFunc,
+	workingDir common.WorkDirFunc,
+	newClient ClientFactory,
+) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Configure a function",
@@ -42,7 +48,7 @@ or from the directory specified with --path.
 	cmd.AddCommand(NewConfigVolumesCmd())
 
 	if os.Getenv(ci.ConfigCIFeatureFlag) == "true" {
-		cmd.AddCommand(NewConfigCICmd(loaderSaver, writer))
+		cmd.AddCommand(NewConfigCICmd(loaderSaver, writer, currentBranch, workingDir))
 	}
 
 	return cmd

--- a/cmd/config_ci_int_test.go
+++ b/cmd/config_ci_int_test.go
@@ -1,0 +1,152 @@
+package cmd_test
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ory/viper"
+	"gotest.tools/v3/assert"
+	fnCmd "knative.dev/func/cmd"
+	"knative.dev/func/cmd/ci"
+	"knative.dev/func/cmd/common"
+	cmdTest "knative.dev/func/cmd/testing"
+	fn "knative.dev/func/pkg/functions"
+	fnTest "knative.dev/func/pkg/testing"
+)
+
+// START: Integration Tests
+// ------------------------
+// No more mocking. Using real filesystem here for LoaderSaver and WorkflowWriter.
+func TestNewConfigCICmd_FailsWhenNotInitialized(t *testing.T) {
+	// passing empty func &fn.Function{} means no func will be initialized
+	// in temp dir
+	opts := defaultIntegrationOpts(t, &fn.Function{})
+	_, gitInitErr := common.NewGitCliWrapper().Init(fnTest.FromTempDirectory(t), mainBranch)
+	expectedErr := fn.NewErrNotInitialized(fnTest.Cwd())
+
+	err := runConfigCiCmdIntegration(t, opts)
+
+	assert.NilError(t, gitInitErr)
+	assert.Error(t, err, expectedErr.Error())
+}
+
+func TestNewConfigCICmd_SuccessWhenInitialized(t *testing.T) {
+	opts := defaultIntegrationOpts(t, nil)
+
+	err := runConfigCiCmdIntegration(t, opts)
+
+	assert.NilError(t, err)
+}
+
+func TestNewConfigCICmd_FailsToLoadFuncWithWrongPath(t *testing.T) {
+	opts := defaultIntegrationOpts(t, nil)
+	opts.args = append(opts.args, "--path=nofunc")
+	var expectedErr *os.PathError
+
+	err := runConfigCiCmdIntegration(t, opts)
+
+	// Use os.IsNotExist for cross-platform compatibility (Linux vs Windows error messages differ)
+	assert.Assert(t, errors.As(err, &expectedErr))
+	assert.Assert(t, os.IsNotExist(expectedErr))
+}
+
+func TestNewConfigCICmd_SuccessfulLoadWithCorrectPath(t *testing.T) {
+	f := cmdTest.CreateFuncWithGitInTempDir(t, fnName)
+	opts := defaultIntegrationOpts(t, &f)
+	opts.args = append(opts.args, "--path="+f.Root)
+
+	err := runConfigCiCmdIntegration(t, opts)
+
+	assert.NilError(t, err)
+}
+
+func TestNewConfigCICmd_CreatesGitHubWorkflowDirectory(t *testing.T) {
+	opts := defaultIntegrationOpts(t, nil)
+
+	err := runConfigCiCmdIntegration(t, opts)
+
+	assert.NilError(t, err)
+	_, statErr := os.Stat(filepath.Join(opts.withFunc.Root, ci.DefaultGitHubWorkflowDir))
+	assert.NilError(t, statErr)
+}
+
+func TestNewConfigCICmd_WritesWorkflowFileToFSWithCorrectYAMLStructure(t *testing.T) {
+	opts := defaultIntegrationOpts(t, nil)
+
+	err := runConfigCiCmdIntegration(t, opts)
+	file, openErr := os.Open(filepath.Join(opts.withFunc.Root, ci.DefaultGitHubWorkflowDir, ci.DefaultGitHubWorkflowFilename))
+	raw, readErr := io.ReadAll(file)
+
+	assert.NilError(t, err)
+	assert.NilError(t, openErr)
+	assert.NilError(t, readErr)
+	assertDefaultWorkflowWithBranch(t, string(raw), mainBranch)
+	file.Close()
+}
+
+// ----------------------
+// END: Integration Tests
+
+// START: Testing Framework
+// ------------------------
+type optsIntegration struct {
+	withFunc *fn.Function
+	args     []string
+}
+
+// defaultIntegrationOpts returns test options for integration tests with sensible defaults:
+//   - withFunc: provided f or newly created function with git in temp directory
+//   - args:     []string{"ci"}
+//
+// If f is nil, creates a new function with git in a temp directory.
+// If f is provided, uses that function (allows custom path testing).
+func defaultIntegrationOpts(t *testing.T, f *fn.Function) optsIntegration {
+	t.Helper()
+
+	aFunc := f
+	if f == nil {
+		fnTmp := cmdTest.CreateFuncWithGitInTempDir(t, fnName)
+		aFunc = &fnTmp
+	}
+
+	return optsIntegration{
+		withFunc: aFunc,
+		args:     []string{"ci"},
+	}
+}
+
+func runConfigCiCmdIntegration(
+	t *testing.T,
+	opts optsIntegration,
+) error {
+	t.Helper()
+
+	// PRE-RUN PREP
+	// all options for "func config ci" command
+	t.Setenv(ci.ConfigCIFeatureFlag, "true")
+
+	args := opts.args
+	if len(opts.args) == 0 {
+		args = []string{"ci"}
+	}
+
+	viper.Reset()
+
+	cmd := fnCmd.NewConfigCmd(
+		common.DefaultLoaderSaver,
+		ci.DefaultWorkflowWriter,
+		common.DefaultCurrentBranch,
+		common.DefaultWorkDir,
+		fnCmd.NewClient,
+	)
+	cmd.SetArgs(args)
+
+	// RUN
+	return cmd.Execute()
+}
+
+// ----------------------
+// END: Testing Framework

--- a/cmd/config_ci_test.go
+++ b/cmd/config_ci_test.go
@@ -2,8 +2,7 @@ package cmd_test
 
 import (
 	"fmt"
-	"io"
-	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -13,30 +12,27 @@ import (
 	fnCmd "knative.dev/func/cmd"
 	"knative.dev/func/cmd/ci"
 	"knative.dev/func/cmd/common"
-	cmdTest "knative.dev/func/cmd/testing"
 	fn "knative.dev/func/pkg/functions"
-	fnTest "knative.dev/func/pkg/testing"
 )
 
 // START: Broad Unit Tests
 // -----------------------
-// Execution is testet starting from the entrypoint "func config ci" including
+// Execution is tested starting from the entrypoint "func config ci" including
 // all components working together. Infrastructure components like the
 // filesystem are mocked.
 func TestNewConfigCICmd_RequiresFeatureFlag(t *testing.T) {
-	result := runConfigCiCmd(t, opts{enableFeature: false})
+	opts := defaultOpts()
+	opts.enableFeature = false
+
+	result := runConfigCiCmd(t, opts)
 
 	assert.ErrorContains(t, result.executeErr, "unknown command \"ci\" for \"config\"")
 }
 
 func TestNewConfigCICmd_CISubcommandExist(t *testing.T) {
 	// leave 'ci' to make this test explicitly use this subcommand
-	opts := opts{
-		enableFeature:       true,
-		withMockLoaderSaver: true,
-		withBufferWriter:    true,
-		args:                []string{"ci"},
-	}
+	opts := defaultOpts()
+	opts.args = []string{"ci"}
 
 	result := runConfigCiCmd(t, opts)
 
@@ -44,14 +40,14 @@ func TestNewConfigCICmd_CISubcommandExist(t *testing.T) {
 }
 
 func TestNewConfigCICmd_WritesWorkflowFile(t *testing.T) {
-	result := runConfigCiCmd(t, unitTestOpts())
+	result := runConfigCiCmd(t, defaultOpts())
 
 	assert.NilError(t, result.executeErr)
 	assert.Assert(t, result.gwYamlString != "")
 }
 
 func TestNewConfigCICmd_WorkflowYAMLHasCorrectStructure(t *testing.T) {
-	result := runConfigCiCmd(t, unitTestOpts())
+	result := runConfigCiCmd(t, defaultOpts())
 
 	assert.NilError(t, result.executeErr)
 	assertDefaultWorkflow(t, result.gwYamlString)
@@ -59,7 +55,7 @@ func TestNewConfigCICmd_WorkflowYAMLHasCorrectStructure(t *testing.T) {
 
 func TestNewConfigCICmd_WorkflowYAMLHasCustomValues(t *testing.T) {
 	// GIVEN
-	opts := unitTestOpts()
+	opts := defaultOpts()
 	opts.args = append(opts.args,
 		"--self-hosted-runner",
 		"--workflow-name=Custom Deploy",
@@ -67,7 +63,6 @@ func TestNewConfigCICmd_WorkflowYAMLHasCustomValues(t *testing.T) {
 		"--registry-login-url-variable-name=DEV_REGISTRY_LOGIN_URL",
 		"--registry-user-variable-name=DEV_REGISTRY_USER",
 		"--registry-pass-secret-name=DEV_REGISTRY_PASS",
-		"--branch=master",
 	)
 
 	// WHEN
@@ -80,7 +75,7 @@ func TestNewConfigCICmd_WorkflowYAMLHasCustomValues(t *testing.T) {
 
 func TestNewConfigCICmd_WorkflowHasNoRegistryLogin(t *testing.T) {
 	// GIVEN
-	opts := unitTestOpts()
+	opts := defaultOpts()
 	opts.args = append(opts.args, "--use-registry-login=false")
 
 	// WHEN
@@ -95,7 +90,7 @@ func TestNewConfigCICmd_WorkflowHasNoRegistryLogin(t *testing.T) {
 
 func TestNewConfigCICmd_RemoteBuildAndDeployWorkflow(t *testing.T) {
 	// GIVEN
-	opts := unitTestOpts()
+	opts := defaultOpts()
 	opts.args = append(opts.args, "--remote")
 
 	// WHEN
@@ -109,7 +104,7 @@ func TestNewConfigCICmd_RemoteBuildAndDeployWorkflow(t *testing.T) {
 
 func TestNewConfigCICmd_HasWorkflowDispatch(t *testing.T) {
 	// GIVEN
-	opts := unitTestOpts()
+	opts := defaultOpts()
 	opts.args = append(opts.args, "--workflow-dispatch")
 
 	// WHEN
@@ -120,124 +115,173 @@ func TestNewConfigCICmd_HasWorkflowDispatch(t *testing.T) {
 	assert.Assert(t, yamlContains(result.gwYamlString, "workflow_dispatch"))
 }
 
-// ---------------------
-// END: Broad Unit Tests
-
-// START: Integration Tests
-// ------------------------
-// No more mocking. Using real filesystem here for LoaderSaver and WorkflowWriter.
-func TestNewConfigCICmd_FailsWhenNotInitialized(t *testing.T) {
-	opts := opts{enableFeature: true, withFuncInTempDir: false}
-	expectedErrMsg := fn.NewErrNotInitialized(fnTest.Cwd()).Error()
-
-	result := runConfigCiCmd(t, opts)
-
-	assert.Error(t, result.executeErr, expectedErrMsg)
-}
-
-func TestNewConfigCICmd_SuccessWhenInitialized(t *testing.T) {
-	result := runConfigCiCmd(t, integrationTestOpts())
-
-	assert.NilError(t, result.executeErr)
-}
-
-func TestNewConfigCICmd_FailsToLoadFuncWithWrongPath(t *testing.T) {
-	opts := integrationTestOpts()
-	opts.args = append(opts.args, "--path=nofunc")
-	expectedErrMsg := "failed to create new function"
-
-	result := runConfigCiCmd(t, opts)
-
-	assert.ErrorContains(t, result.executeErr, expectedErrMsg)
-}
-
-func TestNewConfigCICmd_SuccessfulLoadWithCorrectPath(t *testing.T) {
-	tmpDir := t.TempDir()
-	opts := integrationTestOpts()
-	opts.args = append(opts.args, "--path="+tmpDir)
-	_, fnInitErr := fn.New().Init(
-		fn.Function{Name: "github-ci-func", Runtime: "go", Root: tmpDir},
+func TestNewConfigCICmd_PathFlagResolution(t *testing.T) {
+	var (
+		// os-agnostic test paths
+		cwd              = filepath.Join("current-working-directory")
+		explicitFuncPath = filepath.Join("path-to-func")
 	)
+	testCases := []struct {
+		name         string
+		pathArg      string // empty means no --path flag
+		getwdReturn  string
+		expectedPath string
+	}{
+		{
+			name:         "empty path uses cwd",
+			pathArg:      "",
+			getwdReturn:  cwd,
+			expectedPath: cwd,
+		},
+		{
+			name:         "dot path uses cwd",
+			pathArg:      "--path=.",
+			getwdReturn:  cwd,
+			expectedPath: cwd,
+		},
+		{
+			name:         "explicit func path used as-is",
+			pathArg:      "--path=" + explicitFuncPath,
+			getwdReturn:  cwd,
+			expectedPath: explicitFuncPath,
+		},
+	}
 
-	result := runConfigCiCmd(t, opts)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// GIVEN
+			opts := defaultOpts()
+			opts.args = append(opts.args, tc.pathArg)
+			opts.withFakeGetCwdReturn.dir = tc.getwdReturn
 
-	assert.NilError(t, fnInitErr)
-	assert.NilError(t, result.executeErr)
-}
+			// WHEN
+			result := runConfigCiCmd(t, opts)
 
-func TestNewConfigCICmd_CreatesGitHubWorkflowDirectory(t *testing.T) {
-	result := runConfigCiCmd(t, integrationTestOpts())
-
-	assert.NilError(t, result.executeErr)
-	_, err := os.Stat(result.ciConfig.FnGitHubWorkflowDir(result.f.Root))
-	assert.NilError(t, err)
-}
-
-func TestNewConfigCICmd_WritesWorkflowFileToFSWithCorrectYAMLStructure(t *testing.T) {
-	result := runConfigCiCmd(t, integrationTestOpts())
-	file, openErr := os.Open(result.ciConfig.FnGitHubWorkflowFilepath(result.f.Root))
-	raw, readErr := io.ReadAll(file)
-
-	assert.NilError(t, result.executeErr)
-	assert.NilError(t, openErr)
-	assert.NilError(t, readErr)
-	assertDefaultWorkflow(t, string(raw))
-
-	file.Close()
-}
-
-// ----------------------
-// END: Integration Tests
-
-// START: Testing Framework
-// ------------------------
-type opts struct {
-	withMockLoaderSaver bool
-	withFuncInTempDir   bool
-	enableFeature       bool
-	withBufferWriter    bool
-	args                []string
-}
-
-// unitTestOpts contains test options for broad unit tests
-//
-//   - withMockLoaderSaver: true,
-//   - withFuncInTempDir:   false,
-//   - enableFeature:       true,
-//   - withBufferWriter:    true,
-//   - args:                []string{"ci"},
-func unitTestOpts() opts {
-	return opts{
-		withMockLoaderSaver: true,
-		withFuncInTempDir:   false,
-		enableFeature:       true,
-		withBufferWriter:    true,
-		args:                []string{"ci"},
+			// THEN
+			assert.NilError(t, result.executeErr)
+			assert.Assert(t, strings.Contains(result.actualPath, tc.expectedPath))
+		})
 	}
 }
 
-// integrationTestOpts contains test options for integration tests
-//
-//   - withMockLoaderSaver: false,
-//   - withFuncInTempDir:   true,
-//   - enableFeature:       true,
-//   - withBufferWriter:    false,
-//   - args:                []string{"ci"},
-func integrationTestOpts() opts {
+func TestNewConfigCICmd_PathFlagResolutionError(t *testing.T) {
+	// GIVEN
+	opts := defaultOpts()
+	expectedErr := fmt.Errorf("failed getting current working directory")
+	opts.withFakeGetCwdReturn.err = expectedErr
+
+	// WHEN
+	result := runConfigCiCmd(t, opts)
+
+	// THEN
+	assert.Error(t, result.executeErr, expectedErr.Error())
+}
+
+func TestNewConfigCICmd_BranchFlagResolution(t *testing.T) {
+	testCases := []struct {
+		name           string
+		branchArg      string // empty means no --branch flag
+		gitCliReturn   string
+		expectedBranch string
+	}{
+		{
+			name:           "empty branch uses git cli current branch",
+			branchArg:      "",
+			gitCliReturn:   issueBranch,
+			expectedBranch: issueBranch,
+		},
+		{
+			name:           "explicit branch flag used as-is",
+			branchArg:      "--branch=" + mainBranch,
+			gitCliReturn:   issueBranch,
+			expectedBranch: mainBranch,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// GIVEN
+			opts := defaultOpts()
+			opts.args = append(opts.args, tc.branchArg)
+			opts.withFakeGitCliReturn.output = tc.gitCliReturn
+
+			// WHEN
+			result := runConfigCiCmd(t, opts)
+
+			// THEN
+			assert.NilError(t, result.executeErr)
+			assert.Assert(t, yamlContains(result.gwYamlString, "- "+tc.expectedBranch))
+		})
+	}
+}
+
+func TestNewConfigCICmd_BranchFlagResolutionError(t *testing.T) {
+	// GIVEN
+	opts := defaultOpts()
+	expectedErr := fmt.Errorf("failed getting current branch")
+	opts.withFakeGitCliReturn.err = expectedErr
+
+	// WHEN
+	result := runConfigCiCmd(t, opts)
+
+	// THEN
+	assert.Error(t, result.executeErr, expectedErr.Error())
+}
+
+// ---------------------
+// END: Broad Unit Tests
+
+// START: Testing Framework
+// ------------------------
+const (
+	mainBranch  = "main"
+	issueBranch = "issue-778-current-branch"
+	fnName      = "github-ci-func"
+)
+
+type opts struct {
+	enableFeature        bool
+	withFakeGitCliReturn struct {
+		output string
+		err    error
+	}
+	withFakeGetCwdReturn struct {
+		dir string
+		err error
+	}
+	args []string
+}
+
+// defaultOpts returns test options for broad unit tests with sensible defaults:
+//   - enableFeature:        true
+//   - withFakeGitCliReturn: {output: issueBranch, err: nil}
+//   - withFakeGetCwdReturn: {dir: "", err: nil}
+//   - args:                 []string{"ci"}
+func defaultOpts() opts {
 	return opts{
-		withMockLoaderSaver: false,
-		withFuncInTempDir:   true,
-		enableFeature:       true,
-		withBufferWriter:    false,
-		args:                []string{"ci"},
+		enableFeature: true,
+		withFakeGitCliReturn: struct {
+			output string
+			err    error
+		}{
+			output: issueBranch,
+			err:    nil,
+		},
+		withFakeGetCwdReturn: struct {
+			dir string
+			err error
+		}{
+			dir: "",
+			err: nil,
+		},
+		args: []string{"ci"},
 	}
 }
 
 type result struct {
-	f            fn.Function
-	ciConfig     ci.CIConfig
-	executeErr   error
-	gwYamlString string
+	executeErr error
+	gwYamlString,
+	actualPath string
 }
 
 func runConfigCiCmd(
@@ -248,52 +292,43 @@ func runConfigCiCmd(
 
 	// PRE-RUN PREP
 	// all options for "func config ci" command
-	loaderSaver := common.DefaultLoaderSaver
-	if opts.withMockLoaderSaver {
-		loaderSaver = common.NewMockLoaderSaver()
-	}
-
-	f := fn.Function{}
-	if opts.withFuncInTempDir {
-		f = cmdTest.CreateFuncInTempDir(t, "github-ci-func")
-	}
-
 	if opts.enableFeature {
 		t.Setenv(ci.ConfigCIFeatureFlag, "true")
 	}
 
-	var writer ci.WorkflowWriter = ci.DefaultWorkflowWriter
-	bufferWriter := ci.NewBufferWriter()
-	if opts.withBufferWriter {
-		writer = bufferWriter
+	loaderSaver := common.NewMockLoaderSaver()
+	loaderSaver.LoadFn = func(path string) (fn.Function, error) {
+		return fn.Function{Root: path}, nil
 	}
-
-	args := opts.args
-	if len(opts.args) == 0 {
-		args = []string{"ci"}
-	}
+	writer := ci.NewBufferWriter()
+	currentBranch := common.CurrentBranchStub(
+		opts.withFakeGitCliReturn.output,
+		opts.withFakeGitCliReturn.err,
+	)
+	workingDir := common.WorkDirStub(
+		opts.withFakeGetCwdReturn.dir,
+		opts.withFakeGetCwdReturn.err,
+	)
 
 	viper.Reset()
 
 	cmd := fnCmd.NewConfigCmd(
 		loaderSaver,
 		writer,
+		currentBranch,
+		workingDir,
 		fnCmd.NewClient,
 	)
-	cmd.SetArgs(args)
+	cmd.SetArgs(opts.args)
 
 	// RUN
 	err := cmd.Execute()
 
 	// POST-RUN GATHER
-	ciConfig := ci.NewCIGitHubConfig()
-	gwYamlString := bufferWriter.Buffer.String()
-
 	return result{
-		f,
-		ciConfig,
 		err,
-		gwYamlString,
+		writer.Buffer.String(),
+		writer.Path,
 	}
 }
 
@@ -308,8 +343,14 @@ func runConfigCiCmd(
 func assertDefaultWorkflow(t *testing.T, actualGw string) {
 	t.Helper()
 
+	assertDefaultWorkflowWithBranch(t, actualGw, issueBranch)
+}
+
+func assertDefaultWorkflowWithBranch(t *testing.T, actualGw, branch string) {
+	t.Helper()
+
 	assert.Assert(t, yamlContains(actualGw, "Func Deploy"))
-	assert.Assert(t, yamlContains(actualGw, "- main"))
+	assert.Assert(t, yamlContains(actualGw, "- "+branch))
 
 	assert.Assert(t, yamlContains(actualGw, "ubuntu-latest"))
 
@@ -356,7 +397,6 @@ func assertCustomWorkflow(t *testing.T, actualGw string) {
 	assert.Assert(t, yamlContains(actualGw, "DEV_REGISTRY_LOGIN_URL"))
 	assert.Assert(t, yamlContains(actualGw, "DEV_REGISTRY_USER"))
 	assert.Assert(t, yamlContains(actualGw, "DEV_REGISTRY_PASS"))
-	assert.Assert(t, yamlContains(actualGw, "- master"))
 }
 
 // ----------------------

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -50,7 +50,13 @@ func TestListEnvs(t *testing.T) {
 }
 
 func setupConfigEnvCmd(mock common.FunctionLoaderSaver, args ...string) *cobra.Command {
-	cmd := fnCmd.NewConfigCmd(mock, ci.NewBufferWriter(), fnCmd.NewClient)
+	cmd := fnCmd.NewConfigCmd(
+		mock,
+		ci.NewBufferWriter(),
+		common.CurrentBranchStub("", nil),
+		common.WorkDirStub("", nil),
+		fnCmd.NewClient,
+	)
 	cmd.SetArgs(append([]string{"envs"}, args...))
 	return cmd
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"knative.dev/client/pkg/util"
+	"knative.dev/func/cmd/common"
 	"knative.dev/func/pkg/builders"
 	"knative.dev/func/pkg/config"
 	fn "knative.dev/func/pkg/functions"
@@ -1005,28 +1005,13 @@ func printDeployMessages(out io.Writer, f fn.Function) {
 	if f.Local.Remote && f.Build.Git.URL != "" && f.Build.Git.Revision != "" {
 		// Doing a remote build, specified a git repository to pull from, and
 		// specified a reference within that remote.
-		currentBranch, err := getCurrentGitBranch()
+		currentBranch, err := common.DefaultCurrentBranch(f.Root)
 		if err != nil {
 			fmt.Fprintf(out, "Warning: unable to verify local and remote references match. %v\n", err)
 		} else if currentBranch != f.Build.Git.Revision {
 			fmt.Fprintf(out, "Warning: Local git branch '%s' does not match --git-branch '%s'. The local func.yaml will be used for function metadata (name, runtime, etc). Ensure your local branch matches the remote branch to avoid deployment issues.\n", currentBranch, f.Build.Git.Revision)
 		}
 	}
-}
-
-// getCurrentGitBranch returns the current git branch name
-func getCurrentGitBranch() (string, error) {
-	gitCmd := os.Getenv("FUNC_GIT")
-	if gitCmd == "" {
-		gitCmd = "git"
-	}
-
-	cmd := exec.Command(gitCmd, "rev-parse", "--abbrev-ref", "HEAD")
-	output, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(output)), nil
 }
 
 // isDigested checks that the given image reference has a digest. Invalid

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -146,7 +146,7 @@ func newDescribeConfig(cmd *cobra.Command, args []string) (cfg describeConfig, e
 		Verbose:   viper.GetBool("verbose"),
 	}
 	if cfg.Name == "" && cmd.Flags().Changed("namespace") {
-		// logicially inconsistent to supply only a namespace.
+		// logically inconsistent to supply only a namespace.
 		// Either use the function's local state in its entirety, or specify
 		// both a name and a namespace to ignore any local function source.
 		err = fmt.Errorf("must also specify a name when specifying namespace")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,7 +101,13 @@ Learn more about Knative at: https://knative.dev`, cfg.Name),
 		{
 			Header: "System Commands:",
 			Commands: []*cobra.Command{
-				NewConfigCmd(common.DefaultLoaderSaver, ci.DefaultWorkflowWriter, newClient),
+				NewConfigCmd(
+					common.DefaultLoaderSaver,
+					ci.DefaultWorkflowWriter,
+					common.DefaultCurrentBranch,
+					common.DefaultWorkDir,
+					newClient,
+				),
 				NewLanguagesCmd(newClient),
 				NewTemplatesCmd(newClient),
 				NewRepositoryCmd(newClient),
@@ -247,7 +253,7 @@ func deriveName(explicitName string, path string) string {
 
 // deriveNameAndAbsolutePathFromPath returns resolved function name and absolute path
 // to the function project root. The input parameter path could be one of:
-// 'relative/path/to/foo', '/absolute/path/to/foo', 'foo' or ”.
+// 'relative/path/to/foo', '/absolute/path/to/foo', 'foo' or "."
 func deriveNameAndAbsolutePathFromPath(path string) (string, string) {
 	var absPath string
 

--- a/cmd/testing/factory.go
+++ b/cmd/testing/factory.go
@@ -4,13 +4,14 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"knative.dev/func/cmd/common"
 	fn "knative.dev/func/pkg/functions"
 	fnTest "knative.dev/func/pkg/testing"
 )
 
-// CreateFuncInTempDir creates and initializes a Go function in a temporary
-// directory for testing.
-func CreateFuncInTempDir(t *testing.T, fnName string) fn.Function {
+// CreateFuncWithGitInTempDir creates and initializes a Go function and git in a
+// temporary directory for testing.
+func CreateFuncWithGitInTempDir(t *testing.T, fnName string) fn.Function {
 	t.Helper()
 
 	name := fnName
@@ -21,6 +22,9 @@ func CreateFuncInTempDir(t *testing.T, fnName string) fn.Function {
 	result, err := fn.New().Init(
 		fn.Function{Name: name, Runtime: "go", Root: fnTest.FromTempDirectory(t)},
 	)
+	assert.NilError(t, err)
+
+	_, err = common.NewGitCliWrapper().Init(result.Root, "main")
 	assert.NilError(t, err)
 
 	return result

--- a/pkg/knative/deployer.go
+++ b/pkg/knative/deployer.go
@@ -721,24 +721,22 @@ func checkPullPermissions(ctx context.Context, core v1.CoreV1Interface, trans ht
 }
 
 func secretToConfigFile(sc *corev1.Secret) (*configfile.ConfigFile, error) {
-	var cf *configfile.ConfigFile
-	var err error
 	switch sc.Type {
 	case corev1.SecretTypeDockerConfigJson:
-		cf, err = config.LoadFromReader(bytes.NewReader(sc.Data[corev1.DockerConfigJsonKey]))
+		cf, err := config.LoadFromReader(bytes.NewReader(sc.Data[corev1.DockerConfigJsonKey]))
 		if err != nil {
 			return nil, fmt.Errorf("cannot load config: %w", err)
 		}
+		return cf, nil
 	case corev1.SecretTypeDockercfg:
-		cf = &configfile.ConfigFile{}
-		err = json.Unmarshal(sc.Data[corev1.DockerConfigKey], &cf.AuthConfigs)
-		if err != nil {
+		cf := &configfile.ConfigFile{}
+		if err := json.Unmarshal(sc.Data[corev1.DockerConfigKey], &cf.AuthConfigs); err != nil {
 			return nil, fmt.Errorf("cannot unmarshal config: %w", err)
 		}
+		return cf, nil
 	default:
-		cf = &configfile.ConfigFile{}
+		return &configfile.ConfigFile{}, nil
 	}
-	return cf, nil
 }
 
 type configFileKeychain struct {


### PR DESCRIPTION
<!-- PR Title: feat: default path and branch flags intelligently -->

# Changes

- :gift: Default `--path` flag to current working directory when empty or "."
- :gift: Default `--branch` flag to current git branch instead of hardcoded "main"
- :broom: Consolidate duplicate `getCurrentGitBranch` from `cmd/deploy.go` into shared `gitCliWrapper`
- :broom: Reorganize tests: integration tests to `cmd/config_ci_int_test.go`, unit tests use stubs

/kind enhancement

Relates to #3256

**Release Note**

```release-note
The `func config ci` command now resolves --path and --branch flags intelligently:
- --path defaults to current working directory when empty or "."
- --branch defaults to current git branch when not specified (previously "main")
```

**Docs**

```docs

```