### PR TITLE
ci: add timeout-minutes to all jobs in functions.yaml

### DIFF
--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -30,6 +30,7 @@ jobs:
   precheck:
     name: Precheck
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: knative/actions/setup-go@main
@@ -59,6 +60,7 @@ jobs:
           - "macos-14" # ARM
           - "windows-latest"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - name: Disable CRLF conversion (Windows)
         if: runner.os == 'Windows'
@@ -94,6 +96,7 @@ jobs:
           - "macos-14" # ARM
           - "windows-latest"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       # Setup
       - name: Disable CRLF conversion (Windows)
@@ -131,6 +134,7 @@ jobs:
     name: Integration Tests
     needs: precheck
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     env:
       FUNC_CLUSTER_RETRIES: 5
       FUNC_INT_TEKTON_ENABLED: true
@@ -194,6 +198,7 @@ jobs:
     name: E2E - Core, Metadata, and Remote
     needs: precheck
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     env:
       FUNC_CLUSTER_RETRIES: 5
       FUNC_E2E_CLEAN: false # cluster only used once
@@ -247,6 +252,7 @@ jobs:
   test-e2e-podman:
     name: E2E - Podman
     needs: precheck
+    timeout-minutes: 120
     strategy:
       matrix:
         os:
@@ -312,6 +318,7 @@ jobs:
           - "quarkus"
           - "springboot"
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     env:
       FUNC_CLUSTER_RETRIES: 5 # Cluster allocation retries
       FUNC_E2E_CLEAN: false # Skip deletes (cluster not reused)
@@ -391,6 +398,7 @@ jobs:
     name: E2E - Config CI GitHub Workflows
     needs: precheck
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     env:
       FUNC_CLUSTER_RETRIES: 5
       FUNC_E2E_CLEAN: false
@@ -451,6 +459,7 @@ jobs:
       - test-e2e-config-ci
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: knative/actions/setup-go@main
@@ -489,6 +498,7 @@ jobs:
     name: Publish Utils Image
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: knative/actions/setup-go@main
@@ -531,6 +541,7 @@ jobs:
     name: Publish as Image
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: knative/actions/setup-go@main


### PR DESCRIPTION
## Summary

- Adds `timeout-minutes` to all 11 jobs in `.github/workflows/functions.yaml`
- Without explicit timeouts, GitHub Actions defaults to 6 hours per job; a hung cluster or stuck step would burn runner minutes until the default limit

Timeouts set:

| Job | Timeout |
|-----|---------|
| `precheck` | 15m |
| `test-unit` | 30m |
| `test-templates` | 60m |
| `test-integration` | 120m |
| `test-e2e` | 120m |
| `test-e2e-podman` | 120m |
| `test-e2e-runtimes` | 90m |
| `test-e2e-config-ci` | 120m |
| `build` | 30m |
| `publish-utils-image` | 30m |
| `publish-image` | 30m |

These are conservative upper bounds — happy to adjust based on observed p99 runtimes.

## Test plan

- [ ] Confirm no jobs time out prematurely on a normal PR run

Fixes #3530