### PR TITLE
ci: fix test-e2e-podman to use matrix.os instead of hardcoded runner

### DIFF
--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -247,12 +247,12 @@ jobs:
   test-e2e-podman:
     name: E2E - Podman
     needs: precheck
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         os:
           - "ubuntu-latest" # x86_64
           - "ubuntu-24.04-arm" # ARM64
+    runs-on: ${{ matrix.os }}
     env:
       FUNC_CLUSTER_RETRIES: 5
       FUNC_E2E_PODMAN: true


### PR DESCRIPTION
## Summary

- Fixes `test-e2e-podman` job which defines a matrix with `ubuntu-latest` (x86_64) and `ubuntu-24.04-arm` (ARM64) but had `runs-on: ubuntu-latest` hardcoded
- Both matrix entries were running on x86_64, so ARM64 was never actually tested on ARM hardware
- Changed to `runs-on: ${{ matrix.os }}` so each matrix entry runs on the correct runner

## Test plan

- [ ] Verify the `E2E - Podman` job spawns two matrix runs: one on `ubuntu-latest` and one on `ubuntu-24.04-arm`
- [ ] Confirm both matrix entries complete successfully

Fixes #3537