### PR TITLE
Add middleware-version label on pack remote builds too

### DIFF
--- a/cmd/func-util/main.go
+++ b/cmd/func-util/main.go
@@ -101,10 +101,6 @@ func scaffold(ctx context.Context) error {
 		middlewareVersion = "<unknown>"
 	}
 
-	if err := os.WriteFile("/tekton/results/middlewareVersion", []byte(middlewareVersion), 0644); err != nil {
-		return fmt.Errorf("cannot write middleware version as a result: %w", err)
-	}
-
 	if err := os.WriteFile(middlewareFileName, []byte(middlewareVersion), 0644); err != nil {
 		return fmt.Errorf("cannot write middleware version as a file: %w", err)
 	}

--- a/pkg/pipelines/tekton/task-buildpack.yaml.tmpl
+++ b/pkg/pipelines/tekton/task-buildpack.yaml.tmpl
@@ -146,6 +146,16 @@ spec:
             fi
         done
 
+        # Add middleware version as image label
+        middleware_version_file="$(workspaces.source.path)/middleware-version"
+        if [ -f "$middleware_version_file" ]; then
+          middleware_version="$(cat "$middleware_version_file")"
+          echo "--> Adding middleware version label: $middleware_version"
+          echo -n "middleware-version=$middleware_version" >> "${ENV_DIR}/BP_IMAGE_LABELS"
+        else
+          echo "No middleware-version file ($middleware_version_file) found"
+        fi
+
         ############################################
         ##### Added part for Knative Functions #####
         ############################################


### PR DESCRIPTION
Fix the pack remote builder to add the middleware-version label too