### PR TITLE
Feature: Add user messages to config ci.

### DIFF
--- a/cmd/ci/common.go
+++ b/cmd/ci/common.go
@@ -1,0 +1,26 @@
+package ci
+
+import "fmt"
+
+func runner(conf CIConfig) string {
+	if conf.UseSelfHostedRunner() {
+		return "self-hosted"
+	}
+	return "ubuntu-latest"
+}
+
+func secretsPrefix(s string) string {
+	return "secrets." + s
+}
+
+func varsPrefix(s string) string {
+	return "vars." + s
+}
+
+func newSecret(key string) string {
+	return fmt.Sprintf("${{ %s }}", secretsPrefix(key))
+}
+
+func newVariable(key string) string {
+	return fmt.Sprintf("${{ %s }}", varsPrefix(key))
+}

--- a/cmd/ci/config.go
+++ b/cmd/ci/config.go
@@ -56,6 +56,9 @@ const (
 
 	ForceFlag    = "force"
 	DefaultForce = false
+
+	VerboseFlag    = "verbose"
+	DefaultVerbose = false
 )
 
 // CIConfig readonly configuration
@@ -74,7 +77,8 @@ type CIConfig struct {
 	useSelfHostedRunner,
 	useRemoteBuild,
 	useWorkflowDispatch,
-	force bool
+	force,
+	verbose bool
 }
 
 func NewCIConfig(
@@ -114,6 +118,7 @@ func NewCIConfig(
 		useRemoteBuild:         viper.GetBool(UseRemoteBuildFlag),
 		useWorkflowDispatch:    viper.GetBool(WorkflowDispatchFlag),
 		force:                  viper.GetBool(ForceFlag),
+		verbose:                viper.GetBool(VerboseFlag),
 	}, nil
 }
 
@@ -167,62 +172,70 @@ func resolveWorkflowName(explicit bool) string {
 	return DefaultWorkflowName
 }
 
