### PR TITLE
fix: enable prompt in run

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -154,7 +154,9 @@ func runRun(cmd *cobra.Command, newClient ClientFactory) (err error) {
 		cfg runConfig
 		f   fn.Function
 	)
-	cfg = newRunConfig(cmd) // Will add Prompt on upcoming UX refactor
+	if cfg, err = newRunConfig(cmd).Prompt(); err != nil {
+		return wrapPromptError(err, "run")
+	}
 
 	if f, err = fn.NewFunction(cfg.Path); err != nil {
 		return


### PR DESCRIPTION
enable prompt in run
```release-note
func run without registry pre-set now prompts for it on first run
```

/fixes https://github.com/knative/func/issues/3195