### PR TITLE
ci: add workflow_dispatch trigger to functions workflow

### DIFF
--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -15,6 +15,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Closes #3633

## Summary

- Adds `workflow_dispatch` trigger to the `Functions` CI workflow
- Enables manual reruns directly from the GitHub Actions UI without requiring a code push or new pull request

## Test plan

- [ ] Verify the workflow appears with a "Run workflow" button in the Actions tab after merge