### PR TITLE
fix: Respect `--registry-insecure` flag in remote builds

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -62,7 +62,7 @@ func NewClient(cfg ClientConfig, options ...fn.Option) (*fn.Client, func()) {
 		t  = newTransport(cfg.InsecureSkipVerify)        // may provide a custom impl which proxies
 		c  = newCredentialsProvider(config.Dir(), t, "") // for accessing registries
 		d  = newKnativeDeployer(cfg.Verbose)             // default deployer (can be overridden via options)
-		pp = newTektonPipelinesProvider(c, cfg.Verbose)
+		pp = newTektonPipelinesProvider(c, cfg.Verbose, cfg.InsecureSkipVerify)
 		o  = []fn.Option{ // standard (shared) options for all commands
 			fn.WithVerbose(cfg.Verbose),
 			fn.WithTransport(t),
@@ -143,10 +143,11 @@ func newCredentialsProvider(configPath string, t http.RoundTripper, authFilePath
 	return creds.NewCredentialsProvider(configPath, options...)
 }
 
-func newTektonPipelinesProvider(creds oci.CredentialsProvider, verbose bool) *tekton.PipelinesProvider {
+func newTektonPipelinesProvider(creds oci.CredentialsProvider, verbose bool, registryInsecure bool) *tekton.PipelinesProvider {
 	options := []tekton.Opt{
 		tekton.WithCredentialsProvider(creds),
 		tekton.WithVerbose(verbose),
+		tekton.WithRegistryInsecure(registryInsecure),
 		tekton.WithPipelineDecorator(deployDecorator{}),
 	}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -778,7 +778,7 @@ func (c deployConfig) clientOptions() ([]fn.Option, error) {
 
 	// Override the pipelines provider to use custom credentials
 	// This is needed for remote builds (deploy --remote)
-	o = append(o, fn.WithPipelinesProvider(newTektonPipelinesProvider(creds, c.Verbose)))
+	o = append(o, fn.WithPipelinesProvider(newTektonPipelinesProvider(creds, c.Verbose, c.RegistryInsecure)))
 
 	// Add the appropriate deployer based on deploy type
 	deployer := c.Deployer

--- a/pkg/pipelines/tekton/pipelines_pac_provider.go
+++ b/pkg/pipelines/tekton/pipelines_pac_provider.go
@@ -129,7 +129,7 @@ func (pp *PipelinesProvider) createLocalPACResources(ctx context.Context, f fn.F
 		return err
 	}
 
-	err = createPipelineRunTemplatePAC(f, labels)
+	err = createPipelineRunTemplatePAC(f, labels, pp.registryInsecure)
 	if err != nil {
 		return err
 	}

--- a/pkg/pipelines/tekton/pipelines_provider.go
+++ b/pkg/pipelines/tekton/pipelines_provider.go
@@ -52,6 +52,7 @@ type pacURLCallback = func() (string, error)
 
 type PipelinesProvider struct {
 	verbose             bool
+	registryInsecure    bool
 	getPacURL           pacURLCallback
 	credentialsProvider oci.CredentialsProvider
 	decorator           PipelineDecorator
@@ -66,6 +67,12 @@ func WithCredentialsProvider(credentialsProvider oci.CredentialsProvider) Opt {
 func WithVerbose(verbose bool) Opt {
 	return func(pp *PipelinesProvider) {
 		pp.verbose = verbose
+	}
+}
+
+func WithRegistryInsecure(insecure bool) Opt {
+	return func(pp *PipelinesProvider) {
+		pp.registryInsecure = insecure
 	}
 }
 
@@ -203,7 +210,7 @@ func (pp *PipelinesProvider) Run(ctx context.Context, f fn.Function) (string, fn
 		return "", f, fmt.Errorf("problem in creating secret: %v", err)
 	}
 
-	err = createAndApplyPipelineRunTemplate(f, namespace, labels)
+	err = createAndApplyPipelineRunTemplate(f, namespace, labels, pp.registryInsecure)
 	if err != nil {
 		return "", f, fmt.Errorf("problem in creating pipeline run: %v", err)
 	}

--- a/pkg/pipelines/tekton/templates.go
+++ b/pkg/pipelines/tekton/templates.go
@@ -131,7 +131,7 @@ func createPipelineTemplatePAC(f fn.Function, labels map[string]string) error {
 
 // createPipelineRunTemplatePAC creates a PipelineRun template used for PAC on-cluster build
 // it creates the resource in the project directory
-func createPipelineRunTemplatePAC(f fn.Function, labels map[string]string) error {
+func createPipelineRunTemplatePAC(f fn.Function, labels map[string]string, registryInsecure bool) error {
 	contextDir := f.Build.Git.ContextDir
 	if contextDir == "" && f.Build.Builder == builders.S2I {
 		// TODO(lkingland): could instead update S2I to interpret empty string
@@ -167,7 +167,7 @@ func createPipelineRunTemplatePAC(f fn.Function, labels map[string]string) error
 
 	// Determine if TLS verification should be skipped
 	tlsVerify := "true"
-	if isInsecureRegistry(f.Registry) {
+	if registryInsecure || isInsecureRegistry(f.Registry) {
 		tlsVerify = "false"
 	}
 
@@ -330,7 +330,7 @@ func createAndApplyPipelineTemplate(f fn.Function, namespace string, labels map[
 
 // createAndApplyPipelineRunTemplate creates and applies PipelineRun template for a standard on-cluster build
 // all resources are created on the fly, if there's a PipelineRun defined in the project directory, it is used instead
-func createAndApplyPipelineRunTemplate(f fn.Function, namespace string, labels map[string]string) error {
+func createAndApplyPipelineRunTemplate(f fn.Function, namespace string, labels map[string]string, registryInsecure bool) error {
 	contextDir := f.Build.Git.ContextDir
 	if contextDir == "" && f.Build.Builder == builders.S2I {
 		// TODO(lkingland): could instead update S2I to interpret empty string
@@ -366,7 +366,7 @@ func createAndApplyPipelineRunTemplate(f fn.Function, namespace string, labels m
 
 	// Determine if TLS verification should be skipped
 	tlsVerify := "true"
-	if isInsecureRegistry(f.Registry) {
+	if registryInsecure || isInsecureRegistry(f.Registry) {
 		tlsVerify = "false"
 	}
 

--- a/pkg/pipelines/tekton/templates_test.go
+++ b/pkg/pipelines/tekton/templates_test.go
@@ -147,7 +147,7 @@ func Test_createPipelineRunTemplatePAC(t *testing.T) {
 			f.Image = "docker.io/alice/" + f.Name
 			f.Registry = TestRegistry
 
-			err = createPipelineRunTemplatePAC(f, make(map[string]string))
+			err = createPipelineRunTemplatePAC(f, make(map[string]string), false)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createPipelineRunTemplate() error = %v, wantErr %v", err, tt.wantErr)
@@ -316,7 +316,7 @@ func Test_createAndApplyPipelineRunTemplate(t *testing.T) {
 			f.Image = "docker.io/alice/" + f.Name
 			f.Registry = TestRegistry
 
-			if err := createAndApplyPipelineRunTemplate(f, tt.namespace, tt.labels); (err != nil) != tt.wantErr {
+			if err := createAndApplyPipelineRunTemplate(f, tt.namespace, tt.labels, false); (err != nil) != tt.wantErr {
 				t.Errorf("createAndApplyPipelineRunTemplate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
When --registry-insecure is used, set tlsVerify=false in the Tekton pipeline to allow buildah to push to registries with self-signed certs.