### PR TITLE
feat: unhide username/password/token flags for all builders

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -123,19 +123,12 @@ EXAMPLES
 	cmd.Flags().StringP("platform", "", "",
 		"Optionally specify a target platform, for example \"linux/amd64\" when using the s2i build strategy")
 	cmd.Flags().StringP("username", "", "",
-		"Username to use when pushing to the registry.")
+		"Username to use when pushing to the registry. ($FUNC_USERNAME)")
 	cmd.Flags().StringP("password", "", "",
-		"Password to use when pushing to the registry.")
+		"Password to use when pushing to the registry. ($FUNC_PASSWORD)")
 	cmd.Flags().StringP("token", "", "",
-		"Token to use when pushing to the registry.")
+		"Token to use when pushing to the registry. ($FUNC_TOKEN)")
 	cmd.Flags().BoolP("build-timestamp", "", false, "Use the actual time as the created time for the docker image. This is only useful for buildpacks builder.")
-
-	// Temporarily Hidden Basic Auth Flags
-	// Username, Password and Token flags, which plumb through basic auth, are
-	// currently only available on the "host" builder.
-	_ = cmd.Flags().MarkHidden("username")
-	_ = cmd.Flags().MarkHidden("password")
-	_ = cmd.Flags().MarkHidden("token")
 
 	// Oft-shared flags:
 	addConfirmFlag(cmd, cfg.Confirm)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -207,21 +207,14 @@ EXAMPLES
 	cmd.Flags().String("platform", "",
 		"Optionally specify a specific platform to build for (e.g. linux/amd64). ($FUNC_PLATFORM)")
 	cmd.Flags().StringP("username", "", "",
-		"Username to use when pushing to the registry.")
+		"Username to use when pushing to the registry. ($FUNC_USERNAME)")
 	cmd.Flags().StringP("password", "", "",
-		"Password to use when pushing to the registry.")
+		"Password to use when pushing to the registry. ($FUNC_PASSWORD)")
 	cmd.Flags().StringP("token", "", "",
-		"Token to use when pushing to the registry.")
+		"Token to use when pushing to the registry. ($FUNC_TOKEN)")
 	cmd.Flags().BoolP("build-timestamp", "", false, "Use the actual time as the created time for the docker image. This is only useful for buildpacks builder.")
 	cmd.Flags().StringP("namespace", "n", defaultNamespace(f, false),
 		"Deploy into a specific namespace. Will use the function's current namespace by default if already deployed, and the currently active context if it can be determined. ($FUNC_NAMESPACE)")
-
-	// Temporarily Hidden Basic Auth Flags
-	// Username, Password and Token flags, which plumb through basic auth, are
-	// currently only available on "host" builder.
-	_ = cmd.Flags().MarkHidden("username")
-	_ = cmd.Flags().MarkHidden("password")
-	_ = cmd.Flags().MarkHidden("token")
 
 	// Oft-shared flags:
 	addConfirmFlag(cmd, cfg.Confirm)

--- a/docs/reference/func_build.md
+++ b/docs/reference/func_build.md
@@ -64,12 +64,15 @@ func build
   -c, --confirm                    Prompt to confirm options interactively ($FUNC_CONFIRM)
   -h, --help                       help for build
   -i, --image string               Full image name in the form [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over --registry ($FUNC_IMAGE)
+      --password string            Password to use when pushing to the registry. ($FUNC_PASSWORD)
   -p, --path string                Path to the function.  Default is current directory ($FUNC_PATH)
       --platform string            Optionally specify a target platform, for example "linux/amd64" when using the s2i build strategy
   -u, --push                       Attempt to push the function image to the configured registry after being successfully built
   -r, --registry string            Container registry + registry namespace. (ex 'ghcr.io/myuser').  The full image name is automatically determined using this along with function name. ($FUNC_REGISTRY)
       --registry-authfile string   Path to a authentication file containing registry credentials ($FUNC_REGISTRY_AUTHFILE)
       --registry-insecure          Skip TLS certificate verification when communicating in HTTPS with the registry ($FUNC_REGISTRY_INSECURE)
+      --token string               Token to use when pushing to the registry. ($FUNC_TOKEN)
+      --username string            Username to use when pushing to the registry. ($FUNC_USERNAME)
   -v, --verbose                    Print verbose logs ($FUNC_VERBOSE)
 ```
 

--- a/docs/reference/func_deploy.md
+++ b/docs/reference/func_deploy.md
@@ -128,6 +128,7 @@ func deploy
   -h, --help                          help for deploy
   -i, --image string                  Full image name in the form [registry]/[namespace]/[name]:[tag]@[digest]. This option takes precedence over --registry. Specifying digest is optional, but if it is given, 'build' and 'push' phases are disabled. ($FUNC_IMAGE)
   -n, --namespace string              Deploy into a specific namespace. Will use the function's current namespace by default if already deployed, and the currently active context if it can be determined. ($FUNC_NAMESPACE) (default "default")
+      --password string               Password to use when pushing to the registry. ($FUNC_PASSWORD)
   -p, --path string                   Path to the function.  Default is current directory ($FUNC_PATH)
       --platform string               Optionally specify a specific platform to build for (e.g. linux/amd64). ($FUNC_PLATFORM)
   -u, --push                          Push the function image to registry before deploying. ($FUNC_PUSH) (default true)
@@ -138,6 +139,8 @@ func deploy
   -R, --remote                        Trigger a remote deployment. Default is to deploy and build from the local system ($FUNC_REMOTE)
       --remote-storage-class string   Specify a storage class to use for the volume on-cluster during remote builds
       --service-account string        Service account to be used in the deployed function ($FUNC_SERVICE_ACCOUNT)
+      --token string                  Token to use when pushing to the registry. ($FUNC_TOKEN)
+      --username string               Username to use when pushing to the registry. ($FUNC_USERNAME)
   -v, --verbose                       Print verbose logs ($FUNC_VERBOSE)
 ```
 


### PR DESCRIPTION
Since PR #3298 fixed these credentials to work with all builders (host, pack, s2i), there's no reason to keep them hidden anymore.


Fixes #3299 