### PR TITLE
ci: add concurrency groups to scheduled/update workflows

### DIFF
--- a/.github/workflows/test-podman-next.yaml
+++ b/.github/workflows/test-podman-next.yaml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Podman Next Test

--- a/.github/workflows/update-builder.yaml
+++ b/.github/workflows/update-builder.yaml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 * * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push-image:
     permissions:

--- a/.github/workflows/update-ca-bundle.yaml
+++ b/.github/workflows/update-ca-bundle.yaml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '0 */4 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update:
     name: Update CA bundle

--- a/.github/workflows/update-python-platform.yaml
+++ b/.github/workflows/update-python-platform.yaml
@@ -9,6 +9,10 @@ on:
     - cron: "0 6 * * *" # Daily at 06:00.
   workflow_dispatch: # Manual workflow trigger
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update:
     name: Update func-python version

--- a/.github/workflows/update-quarkus-platform.yaml
+++ b/.github/workflows/update-quarkus-platform.yaml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '0 */4 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update:
     name: Update Quarkus Platform

--- a/.github/workflows/update-springboot-platform.yaml
+++ b/.github/workflows/update-springboot-platform.yaml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '0 */4 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update:
     name: Update Spring Boot Platform


### PR DESCRIPTION
Closes #3547

Without a `concurrency` group, if a scheduled run is still in progress when the next one fires both run simultaneously, wasting runner minutes and potentially creating duplicate PRs. Follows the pattern from #3536 which added concurrency to `functions.yaml`.

Affected workflows: `test-podman-next`, `update-builder`, `update-python-platform`, `update-quarkus-platform`, `update-springboot-platform`, `update-ca-bundle`.