### PR TITLE
Feature: Add test step to CI workflow.

### DIFF
--- a/cmd/ci/common.go
+++ b/cmd/ci/common.go
@@ -3,7 +3,7 @@ package ci
 import "fmt"
 
 func runner(conf CIConfig) string {
-	if conf.UseSelfHostedRunner() {
+	if conf.SelfHostedRunner() {
 		return "self-hosted"
 	}
 	return "ubuntu-latest"

--- a/cmd/ci/config.go
+++ b/cmd/ci/config.go
@@ -42,17 +42,20 @@ const (
 	RegistryUrlVariableNameFlag    = "registry-url-variable-name"
 	DefaultRegistryUrlVariableName = "REGISTRY_URL"
 
-	UseRegistryLoginFlag    = "use-registry-login"
-	DefaultUseRegistryLogin = true
+	RegistryLoginFlag    = "registry-login"
+	DefaultRegistryLogin = true
 
 	WorkflowDispatchFlag    = "workflow-dispatch"
 	DefaultWorkflowDispatch = false
 
-	UseRemoteBuildFlag    = "remote"
-	DefaultUseRemoteBuild = false
+	RemoteBuildFlag    = "remote"
+	DefaultRemoteBuild = false
 
-	UseSelfHostedRunnerFlag    = "self-hosted-runner"
-	DefaultUseSelfHostedRunner = false
+	SelfHostedRunnerFlag    = "self-hosted-runner"
+	DefaultSelfHostedRunner = false
+
+	TestStepFlag    = "test-step"
+	DefaultTestStep = true
 
 	ForceFlag    = "force"
 	DefaultForce = false
@@ -73,10 +76,11 @@ type CIConfig struct {
 	registryUserVar,
 	registryPassSecret,
 	registryUrlVar string
-	useRegistryLogin,
-	useSelfHostedRunner,
-	useRemoteBuild,
-	useWorkflowDispatch,
+	registryLogin,
+	selfHostedRunner,
+	remoteBuild,
+	workflowDispatch,
+	testStep,
 	force,
 	verbose bool
 }
@@ -113,10 +117,11 @@ func NewCIConfig(
 		registryUserVar:        viper.GetString(RegistryUserVariableNameFlag),
 		registryPassSecret:     viper.GetString(RegistryPassSecretNameFlag),
 		registryUrlVar:         viper.GetString(RegistryUrlVariableNameFlag),
-		useRegistryLogin:       viper.GetBool(UseRegistryLoginFlag),
-		useSelfHostedRunner:    viper.GetBool(UseSelfHostedRunnerFlag),
-		useRemoteBuild:         viper.GetBool(UseRemoteBuildFlag),
-		useWorkflowDispatch:    viper.GetBool(WorkflowDispatchFlag),
+		registryLogin:          viper.GetBool(RegistryLoginFlag),
+		selfHostedRunner:       viper.GetBool(SelfHostedRunnerFlag),
+		remoteBuild:            viper.GetBool(RemoteBuildFlag),
+		workflowDispatch:       viper.GetBool(WorkflowDispatchFlag),
+		testStep:               viper.GetBool(TestStepFlag),
 		force:                  viper.GetBool(ForceFlag),
 		verbose:                viper.GetBool(VerboseFlag),
 	}, nil
@@ -165,7 +170,7 @@ func resolveWorkflowName(explicit bool) string {
 		return workflowName
 	}
 
-	if viper.GetBool(UseRemoteBuildFlag) {
+	if viper.GetBool(RemoteBuildFlag) {
 		return DefaultRemoteBuildWorkflowName
 	}
 
@@ -180,32 +185,20 @@ func (cc CIConfig) FnGitHubWorkflowFilepath(fnRoot string) string {
 	return filepath.Join(cc.fnGitHubWorkflowDir(fnRoot), cc.githubWorkflowFilename)
 }
 
-func (cc CIConfig) Path() string {
-	return cc.path
+func (cc CIConfig) OutputPath() string {
+	return filepath.Join(cc.githubWorkflowDir, cc.githubWorkflowFilename)
 }
 
-func (cc CIConfig) WorkflowName() string {
-	return cc.workflowName
+func (cc CIConfig) Path() string {
+	return cc.path
 }
 
 func (cc CIConfig) Branch() string {
 	return cc.branch
 }
 
-func (cc CIConfig) UseRegistryLogin() bool {
-	return cc.useRegistryLogin
-}
-
-func (cc CIConfig) UseSelfHostedRunner() bool {
-	return cc.useSelfHostedRunner
-}
-
-func (cc CIConfig) UseRemoteBuild() bool {
-	return cc.useRemoteBuild
-}
-
-func (cc CIConfig) UseWorkflowDispatch() bool {
-	return cc.useWorkflowDispatch
+func (cc CIConfig) WorkflowName() string {
+	return cc.workflowName
 }
 
 func (cc CIConfig) KubeconfigSecret() string {
@@ -228,14 +221,30 @@ func (cc CIConfig) RegistryUrlVar() string {
 	return cc.registryUrlVar
 }
 
+func (cc CIConfig) RegistryLogin() bool {
+	return cc.registryLogin
+}
+
+func (cc CIConfig) SelfHostedRunner() bool {
+	return cc.selfHostedRunner
+}
+
+func (cc CIConfig) RemoteBuild() bool {
+	return cc.remoteBuild
+}
+
+func (cc CIConfig) WorkflowDispatch() bool {
+	return cc.workflowDispatch
+}
+
+func (cc CIConfig) TestStep() bool {
+	return cc.testStep
+}
+
 func (cc CIConfig) Force() bool {
 	return cc.force
 }
 
 func (cc CIConfig) Verbose() bool {
 	return cc.verbose
-}
-
-func (cc CIConfig) OutputPath() string {
-	return filepath.Join(cc.githubWorkflowDir, cc.githubWorkflowFilename)
 }

--- a/cmd/ci/printer.go
+++ b/cmd/ci/printer.go
@@ -13,6 +13,7 @@ GitHub Workflow Configuration
   Branch:             %s
   Build:              %s
   Runner:             %s
+  Test step:          %s
   Registry login:     %s
   Manual dispatch:    %s
   Workflow overwrite: %s
@@ -54,14 +55,15 @@ func PrintConfiguration(w io.Writer, conf CIConfig) error {
 		conf.Branch(),
 		builder(conf),
 		runner(conf),
-		enabledOrDisabled(conf.UseRegistryLogin()),
-		enabledOrDisabled(conf.UseWorkflowDispatch()),
+		enabledOrDisabled(conf.TestStep()),
+		enabledOrDisabled(conf.RegistryLogin()),
+		enabledOrDisabled(conf.WorkflowDispatch()),
 		enabledOrDisabled(conf.Force()),
 	); err != nil {
 		return err
 	}
 
-	if conf.UseRegistryLogin() {
+	if conf.RegistryLogin() {
 		if _, err := fmt.Fprintf(w, RequireManyPlainText,
 			secretsPrefix(conf.KubeconfigSecret()),
 			secretsPrefix(conf.RegistryPassSecret()),
@@ -86,7 +88,7 @@ func PrintConfiguration(w io.Writer, conf CIConfig) error {
 }
 
 func PrintPostExportMessage(w io.Writer, conf CIConfig) error {
-	if conf.UseRegistryLogin() {
+	if conf.RegistryLogin() {
 		_, err := fmt.Fprintf(w, PostExportManyPlainText,
 			conf.OutputPath(),
 			secretsPrefix(conf.KubeconfigSecret()),
@@ -106,7 +108,7 @@ func PrintPostExportMessage(w io.Writer, conf CIConfig) error {
 }
 
 func builder(conf CIConfig) string {
-	if conf.UseRemoteBuild() {
+	if conf.RemoteBuild() {
 		return "remote"
 	}
 	return "host"

--- a/cmd/ci/printer_test.go
+++ b/cmd/ci/printer_test.go
@@ -35,7 +35,7 @@ func TestPrintConfigurationFail(t *testing.T) {
 
 	t.Run("registry secrets write fails", func(t *testing.T) {
 		w := &failWriter{failOnCall: 2, err: errWrite}
-		conf := CIConfig{useRegistryLogin: true}
+		conf := CIConfig{registryLogin: true}
 
 		err := PrintConfiguration(w, conf)
 
@@ -44,7 +44,7 @@ func TestPrintConfigurationFail(t *testing.T) {
 
 	t.Run("single secret write fails", func(t *testing.T) {
 		w := &failWriter{failOnCall: 2, err: errWrite}
-		conf := CIConfig{useRegistryLogin: false}
+		conf := CIConfig{registryLogin: false}
 
 		err := PrintConfiguration(w, conf)
 
@@ -55,7 +55,7 @@ func TestPrintConfigurationFail(t *testing.T) {
 func TestPrintPostExportMessageFail(t *testing.T) {
 	t.Run("with registry login write fails", func(t *testing.T) {
 		w := &failWriter{failOnCall: 1, err: errWrite}
-		conf := CIConfig{useRegistryLogin: true}
+		conf := CIConfig{registryLogin: true}
 
 		err := PrintPostExportMessage(w, conf)
 
@@ -64,7 +64,7 @@ func TestPrintPostExportMessageFail(t *testing.T) {
 
 	t.Run("without registry login write fails", func(t *testing.T) {
 		w := &failWriter{failOnCall: 1, err: errWrite}
-		conf := CIConfig{useRegistryLogin: false}
+		conf := CIConfig{registryLogin: false}
 
 		err := PrintPostExportMessage(w, conf)
 

--- a/cmd/ci/workflow.go
+++ b/cmd/ci/workflow.go
@@ -41,9 +41,10 @@ type step struct {
 	With map[string]string `yaml:"with,omitempty"`
 }
 
-func NewGitHubWorkflow(conf CIConfig) *githubWorkflow {
+func NewGitHubWorkflow(conf CIConfig, runtime string, messageWriter io.Writer) *githubWorkflow {
 	var steps []step
 	steps = createCheckoutStep(steps)
+	steps = createRuntimeTestStep(conf, steps, runtime, messageWriter)
 	steps = createK8ContextStep(conf, steps)
 	steps = createRegistryLoginStep(conf, steps)
 	steps = createFuncCLIInstallStep(steps)
@@ -61,23 +62,36 @@ func NewGitHubWorkflow(conf CIConfig) *githubWorkflow {
 	}
 }
 
-func createPushTrigger(conf CIConfig) workflowTriggers {
-	result := workflowTriggers{
-		Push: &pushTrigger{Branches: []string{conf.Branch()}},
-	}
-
-	if conf.UseWorkflowDispatch() {
-		result.WorkflowDispatch = &struct{}{}
-	}
-
-	return result
-}
-
 func createCheckoutStep(steps []step) []step {
 	checkoutCode := newStep("Checkout code").
 		withUses("actions/checkout@v4")
 
 	return append(steps, *checkoutCode)
+}
+
+func createRuntimeTestStep(conf CIConfig, steps []step, runtime string, messageWriter io.Writer) []step {
+	if !conf.TestStep() {
+		return steps
+	}
+
+	testStep := newStep("Run tests")
+
+	switch runtime {
+	case "go":
+		testStep.withRun("go test ./...")
+	case "node", "typescript":
+		testStep.withRun("npm ci && npm test")
+	case "python":
+		testStep.withRun("pip install . && python -m pytest")
+	case "quarkus":
+		testStep.withRun("./mvnw test")
+	default:
+		// best-effort user message; errors are non-critical
+		_, _ = fmt.Fprintf(messageWriter, "WARNING: test step not supported for runtime %s\n", runtime)
+		return steps
+	}
+
+	return append(steps, *testStep)
 }
 
 func createK8ContextStep(conf CIConfig, steps []step) []step {
@@ -90,7 +104,7 @@ func createK8ContextStep(conf CIConfig, steps []step) []step {
 }
 
 func createRegistryLoginStep(conf CIConfig, steps []step) []step {
-	if !conf.UseRegistryLogin() {
+	if !conf.RegistryLogin() {
 		return steps
 	}
 
@@ -114,18 +128,30 @@ func createFuncCLIInstallStep(steps []step) []step {
 
 func createFuncDeployStep(conf CIConfig, steps []step) []step {
 	runFuncDeploy := "func deploy"
-	if conf.UseRemoteBuild() {
+	if conf.RemoteBuild() {
 		runFuncDeploy += " --remote"
 	}
 
 	registryUrl := newVariable(conf.RegistryUrlVar())
-	if conf.UseRegistryLogin() {
+	if conf.RegistryLogin() {
 		registryUrl = newVariable(conf.RegistryLoginUrlVar()) + "/" + newVariable(conf.RegistryUserVar())
 	}
 	deployFunc := newStep("Deploy function").
 		withRun(runFuncDeploy + " --registry=" + registryUrl + " -v")
 
 	return append(steps, *deployFunc)
+}
+
+func createPushTrigger(conf CIConfig) workflowTriggers {
+	result := workflowTriggers{
+		Push: &pushTrigger{Branches: []string{conf.Branch()}},
+	}
+
+	if conf.WorkflowDispatch() {
+		result.WorkflowDispatch = &struct{}{}
+	}
+
+	return result
 }
 
 func newStep(name string) *step {

--- a/cmd/ci/workflow_test.go
+++ b/cmd/ci/workflow_test.go
@@ -17,7 +17,7 @@ func TestGitHubWorkflow_Export(t *testing.T) {
 		common.WorkDirStub("", nil),
 		false,
 	)
-	gw := ci.NewGitHubWorkflow(cfg)
+	gw := ci.NewGitHubWorkflow(cfg, "", &bytes.Buffer{})
 	bufferWriter := ci.NewBufferWriter()
 
 	// WHEN

--- a/cmd/config_ci.go
+++ b/cmd/config_ci.go
@@ -20,19 +20,20 @@ func NewConfigCICmd(
 		Use:   "ci",
 		Short: "Generate a GitHub Workflow for function deployment",
 		PreRunE: bindEnv(
-			ci.PlatformFlag,
 			ci.PathFlag,
-			ci.UseRegistryLoginFlag,
-			ci.WorkflowDispatchFlag,
-			ci.UseRemoteBuildFlag,
-			ci.UseSelfHostedRunnerFlag,
+			ci.PlatformFlag,
+			ci.RegistryLoginFlag,
 			ci.WorkflowNameFlag,
-			ci.BranchFlag,
 			ci.KubeconfigSecretNameFlag,
 			ci.RegistryLoginUrlVariableNameFlag,
 			ci.RegistryUserVariableNameFlag,
 			ci.RegistryPassSecretNameFlag,
 			ci.RegistryUrlVariableNameFlag,
+			ci.WorkflowDispatchFlag,
+			ci.RemoteBuildFlag,
+			ci.SelfHostedRunnerFlag,
+			ci.TestStepFlag,
+			ci.BranchFlag,
 			ci.ForceFlag,
 			ci.VerboseFlag,
 		),
@@ -52,50 +53,24 @@ func NewConfigCICmd(
 		},
 	}
 
+	addPathFlag(cmd)
+
 	cmd.Flags().String(
 		ci.PlatformFlag,
 		ci.DefaultPlatform,
 		"Pick a CI/CD platform for which a manifest will be generated. Currently only GitHub is supported.",
 	)
 
-	addPathFlag(cmd)
-	addVerboseFlag(cmd, ci.DefaultVerbose)
-
-	cmd.Flags().Bool(
-		ci.UseRegistryLoginFlag,
-		ci.DefaultUseRegistryLogin,
-		"Add a registry login step in the github workflow",
-	)
-
-	cmd.Flags().Bool(
-		ci.WorkflowDispatchFlag,
-		ci.DefaultWorkflowDispatch,
-		"Add a workflow dispatch trigger for manual workflow execution",
-	)
-	_ = cmd.Flags().MarkHidden(ci.WorkflowDispatchFlag)
-
-	cmd.Flags().Bool(
-		ci.UseRemoteBuildFlag,
-		ci.DefaultUseRemoteBuild,
-		"Build the function on a Tekton-enabled cluster",
-	)
-
-	cmd.Flags().Bool(
-		ci.UseSelfHostedRunnerFlag,
-		ci.DefaultUseSelfHostedRunner,
-		"Use a 'self-hosted' runner instead of the default 'ubuntu-latest' for local runner execution",
+	cmd.Flags().String(
+		ci.BranchFlag,
+		"",
+		"Use a custom branch name in the workflow",
 	)
 
 	cmd.Flags().String(
 		ci.WorkflowNameFlag,
 		ci.DefaultWorkflowName,
 		"Use a custom workflow name",
-	)
-
-	cmd.Flags().String(
-		ci.BranchFlag,
-		"",
-		"Use a custom branch name in the workflow",
 	)
 
 	cmd.Flags().String(
@@ -129,10 +104,43 @@ func NewConfigCICmd(
 	)
 
 	cmd.Flags().Bool(
+		ci.RegistryLoginFlag,
+		ci.DefaultRegistryLogin,
+		"Add a registry login step in the github workflow",
+	)
+
+	cmd.Flags().Bool(
+		ci.WorkflowDispatchFlag,
+		ci.DefaultWorkflowDispatch,
+		"Add a workflow dispatch trigger for manual workflow execution",
+	)
+	_ = cmd.Flags().MarkHidden(ci.WorkflowDispatchFlag)
+
+	cmd.Flags().Bool(
+		ci.RemoteBuildFlag,
+		ci.DefaultRemoteBuild,
+		"Build the function on a Tekton-enabled cluster",
+	)
+
+	cmd.Flags().Bool(
+		ci.SelfHostedRunnerFlag,
+		ci.DefaultSelfHostedRunner,
+		"Use a 'self-hosted' runner instead of the default 'ubuntu-latest' for local runner execution",
+	)
+
+	cmd.Flags().Bool(
+		ci.TestStepFlag,
+		ci.DefaultTestStep,
+		"Add a language-specific test step (supported: go, node, typescript, python, quarkus)",
+	)
+
+	cmd.Flags().Bool(
 		ci.ForceFlag,
 		ci.DefaultForce,
 		"Use to overwrite an existing GitHub workflow",
 	)
+
+	addVerboseFlag(cmd, ci.DefaultVerbose)
 
 	return cmd
 }
@@ -155,7 +163,7 @@ func runConfigCIGitHub(
 		return err
 	}
 
-	githubWorkflow := ci.NewGitHubWorkflow(cfg)
+	githubWorkflow := ci.NewGitHubWorkflow(cfg, f.Runtime, messageWriter)
 	path := cfg.FnGitHubWorkflowFilepath(f.Root)
 	if err := githubWorkflow.Export(path, writer, cfg.Force(), messageWriter); err != nil {
 		return err

--- a/cmd/config_ci_test.go
+++ b/cmd/config_ci_test.go
@@ -140,7 +140,7 @@ func TestNewConfigCICmd_WorkflowNameFromEnvVarPreserveWithRemote(t *testing.T) {
 func TestNewConfigCICmd_WorkflowHasNoRegistryLogin(t *testing.T) {
 	// GIVEN
 	opts := defaultOpts()
-	opts.args = append(opts.args, "--use-registry-login=false")
+	opts.args = append(opts.args, "--registry-login=false")
 
 	// WHEN
 	result := runConfigCiCmd(t, opts)
@@ -394,6 +394,7 @@ func TestNewConfigCICmd_VerboseFlagPrintsWorkflowDetails(t *testing.T) {
 			"host",
 			"ubuntu-latest",
 			"enabled",
+			"enabled",
 			"disabled",
 			"disabled",
 		) + fmt.Sprintf(ci.RequireManyPlainText,
@@ -416,6 +417,7 @@ func TestNewConfigCICmd_VerboseFlagPrintsWorkflowDetails(t *testing.T) {
 			"--self-hosted-runner",
 			"--workflow-name=Deploy Checkout Service",
 			"--remote",
+			"--test-step=false",
 			"--workflow-dispatch",
 			"--force",
 			"--kubeconfig-secret-name=DEV_CLUSTER_KUBECONFIG",
@@ -430,6 +432,7 @@ func TestNewConfigCICmd_VerboseFlagPrintsWorkflowDetails(t *testing.T) {
 			issueBranch,
 			"remote",
 			"self-hosted",
+			"disabled",
 			"enabled",
 			"enabled",
 			"enabled",
@@ -450,7 +453,7 @@ func TestNewConfigCICmd_VerboseFlagPrintsWorkflowDetails(t *testing.T) {
 		opts := defaultOpts()
 		opts.args = append(opts.args,
 			"--verbose",
-			"--use-registry-login=false",
+			"--registry-login=false",
 		)
 		expectedMessage := fmt.Sprintf(ci.MainLayoutPlainText,
 			defaultOutputPath,
@@ -458,6 +461,7 @@ func TestNewConfigCICmd_VerboseFlagPrintsWorkflowDetails(t *testing.T) {
 			issueBranch,
 			"host",
 			"ubuntu-latest",
+			"enabled",
 			"disabled",
 			"disabled",
 			"disabled",
@@ -490,7 +494,7 @@ func TestNewConfigCICmd_PostExportMessageShown(t *testing.T) {
 
 	t.Run("a message is shown with a secret for k8 which needs creation", func(t *testing.T) {
 		opts := defaultOpts()
-		opts.args = append(opts.args, "--use-registry-login=false")
+		opts.args = append(opts.args, "--registry-login=false")
 		expectedMessage := fmt.Sprintf(ci.PostExportOnePlainText,
 			defaultOutputPath,
 			"secrets."+ci.DefaultKubeconfigSecretName,
@@ -525,6 +529,86 @@ func TestNewConfigCICmd_VerboseAndPostExportMessageAreMutuallyExclusive(t *testi
 	})
 }
 
+func TestNewConfigCICmd_TestStepPerRuntime(t *testing.T) {
+	testCases := []struct {
+		name        string
+		runtime     string
+		expectedRun string
+	}{
+		{
+			name:        "go runtime adds go test step",
+			runtime:     "go",
+			expectedRun: "go test ./...",
+		},
+		{
+			name:        "nodejs runtime adds npm test step",
+			runtime:     "node",
+			expectedRun: "npm ci && npm test",
+		},
+		{
+			name:        "typescript runtime adds npm test step",
+			runtime:     "typescript",
+			expectedRun: "npm ci && npm test",
+		},
+		{
+			name:        "python runtime adds python -m pytest step",
+			runtime:     "python",
+			expectedRun: "pip install . && python -m pytest",
+		},
+		{
+			name:        "quarkus runtime adds mvnw test step",
+			runtime:     "quarkus",
+			expectedRun: "./mvnw test",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// GIVEN
+			opts := defaultOpts()
+			opts.runtime = tc.runtime
+
+			// WHEN
+			result := runConfigCiCmd(t, opts)
+
+			// THEN
+			assert.NilError(t, result.executeErr)
+			assert.Assert(t, yamlContains(result.gwYamlString, runTestStepName))
+			assert.Assert(t, yamlContains(result.gwYamlString, tc.expectedRun))
+		})
+	}
+}
+
+func TestNewConfigCICmd_TestStepSkipped(t *testing.T) {
+	t.Run("unsupported runtime skips test step and prints warning", func(t *testing.T) {
+		// GIVEN
+		opts := defaultOpts()
+		opts.runtime = "rust"
+
+		// WHEN
+		result := runConfigCiCmd(t, opts)
+
+		// THEN
+		assert.NilError(t, result.executeErr)
+		assert.Assert(t, !strings.Contains(result.gwYamlString, runTestStepName))
+		assert.Assert(t, strings.Contains(result.stdOut, "WARNING: test step not supported for runtime rust"))
+	})
+
+	t.Run("test step disabled via flag", func(t *testing.T) {
+		// GIVEN
+		opts := defaultOpts()
+		opts.args = append(opts.args, "--test-step=false")
+
+		// WHEN
+		result := runConfigCiCmd(t, opts)
+
+		// THEN
+		assert.NilError(t, result.executeErr)
+		assert.Assert(t, !strings.Contains(result.gwYamlString, runTestStepName))
+		assert.Assert(t, strings.Count(result.gwYamlString, "- name:") == 5)
+	})
+}
+
 // ---------------------
 // END: Broad Unit Tests
 
@@ -536,12 +620,14 @@ const (
 	fnName             = "github-ci-func"
 	forceWarning       = "WARNING: --force flag is set, overwriting existing GitHub Workflow file"
 	customWorkflowName = "Deploy Checkout Service"
+	runTestStepName    = "Run tests"
 )
 
 var defaultOutputPath = filepath.Join(ci.DefaultGitHubWorkflowDir, ci.DefaultGitHubWorkflowFilename)
 
 type opts struct {
 	enableFeature        bool
+	runtime              string
 	withFakeGitCliReturn struct {
 		output string
 		err    error
@@ -562,6 +648,7 @@ type opts struct {
 func defaultOpts() opts {
 	return opts{
 		enableFeature: true,
+		runtime:       "go",
 		withFakeGitCliReturn: struct {
 			output string
 			err    error
@@ -602,7 +689,7 @@ func runConfigCiCmd(
 
 	loaderSaver := common.NewMockLoaderSaver()
 	loaderSaver.LoadFn = func(path string) (fn.Function, error) {
-		return fn.Function{Root: path}, nil
+		return fn.Function{Root: path, Runtime: opts.runtime}, nil
 	}
 
 	writer := opts.withWriter
@@ -668,10 +755,13 @@ func assertDefaultWorkflowWithBranch(t *testing.T, actualGw, branch string) {
 
 	assert.Assert(t, yamlContains(actualGw, "ubuntu-latest"))
 
-	assert.Assert(t, strings.Count(actualGw, "- name:") == 5)
+	assert.Assert(t, strings.Count(actualGw, "- name:") == 6)
 
 	assert.Assert(t, yamlContains(actualGw, "Checkout code"))
 	assert.Assert(t, yamlContains(actualGw, "actions/checkout@v4"))
+
+	assert.Assert(t, yamlContains(actualGw, "Run tests"))
+	assert.Assert(t, yamlContains(actualGw, "go test ./..."))
 
 	assert.Assert(t, yamlContains(actualGw, "Setup Kubernetes context"))
 	assert.Assert(t, yamlContains(actualGw, "azure/k8s-set-context@v4"))

--- a/docs/reference/func_config_ci.md
+++ b/docs/reference/func_config_ci.md
@@ -9,17 +9,21 @@ func config ci
 ### Options
 
 ```
-      --branch string                             Use a custom branch name in the workflow (default "main")
+      --branch string                             Use a custom branch name in the workflow
+      --force                                     Use to overwrite an existing GitHub workflow
   -h, --help                                      help for ci
       --kubeconfig-secret-name string             Use a custom secret name in the workflow, e.g. secret.YOUR_CUSTOM_KUBECONFIG (default "KUBECONFIG")
   -p, --path string                               Path to the function.  Default is current directory ($FUNC_PATH)
+      --platform string                           Pick a CI/CD platform for which a manifest will be generated. Currently only GitHub is supported. (default "github")
+      --registry-login                            Add a registry login step in the github workflow (default true)
       --registry-login-url-variable-name string   Use a custom registry login url variable name in the workflow, e.g. vars.YOUR_REGISTRY_LOGIN_URL (default "REGISTRY_LOGIN_URL")
       --registry-pass-secret-name string          Use a custom registry pass secret name in the workflow, e.g. secret.YOUR_REGISTRY_PASSWORD (default "REGISTRY_PASSWORD")
       --registry-url-variable-name string         Use a custom registry url variable name in the workflow, e.g. vars.YOUR_REGISTRY_URL (default "REGISTRY_URL")
       --registry-user-variable-name string        Use a custom registry user variable name in the workflow, e.g. vars.YOUR_REGISTRY_USER (default "REGISTRY_USERNAME")
       --remote                                    Build the function on a Tekton-enabled cluster
       --self-hosted-runner                        Use a 'self-hosted' runner instead of the default 'ubuntu-latest' for local runner execution
-      --use-registry-login                        Add a registry login step in the github workflow (default true)
+      --test-step                                 Add a language-specific test step (supported: go, node, python) (default true)
+  -v, --verbose                                   Print verbose logs ($FUNC_VERBOSE)
       --workflow-name string                      Use a custom workflow name (default "Func Deploy")
 ```
 

--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -70,7 +70,7 @@ type Function struct {
 	// validated by the client.
 	Domain string `yaml:"domain,omitempty"`
 
-	// Runtime is the language plus context.  nodejs|go|quarkus|rust etc.
+	// Runtime is the language plus context.  node|go|quarkus|rust etc.
 	Runtime string `yaml:"runtime,omitempty"`
 
 	// Template for the function.

--- a/schema/func_yaml-schema.json
+++ b/schema/func_yaml-schema.json
@@ -176,7 +176,7 @@
 				},
 				"runtime": {
 					"type": "string",
-					"description": "Runtime is the language plus context.  nodejs|go|quarkus|rust etc."
+					"description": "Runtime is the language plus context.  node|go|quarkus|rust etc."
 				},
 				"registry": {
 					"type": "string",


### PR DESCRIPTION
# Changes

- :gift: Add `--test-step` flag to `func config ci`, enabled by default, disable with `--test-step=false`
- :gift: Generate a "Run tests" step in the GitHub Actions workflow that executes before deployment
- :gift: Select the test command based on function runtime: `go test ./...` for Go, `npm test` for Node.js, `python -m pytest` for Python
- :gift: Skip the test step with a warning for unsupported runtimes

/kind enhancement

Relates to #3256

**Release Note**

```release-note
New `--test-step` flag for `func config ci` adds a runtime-appropriate test step to the CI workflow before deployment.
```

**Docs**

```docs

```
