### PR TITLE
ci: add timeout, concurrency, and workflow_dispatch to scheduled workflows

### DIFF
--- a/.github/workflows/test-podman-next.yaml
+++ b/.github/workflows/test-podman-next.yaml
@@ -7,10 +7,15 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Podman Next Test
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Remove Unnecessary Software
         run: |

--- a/.github/workflows/update-builder.yaml
+++ b/.github/workflows/update-builder.yaml
@@ -3,6 +3,11 @@ name: Update builder-jammy-full image
 on:
   schedule:
     - cron: '0 * * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-and-push-image:
@@ -10,6 +15,7 @@ jobs:
       contents: read
       packages: write
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: knative/actions/setup-go@main

--- a/.github/workflows/update-ca-bundle.yaml
+++ b/.github/workflows/update-ca-bundle.yaml
@@ -7,11 +7,17 @@ permissions:
 on:
   schedule:
     - cron: '0 */4 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   update:
     name: Update CA bundle
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/update-python-platform.yaml
+++ b/.github/workflows/update-python-platform.yaml
@@ -9,10 +9,15 @@ on:
     - cron: "0 6 * * *" # Daily at 06:00.
   workflow_dispatch: # Manual workflow trigger
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update:
     name: Update func-python version
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/update-quarkus-platform.yaml
+++ b/.github/workflows/update-quarkus-platform.yaml
@@ -7,11 +7,17 @@ permissions:
 on:
   schedule:
     - cron: '0 */4 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   update:
     name: Update Quarkus Platform
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: knative/actions/setup-go@main

--- a/.github/workflows/update-springboot-platform.yaml
+++ b/.github/workflows/update-springboot-platform.yaml
@@ -7,11 +7,17 @@ permissions:
 on:
   schedule:
     - cron: '0 */4 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   update:
     name: Update Spring Boot Platform
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: knative/actions/setup-go@main


### PR DESCRIPTION
## Summary

Follows the patterns established in #3535, #3536, and #3532 for `functions.yaml` and applies them consistently to the remaining scheduled/update workflows.

- **`timeout-minutes`** added to all jobs so hung runners are not blocked indefinitely (closes #3546)
- **`concurrency` groups** added to prevent redundant parallel runs when a scheduled run is still in progress when the next one fires (closes #3547)
- **`workflow_dispatch`** added to `update-builder`, `update-quarkus-platform`, `update-springboot-platform`, and `update-ca-bundle` so they can be triggered manually for testing, matching what `update-python-platform` already had (closes #3548)

## Affected workflows

| Workflow | timeout | concurrency | workflow_dispatch |
|---|---|---|---|
| `test-podman-next.yaml` | +60m | + | — |
| `update-builder.yaml` | +30m | + | + |
| `update-python-platform.yaml` | +30m | + | already present |
| `update-quarkus-platform.yaml` | +30m | + | + |
| `update-springboot-platform.yaml` | +30m | + | + |
| `update-ca-bundle.yaml` | +15m | + | + |

## Test plan

- [ ] Verify YAML syntax is valid for each changed workflow file
- [ ] Confirm scheduled runs still trigger as expected after merge
- [ ] Confirm `workflow_dispatch` appears in the Actions UI for the newly added workflows