### PR TITLE
Add function ready status in describe output

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -152,6 +152,8 @@ func (i info) Human(w io.Writer) error {
 		fmt.Fprintf(w, "  %v\n", route)
 	}
 
+	fmt.Fprintln(w, "Function is ready:")
+	fmt.Fprintf(w, "  %v\n", i.Ready)
 	fmt.Fprintln(w, "Deployer:")
 	fmt.Fprintf(w, "  %v\n", i.Deployer)
 
@@ -180,6 +182,7 @@ func (i info) Plain(w io.Writer) error {
 		fmt.Fprintf(w, "Route %v\n", route)
 	}
 
+	fmt.Fprintf(w, "Ready %v\n", i.Ready)
 	fmt.Fprintf(w, "Deployer %v\n", i.Deployer)
 
 	if len(i.Subscriptions) > 0 {

--- a/pkg/functions/client.go
+++ b/pkg/functions/client.go
@@ -189,6 +189,7 @@ type Instance struct {
 	Labels        map[string]string `json:"labels" yaml:"labels" xml:"-"`
 	Middleware    Middleware        `json:"middleware,omitempty" yaml:"middleware,omitempty"`
 	Generation    int64             `json:"generation,omitempty" yaml:"generation,omitempty"`
+	Ready         string            `json:"ready,omitempty" yaml:"ready,omitempty"`
 }
 
 // Subscriptions currently active to event sources

--- a/pkg/k8s/describer.go
+++ b/pkg/k8s/describer.go
@@ -3,7 +3,10 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fn "knative.dev/func/pkg/functions"
@@ -55,6 +58,14 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (fn.In
 		return fn.Instance{}, fmt.Errorf("unable to get deployment %q: %v", name, err)
 	}
 
+	ready := corev1.ConditionUnknown
+	for _, con := range deployment.Status.Conditions {
+		if con.Type == v1.DeploymentAvailable {
+			ready = con.Status
+			break
+		}
+	}
+
 	primaryRouteURL := fmt.Sprintf("http://%s.%s.svc", name, namespace) // TODO: get correct scheme?
 
 	// get image
@@ -86,6 +97,7 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (fn.In
 			Version: middlewareVersion,
 		},
 		Generation: deployment.Generation,
+		Ready:      strings.ToLower(string(ready)),
 	}
 
 	return description, nil

--- a/pkg/keda/describer.go
+++ b/pkg/keda/describer.go
@@ -3,8 +3,12 @@ package keda
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/kedacore/http-add-on/operator/apis/http/v1alpha1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fn "knative.dev/func/pkg/functions"
 	"knative.dev/func/pkg/k8s"
@@ -60,6 +64,13 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (fn.In
 		return fn.Instance{}, fmt.Errorf("unable to get HTTPScaledObject: %w", err)
 	}
 
+	ready := v1.ConditionUnknown
+	if meta.IsStatusConditionTrue(httpScaledObject.Status.Conditions, v1alpha1.ConditionTypeReady) {
+		ready = v1.ConditionTrue
+	} else if meta.IsStatusConditionFalse(httpScaledObject.Status.Conditions, v1alpha1.ConditionTypeReady) {
+		ready = v1.ConditionFalse
+	}
+
 	if len(httpScaledObject.Spec.Hosts) == 0 {
 		return fn.Instance{}, fmt.Errorf("HTTPScaledObject %q does not have any hosts", name)
 	}
@@ -105,6 +116,7 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (fn.In
 			Version: middlewareVersion,
 		},
 		Generation: deployment.Generation,
+		Ready:      strings.ToLower(string(ready)),
 	}
 
 	return description, nil

--- a/pkg/knative/describer.go
+++ b/pkg/knative/describer.go
@@ -3,13 +3,16 @@ package knative
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientservingv1 "knative.dev/client/pkg/serving/v1"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	fn "knative.dev/func/pkg/functions"
 	"knative.dev/func/pkg/k8s"
+	"knative.dev/pkg/apis"
 )
 
 type Describer struct {
@@ -66,6 +69,14 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (fn.In
 
 	// We're responsible, for this function --> proceed...
 
+	ready := corev1.ConditionUnknown
+	for _, con := range service.Status.Conditions {
+		if con.Type == apis.ConditionReady {
+			ready = con.Status
+			break
+		}
+	}
+
 	routes, err := servingClient.ListRoutes(ctx, clientservingv1.WithService(name))
 	if err != nil {
 		return fn.Instance{}, err
@@ -89,6 +100,7 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (fn.In
 		Routes:     routeURLs,
 		Labels:     service.Labels,
 		Generation: service.Generation,
+		Ready:      strings.ToLower(string(ready)),
 	}
 
 	// get used image (including the sha)


### PR DESCRIPTION
It'd be nice to see in the output of `func describe` to see if a function is ready or not like we have in `func list`: 

```
$ func list                     
NAME     NAMESPACE  RUNTIME  DEPLOYER  URL                                       READY
my-func  default             knative   http://my-func.default.svc.cluster.local  False
```


This PR addresses it and adds it to the output:

```
$ func describe my-func                             
Function name:
  my-func
Function is built in image:
 localhost:5001/my-func@sha256:10c2f7cd025266811b9482ae7014b8b293b9a3c78d41d8ab92b0deacf0e37cd1
Function is deployed in namespace:
  default
Routes:
  http://my-func.default.svc.cluster.local
Function is ready:
  false
Deployer:
  knative
Labels:
  boson.dev/function: true
  function.knative.dev/name: my-func
  function.knative.dev/runtime: go

$ func describe my-func -o yaml                     
route: http://my-func.default.svc.cluster.local
...
ready: "false"
```

# Changes

- :gift: Add function status in describe output

/kind enhancement

**Release Note**
```release-note
Provide functions ready status in "func describe" output
```