### PR TITLE
fix: e2e test naming to match category conventions + add verbose flag to 'func subscribe'

### DIFF
--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -28,7 +28,7 @@ and an 'extension' attribute for the value 'my-extension-value'.
 {{rootCmdUse}} subscribe --filter type=com.example --filter extension=my-extension-value --source my-broker
 `,
 		SuggestFor: []string{"subcsribe"}, //nolint:misspell
-		PreRunE:    bindEnv("filter", "source"),
+		PreRunE:    bindEnv("filter", "source", "verbose"),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runSubscribe(cmd)
 		},
@@ -39,6 +39,7 @@ and an 'extension' attribute for the value 'my-extension-value'.
 	cmd.Flags().StringP("source", "s", "default", "The source, like a Knative Broker")
 
 	addPathFlag(cmd)
+	addVerboseFlag(cmd, false)
 
 	return cmd
 }

--- a/docs/reference/func_subscribe.md
+++ b/docs/reference/func_subscribe.md
@@ -35,6 +35,7 @@ func subscribe --filter type=com.example --filter extension=my-extension-value -
   -h, --help                 help for subscribe
   -p, --path string          Path to the function.  Default is current directory ($FUNC_PATH)
   -s, --source string        The source, like a Knative Broker (default "default")
+  -v, --verbose              Print verbose logs ($FUNC_VERBOSE)
 ```
 
 ### SEE ALSO

--- a/e2e/e2e_credentials_test.go
+++ b/e2e/e2e_credentials_test.go
@@ -13,16 +13,16 @@ import (
 // Test that FUNC_USERNAME/FUNC_PASSWORD are picked up by all pushers
 // by asserting the pusher's log message includes the provided username.
 // This test runs for host, pack, and s2i builders automatically.
-func TestCredentials_DockerPusher_EnvUsed(t *testing.T) {
+func TestCore_CredentialsDockerPusher(t *testing.T) {
 	const user = "e2euser"
 	const pass = "e2epass"
-	t.Setenv("FUNC_USERNAME", user)
-	t.Setenv("FUNC_PASSWORD", pass)
 
 	for _, builder := range []string{"host", "pack", "s2i"} {
 		t.Run(builder, func(t *testing.T) {
 			name := fmt.Sprintf("func-e2e-creds-docker-%s", builder)
 			_ = fromCleanEnv(t, name)
+			t.Setenv("FUNC_USERNAME", user)
+			t.Setenv("FUNC_PASSWORD", pass)
 
 			// Init a simple function
 			if err := newCmd(t, "init", "-l=go").Run(); err != nil {

--- a/e2e/e2e_trigger_sync_test.go
+++ b/e2e/e2e_trigger_sync_test.go
@@ -15,9 +15,9 @@ import (
 	fn "knative.dev/func/pkg/functions"
 )
 
-// TestTriggerSync_StaleTriggerCleanup verifies that stale triggers are deleted
+// TestMetadata_TriggerSyncStaleTriggerCleanup verifies that stale triggers are deleted
 // when subscriptions are removed from func.yaml
-func TestTriggerSync_StaleTriggerCleanup(t *testing.T) {
+func TestMetadata_TriggerSyncStaleTriggerCleanup(t *testing.T) {
 	brokerName := "default"
 	createBrokerWithCheck(t, Namespace, brokerName)
 
@@ -101,9 +101,9 @@ func TestTriggerSync_StaleTriggerCleanup(t *testing.T) {
 	t.Logf("Stale trigger deleted, 1 trigger remains: %v", triggersAfter)
 }
 
-// TestTriggerSync_ManualTriggerPreservation verifies that manually created
+// TestMetadata_TriggerSyncManualTriggerPreservation verifies that manually created
 // triggers (without managed-by annotation) are NOT deleted during sync
-func TestTriggerSync_ManualTriggerPreservation(t *testing.T) {
+func TestMetadata_TriggerSyncManualTriggerPreservation(t *testing.T) {
 	brokerName := "default"
 	createBrokerWithCheck(t, Namespace, brokerName)
 
@@ -166,9 +166,9 @@ func TestTriggerSync_ManualTriggerPreservation(t *testing.T) {
 	t.Log("Managed trigger still exists")
 }
 
-// TestTriggerSync_AddSubscription verifies that new triggers are created
+// TestMetadata_TriggerSyncAddSubscription verifies that new triggers are created
 // when subscriptions are added
-func TestTriggerSync_AddSubscription(t *testing.T) {
+func TestMetadata_TriggerSyncAddSubscription(t *testing.T) {
 	brokerName := "default"
 	createBrokerWithCheck(t, Namespace, brokerName)
 
@@ -232,9 +232,9 @@ func TestTriggerSync_AddSubscription(t *testing.T) {
 	t.Logf("New trigger created, 2 triggers total: %v", triggersAfter)
 }
 
-// TestTriggerSync_Idempotency verifies that repeated deploys with the same
+// TestMetadata_TriggerSyncIdempotency verifies that repeated deploys with the same
 // subscriptions don't create duplicate triggers
-func TestTriggerSync_Idempotency(t *testing.T) {
+func TestMetadata_TriggerSyncIdempotency(t *testing.T) {
 	brokerName := "default"
 	createBrokerWithCheck(t, Namespace, brokerName)
 
@@ -306,9 +306,9 @@ func TestTriggerSync_Idempotency(t *testing.T) {
 	t.Log("Idempotency verified: 3 redeploys produced same triggers")
 }
 
-// TestTriggerSync_RemoveAllSubscriptions verifies that all managed triggers
+// TestMetadata_TriggerSyncRemoveAllSubscriptions verifies that all managed triggers
 // are deleted when all subscriptions are removed
-func TestTriggerSync_RemoveAllSubscriptions(t *testing.T) {
+func TestMetadata_TriggerSyncRemoveAllSubscriptions(t *testing.T) {
 	brokerName := "default"
 	createBrokerWithCheck(t, Namespace, brokerName)
 


### PR DESCRIPTION
Some e2e test never actually ran!... fix this for e2e scripts accept a naming convention
Had to create a verbose flag for `func subscribe` since it was lacking the implementation as well