### PR TITLE
bump k8s version, update deps manually

### DIFF
--- a/hack/component-versions.json
+++ b/hack/component-versions.json
@@ -1,22 +1,22 @@
 {
 	"Contour": {
-		"version": "v1.20.1",
+		"version": "v1.21.0",
 		"owner": "knative-extensions",
 		"repo": "net-contour"
 	},
 	"Eventing": {
-		"version": "v1.20.0",
+		"version": "v1.21.0",
 		"owner": "knative",
 		"repo": "eventing"
 	},
 	"KindNode": {
-		"version": "v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027"
+		"version": "v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f"
 	},
 	"Pac": {
 		"version": "v0.35.2"
 	},
 	"Serving": {
-		"version": "v1.20.1",
+		"version": "v1.21.0",
 		"owner": "knative",
 		"repo": "serving"
 	},

--- a/hack/component-versions.sh
+++ b/hack/component-versions.sh
@@ -8,12 +8,12 @@
 set_versions() {
 	# Note: Kubernetes Version node image per Kind releases (full hash is suggested):
 	# https://github.com/kubernetes-sigs/kind/releases
-	kind_node_version=v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
+	kind_node_version=v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
 
 	# find source-of-truth in component-versions.json to add/modify components
-	knative_serving_version="v1.20.1"
-	knative_eventing_version="v1.20.0"
-	contour_version="v1.20.1"
+	knative_serving_version="v1.21.0"
+	knative_eventing_version="v1.21.0"
+	contour_version="v1.21.0"
 	tekton_version="v1.1.0"
 	pac_version="v0.35.2"
 }


### PR DESCRIPTION
k8s version bump to 1.35 (needs to be 1.33 because knative minimal version bumped)