### PR TITLE
feat: add platform support to pack builder

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -123,7 +123,7 @@ EXAMPLES
 	cmd.Flags().BoolP("push", "u", false,
 		"Attempt to push the function image to the configured registry after being successfully built")
 	cmd.Flags().StringP("platform", "", "",
-		"Optionally specify a target platform, for example \"linux/amd64\" when using the s2i build strategy")
+		"Optionally specify a target platform, for example \"linux/amd64\" when using the s2i or pack build strategy")
 	cmd.Flags().StringP("username", "", "",
 		"Username to use when pushing to the registry. ($FUNC_USERNAME)")
 	cmd.Flags().StringP("password", "", "",
@@ -234,7 +234,7 @@ type buildConfig struct {
 	// working directory of the process.
 	Path string
 
-	// Platform ofr resultant image (s2i builder only)
+	// Platform for resultant image (s2i and pack builders)
 	Platform string
 
 	// Push the resulting image to the registry after building.
@@ -414,8 +414,8 @@ func (c buildConfig) Validate(cmd *cobra.Command) (err error) {
 		return fn.ErrConflictingImageAndRegistry
 	}
 
-	// Platform is only supported with the S2I builder at this time
-	if c.Platform != "" && c.Builder != builders.S2I {
+	// Platform is only supported with the S2I and Pack builders
+	if c.Platform != "" && c.Builder != builders.S2I && c.Builder != builders.Pack {
 		err = fn.ErrPlatformNotSupported
 		return
 	}
@@ -433,11 +433,10 @@ func (c buildConfig) Validate(cmd *cobra.Command) (err error) {
 // builder and pusher are the default implementations and the Pack and S2I
 // constructors simplified.
 //
-// TODO: Platform is currently only used by the S2I builder.  This should be
-// a multi-valued argument which passes through to the "host" builder (which
-// supports multi-arch/platform images), and throw an error if either trying
-// to specify a platform for buildpacks, or trying to specify more than one
-// for S2I.
+// TODO: Platform is currently only used by the S2I and Pack builders (single
+// platform each).  This should be a multi-valued argument which passes through
+// to the "host" builder (which supports multi-arch/platform images), and throw
+// an error if trying to specify more than one for S2I or Pack.
 //
 // TODO: As a further optimization, it might be ideal to only build the
 // image necessary for the target cluster, since the end product of a function
@@ -496,7 +495,7 @@ func (c buildConfig) buildOptions() (oo []fn.BuildOption, err error) {
 	//
 	// TODO: upgrade --platform to a multi-value field.  The individual builder
 	// implementations are responsible for bubbling an error if they do
-	// not support this.  Pack  supports none, S2I supports one, host builder
+	// not support this.  Pack supports one, S2I supports one, host builder
 	// supports multi.
 	if c.Platform != "" {
 		parts := strings.Split(c.Platform, "/")

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -83,15 +83,16 @@ func NewErrPlatformNotSupported(err error, cmd string) error {
 func (e *ErrPlatformNotSupported) Error() string {
 	return fmt.Sprintf(`%v
 
-The --platform flag is only supported with the S2I builder.
+The --platform flag is only supported with the S2I and Pack builders.
 
 Try this:
   func %s --registry <registry> --builder=s2i --platform linux/amd64
+  func %s --registry <registry> --builder=pack --platform linux/amd64
 
 Or remove the --platform flag:
   func %s --registry <registry>
 
-For more options, run 'func %s --help'`, e.Err, e.Cmd, e.Cmd, e.Cmd)
+For more options, run 'func %s --help'`, e.Err, e.Cmd, e.Cmd, e.Cmd, e.Cmd)
 }
 
 func (e *ErrPlatformNotSupported) Unwrap() error {

--- a/docs/reference/func_build.md
+++ b/docs/reference/func_build.md
@@ -66,7 +66,7 @@ func build
   -i, --image string               Full image name in the form [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over --registry ($FUNC_IMAGE)
       --password string            Password to use when pushing to the registry. ($FUNC_PASSWORD)
   -p, --path string                Path to the function.  Default is current directory ($FUNC_PATH)
-      --platform string            Optionally specify a target platform, for example "linux/amd64" when using the s2i build strategy
+      --platform string            Optionally specify a target platform, for example "linux/amd64" when using the s2i or pack build strategy
   -u, --push                       Attempt to push the function image to the configured registry after being successfully built
   -r, --registry string            Container registry + registry namespace. (ex 'ghcr.io/myuser').  The full image name is automatically determined using this along with function name. ($FUNC_REGISTRY)
       --registry-authfile string   Path to a authentication file containing registry credentials ($FUNC_REGISTRY_AUTHFILE)

--- a/pkg/buildpacks/builder.go
+++ b/pkg/buildpacks/builder.go
@@ -121,14 +121,20 @@ var DefaultLifecycleImage = "docker.io/buildpacksio/lifecycle:553c041"
 
 // Build the Function at path.
 func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platform) (err error) {
-	if len(platforms) != 0 {
-		return errors.New("the pack builder does not support specifying target platforms directly")
-	}
-
 	// Builder image from the function if defined, default otherwise.
 	image, err := BuilderImage(f, b.name)
 	if err != nil {
 		return
+	}
+
+	// Validate Platforms
+	if len(platforms) == 1 {
+		platform := strings.ToLower(platforms[0].OS + "/" + platforms[0].Architecture)
+		if image, err = docker.GetPlatformImage(image, platform); err != nil {
+			return fmt.Errorf("cannot get platform image reference for %q: %w", platform, err)
+		}
+	} else if len(platforms) > 1 {
+		return errors.New("the pack builder currently only supports specifying a single target platform")
 	}
 
 	buildpacks := f.Build.Buildpacks
@@ -171,6 +177,9 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 			Network string
 			Volumes []string
 		}{Network: "", Volumes: nil},
+	}
+	if len(platforms) == 1 {
+		opts.Platform = strings.ToLower(platforms[0].OS + "/" + platforms[0].Architecture)
 	}
 	if b.withTimestamp {
 		now := time.Now()

--- a/pkg/buildpacks/builder_test.go
+++ b/pkg/buildpacks/builder_test.go
@@ -304,6 +304,78 @@ func TestBuild_Errors(t *testing.T) {
 	}
 }
 
+// TestBuild_PlatformSingle ensures that when a single platform is specified,
+// opts.Platform is set correctly on the pack BuildOptions.
+func TestBuild_PlatformSingle(t *testing.T) {
+	var (
+		i = &mockImpl{}
+		b = NewBuilder(WithImpl(i))
+		f = fn.Function{Runtime: "node"}
+	)
+
+	i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
+		expected := "linux/amd64"
+		if opts.Platform != expected {
+			t.Fatalf("expected platform '%v', got '%v'", expected, opts.Platform)
+		}
+		return nil
+	}
+
+	platforms := []fn.Platform{{OS: "linux", Architecture: "amd64"}}
+	if err := b.Build(t.Context(), f, platforms); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestBuild_PlatformMultiple ensures that specifying more than one platform
+// returns an error.
+func TestBuild_PlatformMultiple(t *testing.T) {
+	var (
+		i = &mockImpl{}
+		b = NewBuilder(WithImpl(i))
+		f = fn.Function{Runtime: "node"}
+	)
+
+	i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
+		t.Fatal("build should not have been invoked")
+		return nil
+	}
+
+	platforms := []fn.Platform{
+		{OS: "linux", Architecture: "amd64"},
+		{OS: "linux", Architecture: "arm64"},
+	}
+	err := b.Build(t.Context(), f, platforms)
+	if err == nil {
+		t.Fatal("expected an error but got nil")
+	}
+	expected := "the pack builder currently only supports specifying a single target platform"
+	if err.Error() != expected {
+		t.Fatalf("expected error %q, got %q", expected, err.Error())
+	}
+}
+
+// TestBuild_PlatformNone ensures that passing no platforms still works
+// and opts.Platform is empty.
+func TestBuild_PlatformNone(t *testing.T) {
+	var (
+		i = &mockImpl{}
+		b = NewBuilder(WithImpl(i))
+		f = fn.Function{Runtime: "node"}
+	)
+
+	i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
+		if opts.Platform != "" {
+			t.Fatalf("expected empty platform, got '%v'", opts.Platform)
+		}
+		return nil
+	}
+
+	if err := b.Build(t.Context(), f, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
 type mockImpl struct {
 	BuildFn func(context.Context, pack.BuildOptions) error
 }


### PR DESCRIPTION
# Changes

* feat: add platform support to pack builder

  The pack builder previously rejected any --platform flag with a hard error. Since the pack library already supports a Platform field in BuildOptions, this enables single-platform builds following the same pattern as the s2i builder: resolve the builder image via docker.GetPlatformImage and set opts.Platform so pack also pulls the correct run image.

  Multiple platforms are still rejected with a clear error, and omitting --platform continues to work as before.


```release-note
feat: add platform support to pack builder
```