### PR TITLE
ci: add free-disk-space cleanup to test-e2e-podman job

### DIFF
--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -272,6 +272,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: knative/actions/setup-go@main
 
+      - uses: endersonmenezes/free-disk-space@v3
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_swap: true
+          rm_cmd: "rmz" # Faster than rm
+
       - name: Start Podman
         run: sudo apt update && sudo apt install -y podman && podman system service --time=0 &
 


### PR DESCRIPTION
## Summary

- Adds `endersonmenezes/free-disk-space@v3` step to the `test-e2e-podman` job, immediately after `knative/actions/setup-go@main`
- Makes `test-e2e-podman` consistent with all other sibling E2E jobs (`test-integration`, `test-e2e`, `test-e2e-runtimes`, `test-e2e-config-ci`) which already run this cleanup step
- Podman installation is notably large, making disk pressure more likely in this job than others

Fixes #3553