### PR TITLE
ci: remove redundant single-entry matrix in test-podman-next workflow

### DIFF
--- a/.github/workflows/test-podman-next.yaml
+++ b/.github/workflows/test-podman-next.yaml
@@ -7,10 +7,7 @@ on:
 jobs:
   test:
     name: Podman Next Test
-    strategy:
-      matrix:
-        os: ["ubuntu-latest"]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Remove Unnecessary Software
         run: |


### PR DESCRIPTION
## Summary

- Removes the `strategy.matrix` block in `test-podman-next.yaml` which contained only one entry (`ubuntu-latest`)
- Replaces the indirect `runs-on: ${{ matrix.os }}` with the direct `runs-on: ubuntu-latest`
- No behaviour change — simplifies the workflow and makes the intent clearer

## Test plan

- [ ] Confirm the `Func Podman Next Test` workflow still triggers on schedule and runs on `ubuntu-latest`

Fixes #3529