### PR TITLE
test: add unit tests for resolveBuilder in cmd/ci

### DIFF
--- a/cmd/ci/config_test.go
+++ b/cmd/ci/config_test.go
@@ -1,56 +1,13 @@
 package ci
 
 import (
-	"path/filepath"
 	"testing"
 
 	"gotest.tools/v3/assert"
 )
 
-// ---------------------------------------------------------------------------
-// Pure accessor methods on a hand-built CIConfig
-// ---------------------------------------------------------------------------
-
-func TestCIConfig_Verbose(t *testing.T) {
-	assert.Assert(t, !CIConfig{verbose: false}.Verbose())
-	assert.Assert(t, CIConfig{verbose: true}.Verbose())
-}
-
-func TestCIConfig_FnRuntime(t *testing.T) {
-	assert.Equal(t, CIConfig{fnRuntime: "go"}.FnRuntime(), "go")
-	assert.Equal(t, CIConfig{fnRuntime: "python"}.FnRuntime(), "python")
-}
-
-func TestCIConfig_FnBuilder(t *testing.T) {
-	assert.Equal(t, CIConfig{fnBuilder: "host"}.FnBuilder(), "host")
-	assert.Equal(t, CIConfig{fnBuilder: "pack"}.FnBuilder(), "pack")
-	assert.Equal(t, CIConfig{fnBuilder: "s2i"}.FnBuilder(), "s2i")
-}
-
-func TestCIConfig_OutputPath(t *testing.T) {
-	cc := CIConfig{
-		githubWorkflowDir:      DefaultGitHubWorkflowDir,
-		githubWorkflowFilename: DefaultGitHubWorkflowFilename,
-	}
-	want := filepath.Join(DefaultGitHubWorkflowDir, DefaultGitHubWorkflowFilename)
-	assert.Equal(t, cc.OutputPath(), want)
-}
-
-func TestCIConfig_FnGitHubWorkflowFilepath(t *testing.T) {
-	root := "/home/user/myfunc"
-	cc := CIConfig{
-		fnRoot:                 root,
-		githubWorkflowDir:      DefaultGitHubWorkflowDir,
-		githubWorkflowFilename: DefaultGitHubWorkflowFilename,
-	}
-	want := filepath.Join(root, DefaultGitHubWorkflowDir, DefaultGitHubWorkflowFilename)
-	assert.Equal(t, cc.FnGitHubWorkflowFilepath(), want)
-}
-
-// ---------------------------------------------------------------------------
-// resolveBuilder — the main untested code block from config.go
-// ---------------------------------------------------------------------------
-
+// TestResolveBuilder covers the branching logic that selects the correct
+// build strategy for each runtime × local/remote combination.
 func TestResolveBuilder(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -87,44 +44,4 @@ func TestResolveBuilder(t *testing.T) {
 			assert.Equal(t, got, tc.want)
 		})
 	}
-}
-
-// ---------------------------------------------------------------------------
-// Additional simple bool/string accessors
-// ---------------------------------------------------------------------------
-
-func TestCIConfig_BoolAccessors(t *testing.T) {
-	cc := CIConfig{
-		registryLogin:    true,
-		selfHostedRunner: true,
-		remoteBuild:      true,
-		workflowDispatch: true,
-		testStep:         true,
-		force:            true,
-	}
-	assert.Assert(t, cc.RegistryLogin())
-	assert.Assert(t, cc.SelfHostedRunner())
-	assert.Assert(t, cc.RemoteBuild())
-	assert.Assert(t, cc.WorkflowDispatch())
-	assert.Assert(t, cc.TestStep())
-	assert.Assert(t, cc.Force())
-}
-
-func TestCIConfig_StringAccessors(t *testing.T) {
-	cc := CIConfig{
-		branch:              "feature-x",
-		workflowName:        "My Deploy",
-		kubeconfigSecret:    "MY_KUBECONFIG",
-		registryLoginUrlVar: "MY_REGISTRY_URL",
-		registryUserVar:     "MY_USER",
-		registryPassSecret:  "MY_PASS",
-		registryUrlVar:      "MY_REG",
-	}
-	assert.Equal(t, cc.Branch(), "feature-x")
-	assert.Equal(t, cc.WorkflowName(), "My Deploy")
-	assert.Equal(t, cc.KubeconfigSecret(), "MY_KUBECONFIG")
-	assert.Equal(t, cc.RegistryLoginUrlVar(), "MY_REGISTRY_URL")
-	assert.Equal(t, cc.RegistryUserVar(), "MY_USER")
-	assert.Equal(t, cc.RegistryPassSecret(), "MY_PASS")
-	assert.Equal(t, cc.RegistryUrlVar(), "MY_REG")
 }

