### PR TITLE
Ignore eventing error, when eventing is not installed

### DIFF
--- a/pkg/k8s/deployer.go
+++ b/pkg/k8s/deployer.go
@@ -328,6 +328,11 @@ func deleteStaleTriggers(ctx context.Context, eventingClient clienteventingv1.Kn
 	// List existing triggers in the namespace
 	existingTriggers, err := eventingClient.ListTriggers(ctx)
 	if err != nil {
+		if strings.HasPrefix(err.Error(), "no or newer Knative Eventing API found on the backend") {
+			// knative eventing not installed -> nothing to do and return early
+			return nil
+		}
+
 		// If triggers can't be listed ,skip cleanup
 		if errors.IsNotFound(err) {
 			return nil


### PR DESCRIPTION
Fixes #3404

# Changes

- :broom: Ignore error about missing Knative Eventing installation on `func deploy` when Eventing is not required (when the user defined subscriptions for a Function and Eventing would not be installed, then an error of course is still raised)