-func (cc *CIConfig) FnGitHubWorkflowDir(fnRoot string) string {
+func (cc CIConfig) fnGitHubWorkflowDir(fnRoot string) string {
 	return filepath.Join(fnRoot, cc.githubWorkflowDir)
 }
 
-func (cc *CIConfig) FnGitHubWorkflowFilepath(fnRoot string) string {
-	return filepath.Join(cc.FnGitHubWorkflowDir(fnRoot), cc.githubWorkflowFilename)
+func (cc CIConfig) FnGitHubWorkflowFilepath(fnRoot string) string {
+	return filepath.Join(cc.fnGitHubWorkflowDir(fnRoot), cc.githubWorkflowFilename)
 }
 
-func (cc *CIConfig) Path() string {
+func (cc CIConfig) Path() string {
 	return cc.path
 }
 
-func (cc *CIConfig) WorkflowName() string {
+func (cc CIConfig) WorkflowName() string {
 	return cc.workflowName
 }
 
-func (cc *CIConfig) Branch() string {
+func (cc CIConfig) Branch() string {
 	return cc.branch
 }
 
-func (cc *CIConfig) UseRegistryLogin() bool {
+func (cc CIConfig) UseRegistryLogin() bool {
 	return cc.useRegistryLogin
 }
 
-func (cc *CIConfig) UseSelfHostedRunner() bool {
+func (cc CIConfig) UseSelfHostedRunner() bool {
 	return cc.useSelfHostedRunner
 }
 
-func (cc *CIConfig) UseRemoteBuild() bool {
+func (cc CIConfig) UseRemoteBuild() bool {
 	return cc.useRemoteBuild
 }
 
-func (cc *CIConfig) UseWorkflowDispatch() bool {
+func (cc CIConfig) UseWorkflowDispatch() bool {
 	return cc.useWorkflowDispatch
 }
 
-func (cc *CIConfig) KubeconfigSecret() string {
+func (cc CIConfig) KubeconfigSecret() string {
 	return cc.kubeconfigSecret
 }
 
-func (cc *CIConfig) RegistryLoginUrlVar() string {
+func (cc CIConfig) RegistryLoginUrlVar() string {
 	return cc.registryLoginUrlVar
 }
 
-func (cc *CIConfig) RegistryUserVar() string {
+func (cc CIConfig) RegistryUserVar() string {
 	return cc.registryUserVar
 }
 
-func (cc *CIConfig) RegistryPassSecret() string {
+func (cc CIConfig) RegistryPassSecret() string {
 	return cc.registryPassSecret
 }
 
-func (cc *CIConfig) RegistryUrlVar() string {
+func (cc CIConfig) RegistryUrlVar() string {
 	return cc.registryUrlVar
 }
 
-func (cc *CIConfig) Force() bool {
+func (cc CIConfig) Force() bool {
 	return cc.force
+}
+
+func (cc CIConfig) Verbose() bool {
+	return cc.verbose
+}
+
+func (cc CIConfig) OutputPath() string {
+	return filepath.Join(cc.githubWorkflowDir, cc.githubWorkflowFilename)
 }

--- a/cmd/ci/printer.go
+++ b/cmd/ci/printer.go
@@ -1,0 +1,120 @@
+package ci
+
+import (
+	"fmt"
+	"io"
+)
+
+const (
+	MainLayoutPlainText = `
+GitHub Workflow Configuration
+  Workflow filepath:  %s
+  Workflow name:      %s
+  Branch:             %s
+  Build:              %s
+  Runner:             %s
+  Registry login:     %s
+  Manual dispatch:    %s
+  Workflow overwrite: %s
+`
+	RequireManyPlainText = `
+  Required Secrets & Variables:
+    %s
+    %s
+    %s
+    %s
+    %s
+`
+
+	RequireOnePlainText = `  Required secret:    %s
+`
+
+	PostExportManyPlainText = `
+GitHub Workflow created at: %s
+
+Create the following Secrets & Variables on github.com:
+  %s
+  %s
+  %s
+  %s
+  %s
+`
+
+	PostExportOnePlainText = `
+GitHub Workflow created at: %s
+
+Create the following Secret on github.com: %s
+`
+)
+
+func PrintConfiguration(w io.Writer, conf CIConfig) error {
+	if _, err := fmt.Fprintf(w, MainLayoutPlainText,
+		conf.OutputPath(),
+		conf.WorkflowName(),
+		conf.Branch(),
+		builder(conf),
+		runner(conf),
+		enabledOrDisabled(conf.UseRegistryLogin()),
+		enabledOrDisabled(conf.UseWorkflowDispatch()),
+		enabledOrDisabled(conf.Force()),
+	); err != nil {
+		return err
+	}
+
+	if conf.UseRegistryLogin() {
+		if _, err := fmt.Fprintf(w, RequireManyPlainText,
+			secretsPrefix(conf.KubeconfigSecret()),
+			secretsPrefix(conf.RegistryPassSecret()),
+			varsPrefix(conf.RegistryLoginUrlVar()),
+			varsPrefix(conf.RegistryUserVar()),
+			varsPrefix(conf.RegistryUrlVar()),
+		); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	if _, err := fmt.Fprintf(w,
+		RequireOnePlainText,
+		secretsPrefix(conf.KubeconfigSecret()),
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func PrintPostExportMessage(w io.Writer, conf CIConfig) error {
+	if conf.UseRegistryLogin() {
+		_, err := fmt.Fprintf(w, PostExportManyPlainText,
+			conf.OutputPath(),
+			secretsPrefix(conf.KubeconfigSecret()),
+			secretsPrefix(conf.RegistryPassSecret()),
+			varsPrefix(conf.RegistryLoginUrlVar()),
+			varsPrefix(conf.RegistryUserVar()),
+			varsPrefix(conf.RegistryUrlVar()),
+		)
+		return err
+	}
+
+	_, err := fmt.Fprintf(w, PostExportOnePlainText,
+		conf.OutputPath(),
+		secretsPrefix(conf.KubeconfigSecret()),
+	)
+	return err
+}
+
+func builder(conf CIConfig) string {
+	if conf.UseRemoteBuild() {
+		return "remote"
+	}
+	return "host"
+}
+
+func enabledOrDisabled(value bool) string {
+	if value {
+		return "enabled"
+	}
+	return "disabled"
+}

--- a/cmd/ci/printer_test.go
+++ b/cmd/ci/printer_test.go
@@ -1,0 +1,73 @@
+package ci
+
+import (
+	"errors"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+var errWrite = errors.New("write failed")
+
+type failWriter struct {
+	failOnCall int
+	callCount  int
+	err        error
+}
+
+func (fw *failWriter) Write(p []byte) (int, error) {
+	fw.callCount++
+	if fw.callCount >= fw.failOnCall {
+		return 0, fw.err
+	}
+	return len(p), nil
+}
+
+func TestPrintConfigurationFail(t *testing.T) {
+	t.Run("main layout write fails", func(t *testing.T) {
+		w := &failWriter{failOnCall: 1, err: errWrite}
+		conf := CIConfig{}
+
+		err := PrintConfiguration(w, conf)
+
+		assert.Error(t, err, errWrite.Error())
+	})
+
+	t.Run("registry secrets write fails", func(t *testing.T) {
+		w := &failWriter{failOnCall: 2, err: errWrite}
+		conf := CIConfig{useRegistryLogin: true}
+
+		err := PrintConfiguration(w, conf)
+
+		assert.Error(t, err, errWrite.Error())
+	})
+
+	t.Run("single secret write fails", func(t *testing.T) {
+		w := &failWriter{failOnCall: 2, err: errWrite}
+		conf := CIConfig{useRegistryLogin: false}
+
+		err := PrintConfiguration(w, conf)
+
+		assert.Error(t, err, errWrite.Error())
+	})
+}
+
+func TestPrintPostExportMessageFail(t *testing.T) {
+	t.Run("with registry login write fails", func(t *testing.T) {
+		w := &failWriter{failOnCall: 1, err: errWrite}
+		conf := CIConfig{useRegistryLogin: true}
+
+		err := PrintPostExportMessage(w, conf)
+
+		assert.Error(t, err, errWrite.Error())
+	})
+
+	t.Run("without registry login write fails", func(t *testing.T) {
+		w := &failWriter{failOnCall: 1, err: errWrite}
+		conf := CIConfig{useRegistryLogin: false}
+
+		err := PrintPostExportMessage(w, conf)
+
+		assert.Error(t, err, errWrite.Error())
+	})
+}

--- a/pkg/k8s/deployer.go
+++ b/pkg/k8s/deployer.go
@@ -70,7 +70,7 @@ func WithDeployerDecorator(decorator deployer.DeployDecorator) DeployerOpt {
 }
 
 func onClusterFix(f fn.Function) fn.Function {
-	// This only exists because of a bootstapping problem with On-Cluster
+	// This only exists because of a bootstrapping problem with On-Cluster
 	// builds:  It appears that, when sending a function to be built on-cluster
 	// the target namespace is not being transmitted in the pipeline
 	// configuration.  We should figure out how to transmit this information
@@ -98,7 +98,7 @@ func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (fn.DeploymentResu
 	// This is minimal logic currently required of all deployer impls.
 	// If f.Namespace is defined, this is the (possibly new) target
 	// namespace.  Otherwise use the last deployed namespace.  Error if
-	// neither are set.  The logic which arbitrates between curret k8s context,
+	// neither are set.  The logic which arbitrates between current k8s context,
 	// flags, environment variables and global defaults to determine the
 	// effective namespace is not logic for the deployer implementation, which
 	// should have a minimum of logic.  In this case limited to "new ns or


### PR DESCRIPTION
<!-- PR Title: Add user messages to config ci -->

# Changes

- :gift: Add `--verbose` flag that prints full workflow configuration (name, output path, branch, build type, runner, registry login, dispatch, and required secrets/variables)
- :gift: Add post-export message listing the GitHub Secrets and Variables the user needs to create
- :broom: Extract shared helpers (`runner`, `secretsPrefix`, `varsPrefix`, `newSecret`, `newVariable`) into `common.go`
- :broom: Add `OutputPath()` getter to `CIConfig` and refactor printer to use getters instead of direct field access
- :broom: Refactor verbose tests to use exported format constants

/kind enhancement

Relates to #3256

**Release Note**

```release-note
`func config ci` now shows required GitHub Secrets and Variables after workflow creation, and supports `--verbose` for full configuration details.
```

**Docs**

```docs

```
## Screenshots

> [!IMPORTANT]  
> **Ignore** the switched workflow filepath / workflow name in the first image. Its fixed.

<img width="1156" height="238" alt="Screenshot From 2026-02-26 12-36-15" src="https://github.com/user-attachments/assets/a0166732-55ab-4584-8bea-3b4189e847eb" />
<img width="1070" height="120" alt="Screenshot From 2026-02-26 12-36-05" src="https://github.com/user-attachments/assets/bb6b5942-e5fc-4a3a-9650-bc5bf63f9f7d" />
<img width="1138" height="352" alt="Screenshot From 2026-02-26 12-35-47" src="https://github.com/user-attachments/assets/96192851-09bb-4ae1-813f-fd33572abd1b" />
<img width="1067" height="231" alt="Screenshot From 2026-02-26 12-35-29" src="https://github.com/user-attachments/assets/8d6509c4-181c-4486-ad3b-7986c267b644" />
