### PR TITLE
ci: reduce update-builder schedule from hourly to every 4 hours

### DIFF
--- a/.github/workflows/update-builder.yaml
+++ b/.github/workflows/update-builder.yaml
@@ -2,7 +2,7 @@ name: Update builder-jammy-full image
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 */4 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Problem

`update-builder.yaml` runs on an hourly cron (`0 * * * *`), while all other update workflows use `0 */4 * * *` (every 4 hours) or daily. The builder image is published by an external team and does not change hourly, so the extra runs provide no benefit while consuming ~18 runner-hours/day.

## Fix

Change the cron from `0 * * * *` to `0 */4 * * *` to match the cadence of all other update workflows.

Closes #3563