### PR TITLE
fix: workaround podman bug wrt error reporting

### DIFF
--- a/pkg/docker/pusher.go
+++ b/pkg/docker/pusher.go
@@ -194,7 +194,8 @@ func (n *Pusher) pushImage(ctx context.Context, f fn.Function, credentials oci.C
 	errStr := err.Error()
 	if strings.Contains(errStr, "no such host") ||
 		strings.Contains(errStr, "failure in name resolution") ||
-		regexp.MustCompile(`lookup .*: server misbehaving`).MatchString(errStr) {
+		regexp.MustCompile(`lookup .*: server misbehaving`).MatchString(errStr) ||
+		regexp.MustCompile(`500.*but provided no error-message`).MatchString(errStr) {
 		// push with custom transport to be able to push into cluster private registries
 		return n.push(ctx, f, credentials, output)
 	}


### PR DESCRIPTION
# Changes

In case that the image registry hostname is not resolvable podman now return error in bad JSON shape so it's not decodable by client.

For now we assume that `500.*but provided no error-message` means hostname resolution error.

/kind bug


```release-note
fix: cannot push to cluster internal registry with podman (error API returned a 500 (Internal Server Error) but provided no error-message)
```

