### PR TITLE
Feature: Protect existing workflow files from accidental overwrites.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ __pycache__
 AGENTS.override.md
 .claude/*.local.*
 .claude/pr/*
+.roo/*
 
 # E2E Tests
 /e2e/testdata/default_home/go

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,12 @@ edge cases into account.
 ## Commands
 
 ### Build & Development
+
 - `make all` - Build binary and regenerate docs
 - `make build` - Build for current OS
 
 ### Testing strategy reference
+
 Before committing, test locally following the table below:
 
 | If changed | Target | Description |
@@ -32,19 +34,21 @@ Before committing, test locally following the table below:
 | Significant architectural changes | `make test-full` | e2e tests (cluster required - read `CONTRIBUTING.md`) |
 
 ### Generated Files
+
 - `./hack/update-codegen.sh` - update embedded filesystem & regenerate docs
 - `make check-embedded-fs` - check embedded FS is up to date with templates
-
 
 ## Boundaries
 
 ### Always Do
+
 - Run `make test` before considering any change complete
 - Run `make check` before commits
 - Run `make check-embedded-fs` after modifying `templates/`
 - Ask before deleting ANY file or significant code block
 
 ### Ask First
+
 - Security-related code changes (authentication, credentials, secrets handling)
 - API changes
 - Adding new dependencies
@@ -52,6 +56,7 @@ Before committing, test locally following the table below:
 - Architectural decisions
 
 ### Never Do
+
 - Edit generated files directly:
   - `generate/zz_filesystem_generated.go`
   - `schema/func_yaml-schema.json`
@@ -63,11 +68,12 @@ Before committing, test locally following the table below:
 ## Common Pitfalls
 
 ### Codegen Sync
+
 After modifying `templates/` or making documentation changes, you MUST run:
+
 ```bash
 ./hack/update-codegen.sh
 ```
-
 
 ## Contributing
 

--- a/cmd/ci/workflow_test.go
+++ b/cmd/ci/workflow_test.go
@@ -1,6 +1,7 @@
 package ci_test
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -14,12 +15,13 @@ func TestGitHubWorkflow_Export(t *testing.T) {
 	cfg, _ := ci.NewCIConfig(
 		common.CurrentBranchStub("", nil),
 		common.WorkDirStub("", nil),
+		false,
 	)
 	gw := ci.NewGitHubWorkflow(cfg)
 	bufferWriter := ci.NewBufferWriter()
 
 	// WHEN
-	exportErr := gw.Export("path", bufferWriter)
+	exportErr := gw.Export("path", bufferWriter, true, &bytes.Buffer{})
 
 	// THEN
 	assert.NilError(t, exportErr, "unexpected error when exporting GitHub Workflow")


### PR DESCRIPTION
<!-- PR Title: Protect existing workflows from overwrites -->

# Changes

- :gift: Add workflow file existence check to prevent accidental overwrites
- :gift: Add `--force` flag to explicitly allow overwriting existing workflow files
- :gift: Add warning message when `--force` is used to overwrite existing workflows
- :gift: Add distinct default workflow name for remote builds ("Remote Func Deploy") to avoid conflicts

/kind enhancement

Relates to #3256

**Release Note**

```release-note
The `func config ci` command now protects existing workflow files from accidental overwrites. Use the `--force` flag to explicitly overwrite existing files.
```

**Docs**

```docs

```