### PR TITLE
fix: detect podman-docker in CONTAINER_ENGINE resolution

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -44,7 +44,25 @@ populate_environment() {
   else
     export ARCH="$ARCH"
   fi
-  export CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
+  # Resolve the actual container engine:
+  #  1. Honour explicit CONTAINER_ENGINE if already set.
+  #  2. Default to docker.
+  #  3. If docker is actually podman (podman-docker package), switch to podman.
+  #  4. If docker is absent but podman is present, use podman.
+  if [[ -z "${CONTAINER_ENGINE:-}" ]]; then
+    if command -v docker &>/dev/null; then
+      CONTAINER_ENGINE=docker
+      # Detect podman-docker: /usr/bin/docker is a wrapper that exec's podman.
+      if docker --version 2>/dev/null | grep -qi podman; then
+        CONTAINER_ENGINE=podman
+      fi
+    elif command -v podman &>/dev/null; then
+      CONTAINER_ENGINE=podman
+    else
+      CONTAINER_ENGINE=docker
+    fi
+  fi
+  export CONTAINER_ENGINE
   export TERM="${TERM:-dumb}"
 
   echo "KUBECONFIG=${KUBECONFIG}"


### PR DESCRIPTION
## Summary

When `CONTAINER_ENGINE` is unset, `hack/common.sh` previously defaulted to
`docker` unconditionally. On systems with the `podman-docker` package installed,
`/usr/bin/docker` is a shell wrapper that exec's podman. This caused downstream
scripts to never fire their podman-specific workarounds, even when podman was
the actual runtime.

## Changes

- `hack/common.sh`: Replaces the single-line `export CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}` with a detection block that:
  1. Honours an explicit `CONTAINER_ENGINE` if already set.
  2. Defaults to `docker` if `docker` is found in PATH.
  3. Detects podman-docker: if `docker --version` output contains "podman", switches to `podman`.
  4. Falls back to `podman` if `docker` is absent but `podman` is present.

## Testing

This is a shell-only change in `hack/common.sh`. Verified manually on a system
with `podman-docker` installed — `CONTAINER_ENGINE` is now correctly resolved to
`podman`.

Assisted-by: 🤖 Claude Opus/Sonnet 4.6