### PR TITLE
Remove legacy build directives

### DIFF
--- a/cmd/config_labels_test.go
+++ b/cmd/config_labels_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cmd
 

--- a/cmd/func-util/main.go
+++ b/cmd/func-util/main.go
@@ -1,5 +1,4 @@
 //go:build exclude_graphdriver_btrfs || !cgo
-// +build exclude_graphdriver_btrfs !cgo
 
 package main
 

--- a/cmd/func-util/s2i_generate.go
+++ b/cmd/func-util/s2i_generate.go
@@ -1,5 +1,4 @@
 //go:build exclude_graphdriver_btrfs || !cgo
-// +build exclude_graphdriver_btrfs !cgo
 
 package main
 

--- a/cmd/prompt/prompt_test.go
+++ b/cmd/prompt/prompt_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package prompt
 

--- a/e2e/e2e_config_ci_test.go
+++ b/e2e/e2e_config_ci_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/e2e/e2e_core_test.go
+++ b/e2e/e2e_core_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/e2e/e2e_credentials_test.go
+++ b/e2e/e2e_credentials_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/e2e/e2e_matrix_test.go
+++ b/e2e/e2e_matrix_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/e2e/e2e_metadata_test.go
+++ b/e2e/e2e_metadata_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/e2e/e2e_podman_test.go
+++ b/e2e/e2e_podman_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/e2e/e2e_python_update_test.go
+++ b/e2e/e2e_python_update_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/e2e/e2e_remote_test.go
+++ b/e2e/e2e_remote_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Package e2e provides an end-to-end test suite for the Functions CLI "func".

--- a/e2e/e2e_trigger_sync_test.go
+++ b/e2e/e2e_trigger_sync_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/e2e/e2e_userdeps_test.go
+++ b/e2e/e2e_userdeps_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 /*
 Copyright 2021 The Knative Authors

--- a/pkg/docker/docker_client_nonlinux.go
+++ b/pkg/docker/docker_client_nonlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package docker
 

--- a/pkg/docker/docker_client_pm_test.go
+++ b/pkg/docker/docker_client_pm_test.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package docker_test
 

--- a/pkg/docker/runner_int_test.go
+++ b/pkg/docker/runner_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package docker_test
 

--- a/pkg/functions/client_int_test.go
+++ b/pkg/functions/client_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package functions_test
 

--- a/pkg/http/openshift_int_test.go
+++ b/pkg/http/openshift_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package http_test
 

--- a/pkg/k8s/deployer_int_test.go
+++ b/pkg/k8s/deployer_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package k8s_test
 

--- a/pkg/k8s/describer_int_test.go
+++ b/pkg/k8s/describer_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package k8s_test
 

--- a/pkg/k8s/dialer_int_test.go
+++ b/pkg/k8s/dialer_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package k8s_test
 

--- a/pkg/k8s/lister_int_test.go
+++ b/pkg/k8s/lister_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package k8s_test
 

--- a/pkg/k8s/logs_int_test.go
+++ b/pkg/k8s/logs_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package k8s_test
 

--- a/pkg/k8s/persistent_volumes_int_test.go
+++ b/pkg/k8s/persistent_volumes_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package k8s_test
 

--- a/pkg/k8s/remover_int_test.go
+++ b/pkg/k8s/remover_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package k8s_test
 

--- a/pkg/keda/deployer_int_test.go
+++ b/pkg/keda/deployer_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package keda_test
 

--- a/pkg/keda/describer_int_test.go
+++ b/pkg/keda/describer_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package keda_test
 

--- a/pkg/keda/lister_int_test.go
+++ b/pkg/keda/lister_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package keda_test
 

--- a/pkg/keda/remover_int_test.go
+++ b/pkg/keda/remover_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package keda_test
 

--- a/pkg/knative/deployer_int_test.go
+++ b/pkg/knative/deployer_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package knative_test
 

--- a/pkg/knative/describer_int_test.go
+++ b/pkg/knative/describer_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package knative_test
 

--- a/pkg/knative/lister_int_test.go
+++ b/pkg/knative/lister_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package knative_test
 

--- a/pkg/knative/remover_int_test.go
+++ b/pkg/knative/remover_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package knative_test
 

--- a/pkg/pipelines/tekton/gitlab_int_test.go
+++ b/pkg/pipelines/tekton/gitlab_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package tekton_test
 

--- a/pkg/pipelines/tekton/pipelines_int_test.go
+++ b/pkg/pipelines/tekton/pipelines_int_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package tekton_test
 

--- a/pkg/ssh/ssh_agent_conf.go
+++ b/pkg/ssh/ssh_agent_conf.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package ssh
 

--- a/pkg/ssh/ssh_posix_test.go
+++ b/pkg/ssh/ssh_posix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package ssh_test
 

--- a/pkg/utils/names_test.go
+++ b/pkg/utils/names_test.go
@@ -1,5 +1,4 @@
 //go:build !integration
-// +build !integration
 
 package utils
 


### PR DESCRIPTION
The `// +build` syntax is only for compatibility with Go < 1.17. We now require Go 1.25.