### PR TITLE
 docs: Add release note and docs to credentials refactoring

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -45,6 +45,15 @@ DESCRIPTION
 	When building a function for the first time, either a registry or explicit
 	image name is required.  Subsequent builds will reuse these option values.
 
+	Authentication
+	  When --push is used, the 'build' command interacts with container registries to push the function image.
+	  Authentication can be configured using environment variables:
+	  - FUNC_USERNAME: Username for the registry
+	  - FUNC_PASSWORD: Password for the registry
+	  - FUNC_TOKEN: Token for the registry
+
+	  These variables are used to authenticate with the registry specified by --registry.
+
 EXAMPLES
 
 	o Build a function container using the given registry.

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -89,6 +89,15 @@ DESCRIPTION
 	  selectors. Note that the domain specified must be one of those configured
 	  or the flag will be ignored.
 
+	Authentication
+	  The 'deploy' command interacts with container registries to push the function image.
+	  Authentication can be configured using environment variables:
+	  - FUNC_USERNAME: Username for the registry
+	  - FUNC_PASSWORD: Password for the registry
+	  - FUNC_TOKEN: Token for the registry
+
+	  These variables are used to authenticate with the registry specified by --registry.
+
 EXAMPLES
 
 	o Deploy the function

--- a/docs/reference/func_build.md
+++ b/docs/reference/func_build.md
@@ -28,6 +28,15 @@ DESCRIPTION
 	When building a function for the first time, either a registry or explicit
 	image name is required.  Subsequent builds will reuse these option values.
 
+	Authentication
+	  When --push is used, the 'build' command interacts with container registries to push the function image.
+	  Authentication can be configured using environment variables:
+	  - FUNC_USERNAME: Username for the registry
+	  - FUNC_PASSWORD: Password for the registry
+	  - FUNC_TOKEN: Token for the registry
+
+	  These variables are used to authenticate with the registry specified by --registry.
+
 EXAMPLES
 
 	o Build a function container using the given registry.

--- a/docs/reference/func_deploy.md
+++ b/docs/reference/func_deploy.md
@@ -66,6 +66,15 @@ DESCRIPTION
 	  selectors. Note that the domain specified must be one of those configured
 	  or the flag will be ignored.
 
+	Authentication
+	  The 'deploy' command interacts with container registries to push the function image.
+	  Authentication can be configured using environment variables:
+	  - FUNC_USERNAME: Username for the registry
+	  - FUNC_PASSWORD: Password for the registry
+	  - FUNC_TOKEN: Token for the registry
+
+	  These variables are used to authenticate with the registry specified by --registry.
+
 EXAMPLES
 
 	o Deploy the function


### PR DESCRIPTION
# Changes

Changes
Document usage of FUNC_USERNAME, FUNC_PASSWORD, and FUNC_TOKEN environment variables in func deploy help text
Document usage of FUNC_USERNAME, FUNC_PASSWORD, and FUNC_TOKEN environment variables in func build help text
Update generated reference documentation for deploy and build commands
/kind documentation

Fixes #3299

Release Note

The FUNC_USERNAME and FUNC_PASSWORD environment variables (and FUNC_TOKEN) now work for registry authentication in `func deploy` and `func build` commands across different pushers.
Docs

