### PR TITLE
ci: add timeout-minutes to scheduled/update workflow jobs

### DIFF
--- a/.github/workflows/test-podman-next.yaml
+++ b/.github/workflows/test-podman-next.yaml
@@ -11,6 +11,7 @@ jobs:
   test:
     name: Podman Next Test
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Remove Unnecessary Software
         run: |

--- a/.github/workflows/update-builder.yaml
+++ b/.github/workflows/update-builder.yaml
@@ -10,6 +10,7 @@ jobs:
       contents: read
       packages: write
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: knative/actions/setup-go@main

--- a/.github/workflows/update-ca-bundle.yaml
+++ b/.github/workflows/update-ca-bundle.yaml
@@ -12,6 +12,7 @@ jobs:
   update:
     name: Update CA bundle
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/update-python-platform.yaml
+++ b/.github/workflows/update-python-platform.yaml
@@ -13,6 +13,7 @@ jobs:
   update:
     name: Update func-python version
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/update-quarkus-platform.yaml
+++ b/.github/workflows/update-quarkus-platform.yaml
@@ -12,6 +12,7 @@ jobs:
   update:
     name: Update Quarkus Platform
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: knative/actions/setup-go@main

--- a/.github/workflows/update-springboot-platform.yaml
+++ b/.github/workflows/update-springboot-platform.yaml
@@ -12,6 +12,7 @@ jobs:
   update:
     name: Update Spring Boot Platform
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: knative/actions/setup-go@main


### PR DESCRIPTION
Closes #3546

Scheduled workflows had no `timeout-minutes`, meaning a hung job would block a runner indefinitely. Follows the pattern from #3535 which added timeouts to `functions.yaml`.

| Workflow | timeout |
|---|---|
| `test-podman-next.yaml` | 60m |
| `update-builder.yaml` | 30m |
| `update-python-platform.yaml` | 30m |
| `update-quarkus-platform.yaml` | 30m |
| `update-springboot-platform.yaml` | 30m |
| `update-ca-bundle.yaml` | 15m |