### PR TITLE
ci: add workflow_dispatch to scheduled update workflows

### DIFF
--- a/.github/workflows/update-builder.yaml
+++ b/.github/workflows/update-builder.yaml
@@ -3,6 +3,7 @@ name: Update builder-jammy-full image
 on:
   schedule:
     - cron: '0 * * * *'
+  workflow_dispatch:
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/update-ca-bundle.yaml
+++ b/.github/workflows/update-ca-bundle.yaml
@@ -7,6 +7,7 @@ permissions:
 on:
   schedule:
     - cron: '0 */4 * * *'
+  workflow_dispatch:
 
 jobs:
   update:

--- a/.github/workflows/update-quarkus-platform.yaml
+++ b/.github/workflows/update-quarkus-platform.yaml
@@ -7,6 +7,7 @@ permissions:
 on:
   schedule:
     - cron: '0 */4 * * *'
+  workflow_dispatch:
 
 jobs:
   update:

--- a/.github/workflows/update-springboot-platform.yaml
+++ b/.github/workflows/update-springboot-platform.yaml
@@ -7,6 +7,7 @@ permissions:
 on:
   schedule:
     - cron: '0 */4 * * *'
+  workflow_dispatch:
 
 jobs:
   update:


### PR DESCRIPTION
Closes #3548

`update-python-platform` already had `workflow_dispatch` for manual triggering, but the remaining scheduled update workflows did not. Without it there is no way to re-run a workflow outside its schedule without editing the cron expression, making ad-hoc testing and debugging painful.

Affected workflows: `update-builder`, `update-quarkus-platform`, `update-springboot-platform`, `update-ca-bundle`.