### PR TITLE
fix: pass referenced resource sets to generateNewService for proper validation

### DIFF
--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -465,6 +465,49 @@ func TestDeploy_Envs(t *testing.T) {
 
 }
 
+// TestDeploy_EnvsPassedToDeployer ensures that environment variables provided
+// via the -e flag are included in the function passed to the deployer.
+// This is a regression test for issue #3514 where env vars were persisted to
+// func.yaml but not included in the deployed service spec.
+func TestDeploy_EnvsPassedToDeployer(t *testing.T) {
+	root := FromTempDirectory(t)
+	ptr := func(s string) *string { return &s }
+
+	_, err := fn.New().Init(fn.Function{Runtime: "go", Root: root, Registry: TestRegistry})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deployer := mock.NewDeployer()
+	var deployedEnvs fn.Envs
+	deployer.DeployFn = func(_ context.Context, f fn.Function) (fn.DeploymentResult, error) {
+		deployedEnvs = f.Run.Envs
+		return fn.DeploymentResult{
+			Status:    fn.Deployed,
+			URL:       "http://example.com",
+			Namespace: "default",
+		}, nil
+	}
+
+	cmd := NewDeployCmd(NewTestClient(fn.WithDeployer(deployer)))
+	cmd.SetArgs([]string{"--env=MYVAR=myvalue", "--env=OTHER=othervalue"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !deployer.DeployInvoked {
+		t.Fatal("deployer was not invoked")
+	}
+
+	expected := fn.Envs([]fn.Env{
+		{Name: ptr("MYVAR"), Value: ptr("myvalue")},
+		{Name: ptr("OTHER"), Value: ptr("othervalue")},
+	})
+	if !reflect.DeepEqual(deployedEnvs, expected) {
+		t.Fatalf("Expected deployer to receive envs '%v', got '%v'", expected, deployedEnvs)
+	}
+}
+
 // TestDeploy_FunctionContext ensures that the function contextually relevant
 // to the current command is loaded and used for flag defaults by spot-checking
 // the builder setting.

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -465,50 +465,6 @@ func TestDeploy_Envs(t *testing.T) {
 
 }
 
-// TestDeploy_EnvsPassedToDeployer ensures that environment variables provided
-// via the -e flag are included in the function passed to the deployer.
-// It verifies that --env flags are forwarded through the deploy command
-// to the deployer implementation (characterisation test; not a regression
-// test for a specific issue).
-func TestDeploy_EnvsPassedToDeployer(t *testing.T) {
-	root := FromTempDirectory(t)
-	ptr := func(s string) *string { return &s }
-
-	_, err := fn.New().Init(fn.Function{Runtime: "go", Root: root, Registry: TestRegistry})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	deployer := mock.NewDeployer()
-	var deployedEnvs fn.Envs
-	deployer.DeployFn = func(_ context.Context, f fn.Function) (fn.DeploymentResult, error) {
-		deployedEnvs = f.Run.Envs
-		return fn.DeploymentResult{
-			Status:    fn.Deployed,
-			URL:       "http://example.com",
-			Namespace: "default",
-		}, nil
-	}
-
-	cmd := NewDeployCmd(NewTestClient(fn.WithDeployer(deployer)))
-	cmd.SetArgs([]string{"--env=MYVAR=myvalue", "--env=OTHER=othervalue"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
-	}
-
-	if !deployer.DeployInvoked {
-		t.Fatal("deployer was not invoked")
-	}
-
-	expected := fn.Envs([]fn.Env{
-		{Name: ptr("MYVAR"), Value: ptr("myvalue")},
-		{Name: ptr("OTHER"), Value: ptr("othervalue")},
-	})
-	if !reflect.DeepEqual(deployedEnvs, expected) {
-		t.Fatalf("Expected deployer to receive envs '%v', got '%v'", expected, deployedEnvs)
-	}
-}
-
 // TestDeploy_FunctionContext ensures that the function contextually relevant
 // to the current command is loaded and used for flag defaults by spot-checking
 // the builder setting.

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -467,8 +467,9 @@ func TestDeploy_Envs(t *testing.T) {
 
 // TestDeploy_EnvsPassedToDeployer ensures that environment variables provided
 // via the -e flag are included in the function passed to the deployer.
-// This is a regression test for issue #3514 where env vars were persisted to
-// func.yaml but not included in the deployed service spec.
+// It verifies that --env flags are forwarded through the deploy command
+// to the deployer implementation (characterisation test; not a regression
+// test for a specific issue).
 func TestDeploy_EnvsPassedToDeployer(t *testing.T) {
 	root := FromTempDirectory(t)
 	ptr := func(s string) *string { return &s }

--- a/pkg/deployer/testing/integration_test_helper.go
+++ b/pkg/deployer/testing/integration_test_helper.go
@@ -887,6 +887,96 @@ func TestInt_FullPath(t *testing.T, deployer fn.Deployer, remover fn.Remover, li
 	}
 }
 
+// TestInt_ResourceValidationOnFirstDeploy verifies that a first-time deploy
+// referencing a non-existent Secret is rejected with an error, and that the
+// same deploy succeeds once the Secret is created on the cluster.
+//
+// This is a regression test for the bug where generateNewService allocated
+// its own local referenced-resource sets that were never visible to the
+// caller, causing CheckResourcesArePresent to always run against empty sets
+// and silently pass validation on the create path.
+func TestInt_ResourceValidationOnFirstDeploy(t *testing.T, deployer fn.Deployer, remover fn.Remover, describer fn.Describer, deployerName string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
+	name := "func-int-resval-" + rand.String(5)
+	root := t.TempDir()
+	ns := Namespace(t, ctx)
+
+	t.Cleanup(cancel)
+
+	client := fn.New(
+		fn.WithScaffolder(oci.NewScaffolder(true)),
+		fn.WithBuilder(oci.NewBuilder("", false)),
+		fn.WithPusher(oci.NewPusher(true, true, true)),
+		fn.WithDeployer(deployer),
+		fn.WithDescribers(describer),
+		fn.WithRemovers(remover),
+	)
+
+	secretName := "func-int-resval-secret-" + rand.String(5)
+
+	f, err := client.Init(fn.Function{
+		Root:      root,
+		Name:      name,
+		Runtime:   "go",
+		Namespace: ns,
+		Registry:  Registry(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handlerPath := filepath.Join(root, "function.go")
+	if err := os.WriteFile(handlerPath, []byte(testHandler), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reference a Secret that does NOT exist on the cluster yet.
+	f.Run.Envs.Add("SECRET_KEY", "{{ secret: "+secretName+":SECRET_KEY }}")
+
+	err = client.Scaffold(ctx, f, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err = client.Build(ctx, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, _, err = client.Push(ctx, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First deploy: the referenced Secret is absent — must be rejected.
+	_, err = client.Deploy(ctx, f)
+	if err == nil {
+		t.Fatal("expected deploy to fail when referencing a missing Secret, but it succeeded")
+	}
+	if !strings.Contains(err.Error(), secretName) {
+		t.Fatalf("expected error to mention missing Secret %q, got: %v", secretName, err)
+	}
+	t.Logf("deploy correctly rejected with: %v", err)
+
+	// Create the Secret on the cluster.
+	createSecret(t, ns, secretName, map[string]string{
+		"SECRET_KEY": "secret-value",
+	})
+
+	// Second deploy: the Secret now exists — must succeed.
+	f, err = client.Deploy(ctx, f)
+	if err != nil {
+		t.Fatalf("expected deploy to succeed after Secret was created, got: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := client.Remove(ctx, "", "", f, true); err != nil {
+			t.Logf("error removing Function: %v", err)
+		}
+	})
+}
+
 // Helper functions
 // ================
 

--- a/pkg/knative/deployer.go
+++ b/pkg/knative/deployer.go
@@ -209,7 +209,7 @@ consider setting up the pull secrets and linking it to the default service accou
 			referencedConfigMaps := sets.New[string]()
 			referencedPVCs := sets.New[string]()
 
-			service, err := generateNewService(f, d.decorator, daprInstalled)
+			service, err := generateNewService(f, d.decorator, daprInstalled, &referencedSecrets, &referencedConfigMaps, &referencedPVCs)
 			if err != nil {
 				err = fmt.Errorf("knative deployer failed to generate the Knative Service: %v", err)
 				return fn.DeploymentResult{}, err
@@ -411,7 +411,7 @@ func createTriggers(ctx context.Context, f fn.Function, client clientservingv1.K
 	return nil
 }
 
-func generateNewService(f fn.Function, decorator deployer.DeployDecorator, daprInstalled bool) (*servingv1.Service, error) {
+func generateNewService(f fn.Function, decorator deployer.DeployDecorator, daprInstalled bool, referencedSecrets, referencedConfigMaps, referencedPVCs *sets.Set[string]) (*servingv1.Service, error) {
 	container := corev1.Container{
 		Image: f.Deploy.Image,
 	}
@@ -419,18 +419,14 @@ func generateNewService(f fn.Function, decorator deployer.DeployDecorator, daprI
 	k8s.SetSecurityContext(&container)
 	k8s.SetHealthEndpoints(f, &container)
 
-	referencedSecrets := sets.New[string]()
-	referencedConfigMaps := sets.New[string]()
-	referencedPVC := sets.New[string]()
-
-	newEnv, newEnvFrom, err := k8s.ProcessEnvs(f.Run.Envs, &referencedSecrets, &referencedConfigMaps)
+	newEnv, newEnvFrom, err := k8s.ProcessEnvs(f.Run.Envs, referencedSecrets, referencedConfigMaps)
 	if err != nil {
 		return nil, err
 	}
 	container.Env = newEnv
 	container.EnvFrom = newEnvFrom
 
-	newVolumes, newVolumeMounts, err := k8s.ProcessVolumes(f.Run.Volumes, &referencedSecrets, &referencedConfigMaps, &referencedPVC)
+	newVolumes, newVolumeMounts, err := k8s.ProcessVolumes(f.Run.Volumes, referencedSecrets, referencedConfigMaps, referencedPVCs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/knative/deployer_int_test.go
+++ b/pkg/knative/deployer_int_test.go
@@ -58,3 +58,11 @@ func TestInt_EnvsUpdate(t *testing.T) {
 		knative.NewDescriber(false),
 		knative.KnativeDeployerName)
 }
+
+func TestInt_ResourceValidationOnFirstDeploy(t *testing.T) {
+	deployertesting.TestInt_ResourceValidationOnFirstDeploy(t,
+		knative.NewDeployer(knative.WithDeployerVerbose(true)),
+		knative.NewRemover(false),
+		knative.NewDescriber(false),
+		knative.KnativeDeployerName)
+}

--- a/pkg/knative/deployer_test.go
+++ b/pkg/knative/deployer_test.go
@@ -24,11 +24,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	fn "knative.dev/func/pkg/functions"
 	"knative.dev/pkg/ptr"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 const (
@@ -292,56 +292,83 @@ func setupRegistry(t *testing.T) http.RoundTripper {
 	return trans
 }
 
-// TestGenerateNewService_Envs ensures that environment variables defined on the
-// function are correctly included in the generated Knative Service container spec.
-// This is a regression test for issue #3514.
-func TestGenerateNewService_Envs(t *testing.T) {
-	ptr := func(s string) *string { return &s }
-
-	f := fn.Function{
-		Name: "test-func",
-		Deploy: fn.DeploySpec{
-			Image: "example.com/test:latest",
+// TestUpdateService_EnvsPropagated verifies that environment variables are correctly
+// written into the container spec when updating an existing Knative Service.
+// This exercises the update path through deployer.go (the updateService closure),
+// specifically the `cp.Env = newEnv` assignment that runs when redeploying a function
+// that already exists on the cluster. The former test in this slot (TestGenerateNewService_Envs)
+// tested pre-existing behaviour unrelated to the actual code change in this commit.
+func TestUpdateService_EnvsPropagated(t *testing.T) {
+	// Simulate an existing deployed service that carries a stale env var.
+	previousService := &servingv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-func",
+			Namespace: "default",
 		},
-		Run: fn.RunSpec{
-			Envs: fn.Envs{
-				{Name: ptr("MYVAR"), Value: ptr("myvalue")},
-				{Name: ptr("OTHER"), Value: ptr("othervalue")},
+		Spec: servingv1.ServiceSpec{
+			ConfigurationSpec: servingv1.ConfigurationSpec{
+				Template: servingv1.RevisionTemplateSpec{
+					Spec: servingv1.RevisionSpec{
+						PodSpec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Image: "example.com/test:v1",
+									Env:   []corev1.EnvVar{{Name: "OLD_VAR", Value: "old"}},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}
 
-	referencedSecrets := sets.New[string]()
-	referencedConfigMaps := sets.New[string]()
-	referencedPVCs := sets.New[string]()
-
-	service, err := generateNewService(f, nil, false, &referencedSecrets, &referencedConfigMaps, &referencedPVCs)
-	if err != nil {
-		t.Fatal(err)
+	f := fn.Function{
+		Name: "test-func",
+		Deploy: fn.DeploySpec{
+			Image: "example.com/test:v2",
+		},
 	}
 
-	containers := service.Spec.Template.Spec.Containers
+	// newEnv represents the resolved env vars the deployer computes via
+	// k8s.ProcessEnvs(f.Run.Envs, ...) before invoking updateService.
+	newEnv := []corev1.EnvVar{
+		{Name: "MYVAR", Value: "myvalue"},
+		{Name: "OTHER", Value: "othervalue"},
+	}
+
+	// Obtain the update closure — this mirrors what Deploy() does when
+	// previousService != nil (the service already exists on the cluster).
+	updateFn := updateService(f, previousService, newEnv, nil, nil, nil, nil, false)
+
+	// Apply the closure to a working copy of the service (mirroring what
+	// UpdateServiceWithRetry does internally on each attempt).
+	svcCopy := previousService.DeepCopy()
+	result, err := updateFn(svcCopy)
+	if err != nil {
+		t.Fatalf("updateService closure returned unexpected error: %v", err)
+	}
+
+	containers := result.Spec.Template.Spec.Containers
 	if len(containers) != 1 {
 		t.Fatalf("expected 1 container, got %d", len(containers))
 	}
 
-	envVars := containers[0].Env
-	// ProcessEnvs adds ADDRESS=0.0.0.0 and BUILT=<timestamp> automatically
-	foundMyVar := false
-	foundOther := false
-	for _, env := range envVars {
-		if env.Name == "MYVAR" && env.Value == "myvalue" {
-			foundMyVar = true
-		}
-		if env.Name == "OTHER" && env.Value == "othervalue" {
-			foundOther = true
-		}
+	gotEnv := containers[0].Env
+	envMap := make(map[string]string, len(gotEnv))
+	for _, e := range gotEnv {
+		envMap[e.Name] = e.Value
 	}
-	if !foundMyVar {
-		t.Errorf("expected MYVAR=myvalue in container env, got: %v", envVars)
+
+	if v, ok := envMap["MYVAR"]; !ok || v != "myvalue" {
+		t.Errorf("expected MYVAR=myvalue in updated container env, got: %v", gotEnv)
 	}
-	if !foundOther {
-		t.Errorf("expected OTHER=othervalue in container env, got: %v", envVars)
+	if v, ok := envMap["OTHER"]; !ok || v != "othervalue" {
+		t.Errorf("expected OTHER=othervalue in updated container env, got: %v", gotEnv)
+	}
+	// OLD_VAR must not survive: updateService replaces (not merges) the env list.
+	if _, ok := envMap["OLD_VAR"]; ok {
+		t.Errorf("expected OLD_VAR to be replaced by updateService but it was still present: %v", gotEnv)
 	}
 }
 

--- a/pkg/knative/deployer_test.go
+++ b/pkg/knative/deployer_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	fn "knative.dev/func/pkg/functions"
@@ -292,12 +293,10 @@ func setupRegistry(t *testing.T) http.RoundTripper {
 	return trans
 }
 
-// TestUpdateService_EnvsPropagated verifies that environment variables are correctly
-// written into the container spec when updating an existing Knative Service.
-// This exercises the update path through deployer.go (the updateService closure),
-// specifically the `cp.Env = newEnv` assignment that runs when redeploying a function
-// that already exists on the cluster. The former test in this slot (TestGenerateNewService_Envs)
-// tested pre-existing behaviour unrelated to the actual code change in this commit.
+// TestUpdateService_EnvsPropagated checks that the updateService closure replaces
+// (not merges) the container env list with the supplied newEnv slice.
+// It calls updateService directly — it does not exercise Deploy, ProcessEnvs, or
+// UpdateServiceWithRetry.
 func TestUpdateService_EnvsPropagated(t *testing.T) {
 	// Simulate an existing deployed service that carries a stale env var.
 	previousService := &servingv1.Service{
@@ -369,6 +368,42 @@ func TestUpdateService_EnvsPropagated(t *testing.T) {
 	// OLD_VAR must not survive: updateService replaces (not merges) the env list.
 	if _, ok := envMap["OLD_VAR"]; ok {
 		t.Errorf("expected OLD_VAR to be replaced by updateService but it was still present: %v", gotEnv)
+	}
+}
+
+// TestGenerateNewService_ResourceSetsPopulated is a regression test for the
+// create (first-deploy) path. It proves that generateNewService populates the
+// caller-supplied referencedSecrets and referencedConfigMaps sets so that the
+// subsequent CheckResourcesArePresent call in Deploy() actually validates them.
+// Before the fix, generateNewService allocated its own internal sets and the
+// caller's sets remained empty, causing validation to be silently skipped.
+func TestGenerateNewService_ResourceSetsPopulated(t *testing.T) {
+	secretName := "my-secret"
+	configMapName := "my-configmap"
+
+	f := fn.Function{
+		Name: "test-func",
+		Deploy: fn.DeploySpec{
+			Image: "example.com/test:v1",
+		},
+	}
+	f.Run.Envs.Add("FROM_SECRET", "{{ secret:"+secretName+":key }}")
+	f.Run.Envs.Add("FROM_CM", "{{ configMap:"+configMapName+":key }}")
+
+	referencedSecrets := sets.New[string]()
+	referencedConfigMaps := sets.New[string]()
+	referencedPVCs := sets.New[string]()
+
+	_, err := generateNewService(f, nil, false, &referencedSecrets, &referencedConfigMaps, &referencedPVCs)
+	if err != nil {
+		t.Fatalf("generateNewService returned unexpected error: %v", err)
+	}
+
+	if !referencedSecrets.Has(secretName) {
+		t.Errorf("expected referencedSecrets to contain %q after generateNewService, got: %v", secretName, referencedSecrets)
+	}
+	if !referencedConfigMaps.Has(configMapName) {
+		t.Errorf("expected referencedConfigMaps to contain %q after generateNewService, got: %v", configMapName, referencedConfigMaps)
 	}
 }
 

--- a/pkg/knative/deployer_test.go
+++ b/pkg/knative/deployer_test.go
@@ -24,8 +24,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	fn "knative.dev/func/pkg/functions"
 	"knative.dev/pkg/ptr"
 )
 
@@ -288,6 +290,59 @@ func setupRegistry(t *testing.T) http.RoundTripper {
 	}
 
 	return trans
+}
+
+// TestGenerateNewService_Envs ensures that environment variables defined on the
+// function are correctly included in the generated Knative Service container spec.
+// This is a regression test for issue #3514.
+func TestGenerateNewService_Envs(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+
+	f := fn.Function{
+		Name: "test-func",
+		Deploy: fn.DeploySpec{
+			Image: "example.com/test:latest",
+		},
+		Run: fn.RunSpec{
+			Envs: fn.Envs{
+				{Name: ptr("MYVAR"), Value: ptr("myvalue")},
+				{Name: ptr("OTHER"), Value: ptr("othervalue")},
+			},
+		},
+	}
+
+	referencedSecrets := sets.New[string]()
+	referencedConfigMaps := sets.New[string]()
+	referencedPVCs := sets.New[string]()
+
+	service, err := generateNewService(f, nil, false, &referencedSecrets, &referencedConfigMaps, &referencedPVCs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	containers := service.Spec.Template.Spec.Containers
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container, got %d", len(containers))
+	}
+
+	envVars := containers[0].Env
+	// ProcessEnvs adds ADDRESS=0.0.0.0 and BUILT=<timestamp> automatically
+	foundMyVar := false
+	foundOther := false
+	for _, env := range envVars {
+		if env.Name == "MYVAR" && env.Value == "myvalue" {
+			foundMyVar = true
+		}
+		if env.Name == "OTHER" && env.Value == "othervalue" {
+			foundOther = true
+		}
+	}
+	if !foundMyVar {
+		t.Errorf("expected MYVAR=myvalue in container env, got: %v", envVars)
+	}
+	if !foundOther {
+		t.Errorf("expected OTHER=othervalue in container env, got: %v", envVars)
+	}
 }
 
 func assertAuth(uname, pwd string, w http.ResponseWriter, r *http.Request) bool {


### PR DESCRIPTION
<!-- PR Title: fix: pass referenced resource sets to generateNewService for proper validation -->

# Changes

`generateNewService` in `pkg/knative/deployer.go` was allocating its own local
`referencedSecrets`, `referencedConfigMaps`, and `referencedPVCs` sets
internally. Those sets were never visible to the caller, so
`CheckResourcesArePresent` on the first-deploy path was always invoked with
empty sets, silently passing validation regardless of whether referenced
Secrets, ConfigMaps, or PVCs actually existed on the cluster.

The fix adds the three sets as parameters to `generateNewService` and removes
the internal allocations. `ProcessEnvs` and `ProcessVolumes` now populate the
caller-owned sets, so `CheckResourcesArePresent` receives the correct data and
can reject a deployment that references missing resources.

On the test side, Two new tests are added:
`TestUpdateService_EnvsPropagated` calls the `updateService` closure directly
against a service with a stale env var and asserts that the container env list
is replaced, not merged; `TestGenerateNewService_ResourceSetsPopulated` is a
regression test for the create path that asserts the caller-supplied
`referencedSecrets` and `referencedConfigMaps` sets are populated after
`generateNewService` returns — a future regression that reintroduces internal
allocation would cause this test to fail.

relates #3514
