### PR TITLE
use python3 instead of hardcoded python version in assembler

### DIFF
--- a/pkg/s2i/assemblers.go
+++ b/pkg/s2i/assemblers.go
@@ -106,7 +106,7 @@ function should_collectstatic() {
 function virtualenv_bin() {
     # New versions of Python (>3.6) should use venv module
     # from stdlib instead of virtualenv package
-    python3.9 -m venv $1
+    python3 -m venv $1
 }
 
 # Install pipenv or micropipenv to the separate virtualenv to isolate it


### PR DESCRIPTION
Dont hardcode the python minor version in s2i assemble script. This way the version can be resolved based on the builder-image