### PR TITLE
Use correct namespace in KEAD and k8s listers

### DIFF
--- a/pkg/k8s/lister.go
+++ b/pkg/k8s/lister.go
@@ -42,7 +42,7 @@ func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, err
 			continue
 		}
 
-		item, err := l.get(ctx, clientset, service.Name, namespace)
+		item, err := l.get(ctx, clientset, service.Name, service.Namespace)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get details about function: %v", err)
 		}

--- a/pkg/keda/lister.go
+++ b/pkg/keda/lister.go
@@ -49,7 +49,7 @@ func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, err
 			continue
 		}
 
-		item, err := l.get(ctx, httpScaledObjectClientset, service.Name, namespace)
+		item, err := l.get(ctx, httpScaledObjectClientset, service.Name, service.Namespace)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get details about function: %v", err)
 		}


### PR DESCRIPTION
Use correct namespace for Keda and k8s lister.

Before:

```
$ func list --all-namespaces                                    
Error: unable to get details about function: unable to get HTTPScaledObject: the server could not find the requested resource (get httpscaledobjects.http.keda.sh my-func)

...
```

With the fix of this PR:
```
$ ./func list --all-namespaces                                                                                                          1 ↵
NAME     NAMESPACE  RUNTIME  DEPLOYER  URL                                                 READY
my-func  default             keda      http://my-func-interceptor-bridge.default.svc:8080  True
```