### PR TITLE
ci: replace ad-hoc rm -rf with free-disk-space action in test-podman-next

### DIFF
--- a/.github/workflows/test-podman-next.yaml
+++ b/.github/workflows/test-podman-next.yaml
@@ -12,11 +12,13 @@ jobs:
     name: Podman Next Test
     runs-on: ubuntu-latest
     steps:
-      - name: Remove Unnecessary Software
-        run: |
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /usr/local/lib/android || true
-          sudo rm -rf /opt/ghc || true
+      - uses: endersonmenezes/free-disk-space@v3
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_swap: true
+          rm_cmd: "rmz" # Faster than rm
       - name: Set Environment Variables
         run: |
           echo "KUBECONFIG=${{ github.workspace }}/hack/bin/kubeconfig.yaml" >> "$GITHUB_ENV"


### PR DESCRIPTION
Fixes #3554

## Summary

- Replaces three manual `sudo rm -rf` lines in `test-podman-next.yaml` with the standardized `endersonmenezes/free-disk-space@v3` action
- The action also removes swap (`remove_swap: true`), which the manual approach missed
- Uses `rmz` for faster removal, consistent with all other long-running CI jobs

## Test plan
- [ ] Verify the workflow runs successfully with the new action
- [ ] Confirm disk space is freed before the podman-next test step