### PR TITLE
ci: set retention-days on platform binary artifacts in build job

### DIFF
--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -473,30 +473,37 @@ jobs:
         with:
           name: OSX Binary (AMD)
           path: func_darwin_amd64
+          retention-days: 30
       - uses: actions/upload-artifact@v4
         with:
           name: OSX Binary (ARM)
           path: func_darwin_arm64
+          retention-days: 30
       - uses: actions/upload-artifact@v4
         with:
           name: Linux Binary (AMD)
           path: func_linux_amd64
+          retention-days: 30
       - uses: actions/upload-artifact@v4
         with:
           name: Linux Binary (ARM)
           path: func_linux_arm64
+          retention-days: 30
       - uses: actions/upload-artifact@v4
         with:
           name: Linux Binary (PPC64LE)
           path: func_linux_ppc64le
+          retention-days: 30
       - uses: actions/upload-artifact@v4
         with:
           name: Linux Binary (S390X)
           path: func_linux_s390x
+          retention-days: 30
       - uses: actions/upload-artifact@v4
         with:
           name: Windows Binary
           path: func_windows_amd64.exe
+          retention-days: 30
 
   publish-utils-image:
     name: Publish Utils Image


### PR DESCRIPTION
Fixes #3555

## Summary

- The `build` job uploads 7 cross-platform binaries with no `retention-days` setting, causing them to use GitHub's default 90-day retention.
- Cluster-log artifacts in the same file already use `retention-days: 7`.
- This PR adds `retention-days: 30` to all 7 binary artifact upload steps (darwin/amd64, darwin/arm64, linux/amd64, linux/arm64, linux/ppc64le, linux/s390x, windows/amd64) to align retention policy and prevent unbounded storage accumulation.

## Test plan

- [ ] Verify `.github/workflows/functions.yaml` build job now has `retention-days: 30` on all 7 `actions/upload-artifact@v4` steps.
- [ ] Confirm no other artifact upload steps were unintentionally modified.