### PR TITLE
feat: improved host builder .funcignore support

### DIFF
--- a/pkg/oci/builder.go
+++ b/pkg/oci/builder.go
@@ -41,6 +41,25 @@ var defaultIgnored = []string{
 	".gitignore",
 }
 
+// readFuncIgnore reads the .funcignore file from the given root directory
+// and returns its patterns with blank lines and '#' comments removed. A
+// missing or unreadable file returns nil; .funcignore is optional.
+func readFuncIgnore(root string) []string {
+	data, err := os.ReadFile(filepath.Join(root, ".funcignore"))
+	if err != nil {
+		return nil
+	}
+	var patterns []string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		patterns = append(patterns, line)
+	}
+	return patterns
+}
+
 var builders = map[string]languageBuilder{
 	"go":     goBuilder{},
 	"python": pythonBuilder{},
@@ -299,7 +318,10 @@ func writeDataLayer(job buildJob) (layer imageLayer, err error) {
 	source := job.function.Root // The source is the function's entire filesystem
 	target := filepath.Join(job.buildDir(), "datalayer.tar.gz")
 
-	if err = newDataTarball(source, target, defaultIgnored, job.verbose); err != nil {
+	ignored := append([]string{}, defaultIgnored...)
+	ignored = append(ignored, readFuncIgnore(source)...)
+
+	if err = newDataTarball(source, target, ignored, job.verbose); err != nil {
 		return
 	}
 
@@ -340,9 +362,26 @@ func newDataTarball(root, target string, ignored []string, verbose bool) error {
 			return err
 		}
 
-		// Skip files explicitly ignored
+		relPath, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+
+		// Skip files explicitly ignored. Two pattern forms are supported:
+		//   "/foo/bar" — root-relative; matches that exact path and
+		//                everything beneath it.
+		//   "foo"     — base-name; matches any entry named "foo" at any
+		//                depth (the historical default).
 		for _, v := range ignored {
-			if info.Name() == v {
+			match := false
+			if strings.HasPrefix(v, "/") {
+				p := v[1:]
+				r := filepath.ToSlash(relPath)
+				match = r == p || strings.HasPrefix(r, p+"/")
+			} else {
+				match = info.Name() == v
+			}
+			if match {
 				if info.IsDir() {
 					return filepath.SkipDir
 				}
@@ -362,10 +401,6 @@ func newDataTarball(root, target string, ignored []string, verbose bool) error {
 			return err
 		}
 
-		relPath, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
 		header.Name = slashpath.Join("/func", filepath.ToSlash(relPath))
 		header.Uid = DefaultUid
 		header.Gid = DefaultGid

--- a/pkg/oci/builder_test.go
+++ b/pkg/oci/builder_test.go
@@ -469,6 +469,114 @@ func (l *TestLanguageBuilder) Configure(job buildJob, p v1.Platform, c v1.Config
 	return l.ConfigureFn(job, p, c)
 }
 
+// Test_readFuncIgnore ensures that the .funcignore file is parsed correctly,
+// skipping comments and blank lines.
+func Test_readFuncIgnore(t *testing.T) {
+	root := t.TempDir()
+
+	content := `
+# Comment
+/design
+/archive
+.jj
+`
+	if err := os.WriteFile(filepath.Join(root, ".funcignore"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	patterns := readFuncIgnore(root)
+	expected := []string{"/design", "/archive", ".jj"}
+
+	if diff := cmp.Diff(expected, patterns); diff != "" {
+		t.Error("patterns differ (-want, +got):", diff)
+	}
+}
+
+// Test_readFuncIgnore_missing ensures that a missing .funcignore returns nil.
+func Test_readFuncIgnore_missing(t *testing.T) {
+	root := t.TempDir()
+
+	patterns := readFuncIgnore(root)
+	if patterns != nil {
+		t.Fatalf("expected nil, got %v", patterns)
+	}
+}
+
+// Test_newDataTarball_funcIgnore ensures that directories listed in
+// .funcignore are excluded from the data tarball, even if they contain
+// absolute symlinks that would otherwise cause an error.
+func Test_newDataTarball_funcIgnore(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink tests not supported on windows")
+	}
+
+	root := t.TempDir()
+
+	// Create a normal file
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a directory with an absolute symlink (like .jj would have)
+	jjDir := filepath.Join(root, ".jj")
+	if err := os.MkdirAll(filepath.Join(jjDir, "repo"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("/var/absolute/target", filepath.Join(jjDir, "repo", "config-id")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Without funcignore, the build should fail due to absolute symlink
+	target := filepath.Join(root, "test-fail.tar.gz")
+	err := newDataTarball(root, target, defaultIgnored, false)
+	if err == nil {
+		t.Fatal("expected error for absolute symlink without funcignore")
+	}
+
+	// With /.jj in the ignored list (as read from .funcignore), it should succeed
+	ignored := append([]string{}, defaultIgnored...)
+	ignored = append(ignored, "/.jj")
+
+	target = filepath.Join(root, "test-pass.tar.gz")
+	if err := newDataTarball(root, target, ignored, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify a.txt is in the tarball but .jj is not
+	f, err := os.Open(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+	foundA := false
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatal(err)
+		}
+		if hdr.Name == "/func/a.txt" {
+			foundA = true
+		}
+		if strings.Contains(hdr.Name, ".jj") {
+			t.Fatalf(".jj should be excluded but found: %v", hdr.Name)
+		}
+	}
+	if !foundA {
+		t.Fatal("a.txt not found in tarball")
+	}
+}
+
 // Test_validatedLinkTarget ensures that the function disallows
 // links which are absolute or refer to targets outside the given root, in
 // addition to the basic job of returning the value of reading the link.


### PR DESCRIPTION
The host (OCI) builder walks the function root to build its data layer and applies a fixed defaultIgnored list (.git, .func, .funcignore, .gitignore). Workspace-specific directories outside that list — most commonly .jj/, which contains absolute symlinks to system sockets — trip validatedLinkTarget and make the build fail, with no way for the user to opt out.

Fix is to read .funcignore (which the s2i builder already honors via a .s2iignore symlink) and append its patterns to defaultIgnored. Supports two pattern forms:

  /foo/bar  root-relative; excludes that path and its descendants
  foo       base-name; excludes any entry named 'foo' at any depth
