### PR TITLE
Remove stern dependency from subscription e2e tests

### DIFF
--- a/e2e/e2e_metadata_test.go
+++ b/e2e/e2e_metadata_test.go
@@ -4,7 +4,6 @@
 package e2e
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -14,7 +13,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -728,32 +726,33 @@ func TestMetadata_Subscriptions_Raw(t *testing.T) {
 func waitForEvent(t *testing.T, functionName, eventId string) <-chan string {
 	t.Helper()
 
-	eventReceived := make(chan string, 10)
+	eventReceived := make(chan string, 1)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
-	pr, pw := io.Pipe()
-	cmd := exec.CommandContext(ctx, "stern", functionName+"-.*", "-n", Namespace)
-	cmd.Stderr = io.Discard
-	cmd.Stdout = pw
-	cmd.Env = append(os.Environ(), "KUBECONFIG="+Kubeconfig)
-	err := cmd.Start()
-	if err != nil {
-		t.Fatal(err)
-	}
 	go func() {
-		r := bufio.NewReader(pr)
-		m, e := regexp.MatchReader(`EVENT_RECEIVED: id=`+eventId, r)
-		if e != nil {
-			panic(e)
+		pattern := `EVENT_RECEIVED: id=` + eventId
+		for {
+			if ctx.Err() != nil {
+				return
+			}
+			cmd := exec.CommandContext(ctx, "kubectl", "logs",
+				"-l", "function.knative.dev/name="+functionName,
+				"-n", Namespace, "--all-containers=true")
+			cmd.Env = append(os.Environ(), "KUBECONFIG="+Kubeconfig)
+			out, _ := cmd.Output()
+			if strings.Contains(string(out), pattern) {
+				eventReceived <- "OK"
+				cancel()
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(2 * time.Second):
+			}
 		}
-		if m {
-			eventReceived <- "OK"
-			close(eventReceived)
-			cancel()
-		}
-		_, _ = io.Copy(io.Discard, r)
 	}()
 
 	return eventReceived


### PR DESCRIPTION
When running E2E tests on a new machine, I noticed that stern became a hard dependency in our test suite.  This is a quick fix, because the use case can be covered with this somewhat awkward kubectl logs command, however.

A more complete solution could be to use a second Function, deployed alongside the subscriber, which awaits a POST from the subscriber indicating it received the event, and the test just waits for that "verifier" to retuturn the expected event was received via its default endpoint.