### PR TITLE
ci: upgrade Node.js from EOL v18 to v20 in update workflows

### DIFF
--- a/.github/workflows/update-ca-bundle.yaml
+++ b/.github/workflows/update-ca-bundle.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: "20"
       - name: Install NPM deps.
         run: npm install octokit@3.2.1
       - name: Create PR

--- a/.github/workflows/update-quarkus-platform.yaml
+++ b/.github/workflows/update-quarkus-platform.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: knative/actions/setup-go@main
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: "20"
       - uses: actions/setup-java@v4
         with:
           java-version: 21

--- a/.github/workflows/update-springboot-platform.yaml
+++ b/.github/workflows/update-springboot-platform.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: knative/actions/setup-go@main
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: "20"
       - uses: actions/setup-java@v4
         with:
           java-version: 21


### PR DESCRIPTION
## Summary

- Upgrades `node-version` from `18` to `"20"` in `update-ca-bundle.yaml`, `update-quarkus-platform.yaml`, and `update-springboot-platform.yaml`
- Node.js 18 reached End of Life in April 2024; Node.js 20 is the current LTS with active security support

## Test plan

- [ ] Verify `Update CA bundle` scheduled workflow runs successfully with Node 20
- [ ] Verify `Update Quarkus Platform` workflow runs successfully with Node 20
- [ ] Verify `Update Spring Boot Platform` workflow runs successfully with Node 20

Fixes #3528