### PR TITLE
ci: add top-level permissions for least-privilege security

### DIFF
--- a/.github/workflows/test-podman-next.yaml
+++ b/.github/workflows/test-podman-next.yaml
@@ -1,5 +1,8 @@
 name: Func Podman Next Test
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '0 2 * * *'


### PR DESCRIPTION
## Summary

- Add `permissions: contents: read` to `test-podman-next.yaml` to restrict the default GITHUB_TOKEN to read-only access, following the principle of least privilege.

Fixes #3539

## Test plan

- [ ] Verify CI passes — no functional change, workflow only needs read access