### PR TITLE
fix: install podman 5.x from Ubuntu Plucky in CI & fix its runs-on value

### DIFF
--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -248,12 +248,12 @@ jobs:
   test-e2e-podman:
     name: E2E - Podman
     needs: precheck
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         os:
           - "ubuntu-latest"      # x86_64
           - "ubuntu-24.04-arm"   # ARM64
+    runs-on: ${{ matrix.os }}
     env:
       FUNC_CLUSTER_RETRIES: 5
       FUNC_E2E_PODMAN: true
@@ -263,8 +263,27 @@ jobs:
       - uses: actions/checkout@v4
       - uses: knative/actions/setup-go@main
 
+      - name: Install Podman
+        run: |
+          # Ubuntu 24.04 ships Podman 4.x (API 1.41) but Docker v29 on the
+          # runner requires API >= 1.44.  Install Podman 5.x from Ubuntu 25.04
+          # (Plucky) packages.  See https://github.com/containers/podman/issues/27890
+          ARCH=$(dpkg --print-architecture)
+          if [ "$ARCH" = "amd64" ]; then
+            MIRROR="http://archive.ubuntu.com/ubuntu"
+          else
+            MIRROR="http://ports.ubuntu.com/ubuntu-ports"
+          fi
+          echo "deb $MIRROR plucky main universe" \
+            | sudo tee /etc/apt/sources.list.d/ubuntu-plucky.list
+          # Pin plucky low; only pull when explicitly requested via -t
+          printf 'Package: *\nPin: release n=plucky\nPin-Priority: 100\n' \
+            | sudo tee /etc/apt/preferences.d/ubuntu-plucky
+          sudo apt-get update
+          sudo apt-get -y install -t plucky podman crun
+          podman --version
       - name: Start Podman
-        run: sudo apt update && sudo apt install -y podman && podman system service --time=0 &
+        run: podman system service --time=0 &
 
       - name: Install Binaries
         run: ./hack/binaries.sh


### PR DESCRIPTION
This PR introduces 2 things:
1) install podman 5.X from Ubuntu Plucky to fix API version mismatch of Docker engine
#### why?
- [GH Action runner updated to docker v29 on Feb 9](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) -> this raises minimum API to 1.44
-  podman 4.X (what we install currently on main) only provides docker engine API 1.41 -> with this PR we raise that to podman 5.X which has the minimal required 1.44

[original failed podman test in CI](https://github.com/knative/func/actions/runs/21971697863/job/63474860698?pr=3433)

2) fix `runs-on: ${{ matrix.os }}` so that this runs as intended on both OSs