### PR TITLE
ci: delete runner caches when PR is closed

### DIFF
--- a/.github/workflows/cleanup-pr-caches.yaml
+++ b/.github/workflows/cleanup-pr-caches.yaml
@@ -1,0 +1,41 @@
+name: Cleanup PR Caches
+
+permissions:
+  actions: write
+  contents: read
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    name: Delete runner caches for closed PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Delete caches
+        run: |
+          REPO="${{ github.repository }}"
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+          echo "Listing caches for branch: $BRANCH"
+          cache_keys=$(gh actions-cache list \
+            --repo "$REPO" \
+            --branch "$BRANCH" \
+            --limit 100 \
+            | cut -f1)
+          if [ -z "$cache_keys" ]; then
+            echo "No caches found for this PR."
+            exit 0
+          fi
+          echo "Deleting caches..."
+          while IFS= read -r key; do
+            gh actions-cache delete "$key" \
+              --repo "$REPO" \
+              --branch "$BRANCH" \
+              --confirm
+            echo "Deleted: $key"
+          done <<< "$cache_keys"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cleanup-pr-caches.yaml
+++ b/.github/workflows/cleanup-pr-caches.yaml
@@ -1,9 +1,5 @@
 name: Cleanup PR Caches
 
-permissions:
-  actions: write
-  contents: read
-
 on:
   pull_request:
     types:
@@ -14,28 +10,28 @@ jobs:
     name: Delete runner caches for closed PR
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
     steps:
       - name: Delete caches
         run: |
           REPO="${{ github.repository }}"
           BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
           echo "Listing caches for branch: $BRANCH"
-          cache_keys=$(gh actions-cache list \
-            --repo "$REPO" \
-            --branch "$BRANCH" \
-            --limit 100 \
-            | cut -f1)
-          if [ -z "$cache_keys" ]; then
+          cache_ids=$(gh api --paginate \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$REPO/actions/caches?ref=$BRANCH&per_page=100" \
+            --jq '.actions_caches[].id')
+          if [ -z "$cache_ids" ]; then
             echo "No caches found for this PR."
             exit 0
           fi
           echo "Deleting caches..."
-          while IFS= read -r key; do
-            gh actions-cache delete "$key" \
-              --repo "$REPO" \
-              --branch "$BRANCH" \
-              --confirm
-            echo "Deleted: $key"
-          done <<< "$cache_keys"
+          while IFS= read -r id; do
+            gh cache delete "$id" \
+              --repo "$REPO"
+            echo "Deleted cache ID: $id"
+          done <<< "$cache_ids"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #3635

## Summary

- Adds a new `Cleanup PR Caches` workflow triggered on `pull_request: closed`
- Deletes all GitHub Actions runner caches scoped to the closed PR's merge ref
- Requires `actions: write` permission (scoped to this job only)

## Motivation

GitHub caps Actions cache storage at 10 GB per repository. Caches created during PR runs are scoped to `refs/pull/<N>/merge` and are never automatically removed when a PR closes. Over time these orphaned caches consume the quota and cause cache evictions on active branches.

## How it works

On every PR close/merge, the workflow lists all caches for the PR's merge ref and deletes them via the `gh actions-cache delete` CLI command.

## Test plan

- [ ] Merge or close a PR and verify the `Cleanup PR Caches` workflow runs
- [ ] Confirm caches scoped to that PR's branch are removed from the Actions cache list