### PR TITLE
add middleware version as image label

### DIFF
--- a/pkg/builders/middleware_labels_int_test.go
+++ b/pkg/builders/middleware_labels_int_test.go
@@ -1,0 +1,105 @@
+//go:build integration
+
+package builders_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/client"
+
+	"knative.dev/func/pkg/buildpacks"
+	fn "knative.dev/func/pkg/functions"
+	"knative.dev/func/pkg/s2i"
+)
+
+// Scaffolder scaffolds a function for building
+type Scaffolder interface {
+	Scaffold(ctx context.Context, f fn.Function, path string) error
+}
+
+// Builder builds a function image
+type Builder interface {
+	Build(ctx context.Context, f fn.Function, platforms []fn.Platform) error
+}
+
+// TestInt_MiddlewareLabels verifies that the middleware-version label is set
+// on function images built by each builder type.
+func TestInt_MiddlewareLabels(t *testing.T) {
+	tests := []struct {
+		name       string
+		timeout    time.Duration
+		scaffolder Scaffolder
+		builder    Builder
+	}{
+		{
+			name:       "s2i",
+			timeout:    5 * time.Minute,
+			scaffolder: s2i.NewScaffolder(true),
+			builder:    s2i.NewBuilder(s2i.WithVerbose(true)),
+		},
+		{
+			name:       "buildpacks",
+			timeout:    10 * time.Minute,
+			scaffolder: buildpacks.NewScaffolder(true),
+			builder:    buildpacks.NewBuilder(buildpacks.WithVerbose(true)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := initFunction(t, "test-"+tt.name+"-labels")
+			ctx, cancel := context.WithTimeout(context.Background(), tt.timeout)
+			defer cancel()
+
+			if err := tt.scaffolder.Scaffold(ctx, f, ""); err != nil {
+				t.Fatal(err)
+			}
+			if err := tt.builder.Build(ctx, f, nil); err != nil {
+				t.Fatal(err)
+			}
+
+			assertMiddlewareLabel(t, ctx, f.Build.Image)
+		})
+	}
+}
+
+func initFunction(t *testing.T, name string) fn.Function {
+	t.Helper()
+	f := fn.Function{
+		Name:     name,
+		Root:     t.TempDir(),
+		Runtime:  "go",
+		Registry: "localhost:50000",
+	}
+	f, err := fn.New().Init(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Build.Image = "localhost:50000/" + name + ":latest"
+	return f
+}
+
+func assertMiddlewareLabel(t *testing.T, ctx context.Context, image string) {
+	t.Helper()
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+
+	inspect, _, err := cli.ImageInspectWithRaw(ctx, image)
+	if err != nil {
+		t.Fatalf("failed to inspect image %s: %v", image, err)
+	}
+
+	middlewareVersion, ok := inspect.Config.Labels[fn.MiddlewareVersionLabelKey]
+	if !ok {
+		t.Fatalf("label %q not found in image. Labels: %v", fn.MiddlewareVersionLabelKey, inspect.Config.Labels)
+	}
+	if middlewareVersion == "" {
+		t.Fatalf("label %q is empty", fn.MiddlewareVersionLabelKey)
+	}
+	t.Logf("middleware-version label: %s", middlewareVersion)
+}

--- a/pkg/s2i/builder.go
+++ b/pkg/s2i/builder.go
@@ -21,6 +21,7 @@ import (
 	"knative.dev/func/pkg/builders"
 	"knative.dev/func/pkg/docker"
 	fn "knative.dev/func/pkg/functions"
+	"knative.dev/func/pkg/scaffolding"
 )
 
 // DefaultName when no WithName option is provided to NewBuilder
@@ -171,6 +172,15 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 		// bloats the build process and can cause unexpected errors in the resultant
 		// function.
 		ExcludeRegExp: "(^|/)\\.git|\\.env|\\.func|node_modules(/|$)",
+	}
+
+	// Set middleware version label
+	middlewareVersion, err := scaffolding.MiddlewareVersion(f.Root, f.Runtime, f.Invoke, fn.EmbeddedTemplatesFS)
+	if err != nil {
+		return fmt.Errorf("cannot get middleware version: %w", err)
+	}
+	if middlewareVersion != "" {
+		cfg.Labels = map[string]string{fn.MiddlewareVersionLabelKey: middlewareVersion}
 	}
 
 	// Environment variables


### PR DESCRIPTION
Add the middleware-version image label to function images built by S2I and Pack builders to preserve complete the implementation. OCI already implements this (only added unit test since we can inspect the actual blobs/files created)
- label is only set when non-empty

1. `func build --builder=s2i --push`
2. `Docker inspect...`
3.  Labels contain: `"middleware-version": "v0.21.3",`

PS:
some pack tests needed proper directory root because middleware fetch uses actual path detection for those templates (so it needs proper function root)

PSS: the s2i was added prior by Christoph but removed by me in the XXL scaffolding PR. Re-adding it here.

/kind enhancement
/fixes https://github.com/knative/func/issues/3406

```release-note
All function images now include the `middleware-version` label build by standard deployment
```
