### PR TITLE
ci: add concurrency group to functions.yaml to cancel redundant runs

### DIFF
--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Global version definitions
 env:


### PR DESCRIPTION
## Summary

- Adds a `concurrency` block to `.github/workflows/functions.yaml`
- Without it, pushing multiple commits to the same PR (or re-running after a fixup) queues multiple workflow runs simultaneously, wasting runner minutes on results that will be superseded
- With `cancel-in-progress: true`, any in-progress run for the same branch or PR ref is cancelled when a new run starts

## Test plan

- [ ] Push two commits to a PR branch in quick succession and confirm the first run is cancelled when the second starts
- [ ] Confirm pushes to `main` still run to completion (each push to main gets its own group key)

Fixes #3531