### PR TITLE
Bump golangci-lint to 2.11.4

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,7 +2,6 @@ version: "2"
 linters:
   enable:
     - unconvert
-    - prealloc
     - bodyclose
   exclusions:
     generated: lax

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ check-eof: ## Check files end with newlines
 		done | grep . && exit 1 || true
 
 $(BIN_GOLANGCI_LINT):
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v2.5.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v2.11.4
 
 $(BIN_MISSPELL):
 	@echo "Installing misspell..."

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -280,7 +280,7 @@ func singleCommand(cmd *cobra.Command, args []string, cfg createConfig) string {
 		b.WriteString(" -r " + cfg.Repository)
 	}
 	if cmd.Flags().Lookup("verbose").Changed {
-		b.WriteString(fmt.Sprintf(" -v %v", cfg.Verbose))
+		fmt.Fprintf(&b, " -v %v", cfg.Verbose)
 	}
 	if len(args) > 0 {
 		b.WriteString(" " + cfg.Path) // optional trailing <path> argument

--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -353,7 +353,7 @@ func (f Function) Validate() error {
 	}
 
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("'%v' contains errors:", FunctionFile))
+	fmt.Fprintf(&b, "'%v' contains errors:", FunctionFile)
 
 	for _, ee := range errs {
 		if len(ee) > 0 {


### PR DESCRIPTION
Default Go was bumped to 1.26 (https://github.com/knative/actions/commit/8eec6924c3bf1d8a12b04f0e444e5e14ce26618f) which causes the linter to panic.