--- a/cmd/ci/config_test.go
+++ b/cmd/ci/config_test.go
@@ -1,0 +1,130 @@
+package ci
+
+import (
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Pure accessor methods on a hand-built CIConfig
+// ---------------------------------------------------------------------------
+
+func TestCIConfig_Verbose(t *testing.T) {
+	assert.Assert(t, !CIConfig{verbose: false}.Verbose())
+	assert.Assert(t, CIConfig{verbose: true}.Verbose())
+}
+
+func TestCIConfig_FnRuntime(t *testing.T) {
+	assert.Equal(t, CIConfig{fnRuntime: "go"}.FnRuntime(), "go")
+	assert.Equal(t, CIConfig{fnRuntime: "python"}.FnRuntime(), "python")
+}
+
+func TestCIConfig_FnBuilder(t *testing.T) {
+	assert.Equal(t, CIConfig{fnBuilder: "host"}.FnBuilder(), "host")
+	assert.Equal(t, CIConfig{fnBuilder: "pack"}.FnBuilder(), "pack")
+	assert.Equal(t, CIConfig{fnBuilder: "s2i"}.FnBuilder(), "s2i")
+}
+
+func TestCIConfig_OutputPath(t *testing.T) {
+	cc := CIConfig{
+		githubWorkflowDir:      DefaultGitHubWorkflowDir,
+		githubWorkflowFilename: DefaultGitHubWorkflowFilename,
+	}
+	want := filepath.Join(DefaultGitHubWorkflowDir, DefaultGitHubWorkflowFilename)
+	assert.Equal(t, cc.OutputPath(), want)
+}
+
+func TestCIConfig_FnGitHubWorkflowFilepath(t *testing.T) {
+	root := "/home/user/myfunc"
+	cc := CIConfig{
+		fnRoot:                 root,
+		githubWorkflowDir:      DefaultGitHubWorkflowDir,
+		githubWorkflowFilename: DefaultGitHubWorkflowFilename,
+	}
+	want := filepath.Join(root, DefaultGitHubWorkflowDir, DefaultGitHubWorkflowFilename)
+	assert.Equal(t, cc.FnGitHubWorkflowFilepath(), want)
+}
+
+// ---------------------------------------------------------------------------
+// resolveBuilder — the main untested code block from config.go
+// ---------------------------------------------------------------------------
+
+func TestResolveBuilder(t *testing.T) {
+	tests := []struct {
+		name    string
+		runtime string
+		remote  bool
+		want    string
+		wantErr bool
+	}{
+		{name: "go local", runtime: "go", remote: false, want: "host"},
+		{name: "go remote", runtime: "go", remote: true, want: "pack"},
+		{name: "node local", runtime: "node", remote: false, want: "pack"},
+		{name: "node remote", runtime: "node", remote: true, want: "pack"},
+		{name: "typescript local", runtime: "typescript", remote: false, want: "pack"},
+		{name: "typescript remote", runtime: "typescript", remote: true, want: "pack"},
+		{name: "rust local", runtime: "rust", remote: false, want: "pack"},
+		{name: "rust remote", runtime: "rust", remote: true, want: "pack"},
+		{name: "quarkus local", runtime: "quarkus", remote: false, want: "pack"},
+		{name: "quarkus remote", runtime: "quarkus", remote: true, want: "pack"},
+		{name: "springboot local", runtime: "springboot", remote: false, want: "pack"},
+		{name: "springboot remote", runtime: "springboot", remote: true, want: "pack"},
+		{name: "python local", runtime: "python", remote: false, want: "host"},
+		{name: "python remote", runtime: "python", remote: true, want: "s2i"},
+		{name: "unknown runtime", runtime: "fortran", remote: false, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveBuilder(tc.runtime, tc.remote)
+			if tc.wantErr {
+				assert.Assert(t, err != nil, "expected an error for runtime %q", tc.runtime)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got, tc.want)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Additional simple bool/string accessors
+// ---------------------------------------------------------------------------
+
+func TestCIConfig_BoolAccessors(t *testing.T) {
+	cc := CIConfig{
+		registryLogin:    true,
+		selfHostedRunner: true,
+		remoteBuild:      true,
+		workflowDispatch: true,
+		testStep:         true,
+		force:            true,
+	}
+	assert.Assert(t, cc.RegistryLogin())
+	assert.Assert(t, cc.SelfHostedRunner())
+	assert.Assert(t, cc.RemoteBuild())
+	assert.Assert(t, cc.WorkflowDispatch())
+	assert.Assert(t, cc.TestStep())
+	assert.Assert(t, cc.Force())
+}
+
+func TestCIConfig_StringAccessors(t *testing.T) {
+	cc := CIConfig{
+		branch:              "feature-x",
+		workflowName:        "My Deploy",
+		kubeconfigSecret:    "MY_KUBECONFIG",
+		registryLoginUrlVar: "MY_REGISTRY_URL",
+		registryUserVar:     "MY_USER",
+		registryPassSecret:  "MY_PASS",
+		registryUrlVar:      "MY_REG",
+	}
+	assert.Equal(t, cc.Branch(), "feature-x")
+	assert.Equal(t, cc.WorkflowName(), "My Deploy")
+	assert.Equal(t, cc.KubeconfigSecret(), "MY_KUBECONFIG")
+	assert.Equal(t, cc.RegistryLoginUrlVar(), "MY_REGISTRY_URL")
+	assert.Equal(t, cc.RegistryUserVar(), "MY_USER")
+	assert.Equal(t, cc.RegistryPassSecret(), "MY_PASS")
+	assert.Equal(t, cc.RegistryUrlVar(), "MY_REG")
+}


### PR DESCRIPTION
# test: add unit tests for resolveBuilder in cmd/ci

## Related Issue

Closes: https://github.com/knative/func/issues/3568

## What this PR does

Adds `cmd/ci/config_test.go` — a new test file for `cmd/ci/config.go`.

The unexported `resolveBuilder` function had **zero test coverage**. It
contains non-trivial branching logic that selects the correct build strategy
(`host`, `pack`, or `s2i`) for each runtime × local/remote combination.

This PR adds a focused, 15-subcase table-driven test for `resolveBuilder`
using struct literals — no viper setup, no mocks, no cluster, no network.

Trivial one-liner getter/accessor methods are intentionally not tested here,
as they add no meaningful coverage and only verify that Go's struct field
assignment works.

## Changes

| File | Change |
|---|---|
| `cmd/ci/config_test.go` | **New** — 1 table-driven test with 15 sub-cases |

## Tests added

```
TestResolveBuilder (15 sub-cases):
  go local         → host
  go remote        → pack
  node local/remote        → pack
  typescript local/remote  → pack
  rust local/remote        → pack
  quarkus local/remote     → pack
  springboot local/remote  → pack
  python local     → host
  python remote    → s2i
  unknown runtime  → error
```

## How to verify

```bash
go test ./cmd/ci/... -v -run TestResolveBuilder
```

Expected output: **all 15 sub-tests PASS**, `ok knative.dev/func/cmd/ci`.

## Checklist

- [x] Tests only — no production code changed
- [x] `make test` passes
- [x] `make check` passes
- [x] No new dependencies introduced
