### PR TITLE
ci: pin remaining GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: knative/actions/setup-go@main
 
       - name: Check and Lint
@@ -70,13 +70,13 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: knative/actions/setup-go@main
 
       - name: Run Unit Tests
         run: make test
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./coverage.txt
           flags: unit ${{ matrix.os }}
@@ -107,25 +107,25 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: knative/actions/setup-go@main
 
         # Toolchains
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
 
         # Run
       - name: Templates Tests
@@ -148,9 +148,9 @@ jobs:
       FUNC_INT_PAC_HOST: pac-ctr.localtest.me
       KUBECONFIG: ${{github.workspace}}/hack/bin/kubeconfig.yaml
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: knative/actions/setup-go@main
-      - uses: endersonmenezes/free-disk-space@v3
+      - uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3
         with:
           remove_android: true
           remove_dotnet: true
@@ -174,7 +174,7 @@ jobs:
       - name: Run Integration Tests
         run: make test-integration
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./coverage.txt
           flags: integration
@@ -188,7 +188,7 @@ jobs:
         run: ./hack/dump-logs.sh cluster_log.txt
       - name: Archive Cluster Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cluster-logs-integration
           path: ./cluster_log.txt
@@ -208,9 +208,9 @@ jobs:
       FUNC_E2E_CLEAN: false # cluster only used once
       FUNC_E2E_VERBOSE: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: knative/actions/setup-go@main
-      - uses: endersonmenezes/free-disk-space@v3
+      - uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3
         with:
           remove_android: true
           remove_dotnet: true
@@ -230,7 +230,7 @@ jobs:
       - name: Run Basic E2E Tests (core, metadata, remote)
         run: make test-e2e
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./coverage.txt
           flags: e2e
@@ -244,7 +244,7 @@ jobs:
         run: ./hack/dump-logs.sh cluster_log.txt
       - name: Archive Cluster Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cluster-logs-e2e-core
           path: ./cluster_log.txt
@@ -269,10 +269,10 @@ jobs:
       FUNC_E2E_CLEAN: false # cluster only used once
       FUNC_E2E_VERBOSE: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: knative/actions/setup-go@main
 
-      - uses: endersonmenezes/free-disk-space@v3
+      - uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3
         with:
           remove_android: true
           remove_dotnet: true
@@ -293,7 +293,7 @@ jobs:
       - name: Run E2E Podman Tests
         run: make test-e2e-podman
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./coverage.txt
           flags: e2e
@@ -307,7 +307,7 @@ jobs:
         run: ./hack/dump-logs.sh cluster_log.txt
       - name: Archive Cluster Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cluster-logs-${{ matrix.os }}-podman
           path: ./cluster_log.txt
@@ -338,9 +338,9 @@ jobs:
       FUNC_E2E_VERBOSE: true
       FUNC_E2E_MATRIX_RUNTIMES: ${{ matrix.runtime }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: knative/actions/setup-go@main
-      - uses: endersonmenezes/free-disk-space@v3
+      - uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3
         with:
           remove_android: true
           remove_dotnet: true
@@ -351,23 +351,23 @@ jobs:
         # Install Toolchain Being Tested
       - name: Setup Python
         if: matrix.runtime == 'python'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Setup Node.js
         if: matrix.runtime == 'node' || matrix.runtime == 'typescript'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Setup Java
         if: matrix.runtime == 'quarkus' || matrix.runtime == 'springboot'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Setup Rust
         if: matrix.runtime == 'rust'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
 
       # Allocate Cluster
       - name: Install Binaries
@@ -383,7 +383,7 @@ jobs:
         run: make test-e2e-matrix
 
       # Coverage and Logs
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./coverage.txt
           flags: e2e ${{ matrix.runtime }}
@@ -397,7 +397,7 @@ jobs:
         run: ./hack/dump-logs.sh cluster_log.txt
       - name: Archive Cluster Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cluster-logs-${{ matrix.runtime }}
           path: ./cluster_log.txt
@@ -416,9 +416,9 @@ jobs:
       FUNC_E2E_CLEAN: false
       FUNC_E2E_VERBOSE: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: knative/actions/setup-go@main
-      - uses: endersonmenezes/free-disk-space@v3
+      - uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3
         with:
           remove_android: true
           remove_dotnet: true
@@ -438,7 +438,7 @@ jobs:
       - name: Run Config CI E2E Tests
         run: make test-e2e-config-ci
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./coverage.txt
           flags: e2e-config-ci
@@ -452,7 +452,7 @@ jobs:
         run: ./hack/dump-logs.sh cluster_log.txt
       - name: Archive Cluster Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cluster-logs-e2e-config-ci
           path: ./cluster_log.txt
@@ -473,41 +473,41 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: knative/actions/setup-go@main
       - name: Build Platform Binaries
         run: make cross-platform
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: OSX Binary (AMD)
           path: func_darwin_amd64
           retention-days: 30
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: OSX Binary (ARM)
           path: func_darwin_arm64
           retention-days: 30
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: Linux Binary (AMD)
           path: func_linux_amd64
           retention-days: 30
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: Linux Binary (ARM)
           path: func_linux_arm64
           retention-days: 30
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: Linux Binary (PPC64LE)
           path: func_linux_ppc64le
           retention-days: 30
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: Linux Binary (S390X)
           path: func_linux_s390x
           retention-days: 30
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: Windows Binary
           path: func_windows_amd64.exe
@@ -519,11 +519,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: knative/actions/setup-go@main
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -550,7 +550,7 @@ jobs:
           DIGEST="$(jq -r '."containerimage.digest"' build-metadata.json)"
           echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"
       - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-name: "ghcr.io/knative/func-utils"
           subject-digest: ${{ steps.build-images.outputs.digest }}
@@ -562,7 +562,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: knative/actions/setup-go@main
-      - uses: imjasonh/setup-ko@v0.6
+      - uses: imjasonh/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
       - run: ko build --platform=linux/ppc64le,linux/s390x,linux/amd64,linux/arm64 -B ./cmd/func

--- a/.github/workflows/test-podman-next.yaml
+++ b/.github/workflows/test-podman-next.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: endersonmenezes/free-disk-space@v3
+      - uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3
         with:
           remove_android: true
           remove_dotnet: true
@@ -31,7 +31,7 @@ jobs:
           echo "FUNC_ALLOCATE_RETRIES=5" >> "$GITHUB_ENV"
       - name: Disable CLRF conversion
         run: git config --global core.autocrlf false
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: knative/actions/setup-go@main
       - name: Install Binaries
         run: ./hack/binaries.sh
@@ -50,7 +50,7 @@ jobs:
         run: ./hack/dump-logs.sh cluster_log.txt
       - name: Archive Cluster Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cluster-logs-podman-next
           path: ./cluster_log.txt

--- a/.github/workflows/update-builder.yaml
+++ b/.github/workflows/update-builder.yaml
@@ -17,10 +17,10 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: knative/actions/setup-go@main
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Build and Push
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/update-ca-bundle.yaml
+++ b/.github/workflows/update-ca-bundle.yaml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
       - name: Install NPM deps.

--- a/.github/workflows/update-python-platform.yaml
+++ b/.github/workflows/update-python-platform.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - uses: knative/actions/setup-go@main
 
@@ -29,7 +29,7 @@ jobs:
       - name: Run make generate
         run: make generate/zz_filesystem_generated.go
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
 
@@ -37,7 +37,7 @@ jobs:
         run: make test-python
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ github.token }}
           commit-message: 'chore: update func-python version'

--- a/.github/workflows/update-quarkus-platform.yaml
+++ b/.github/workflows/update-quarkus-platform.yaml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: knative/actions/setup-go@main
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: 21
           distribution: 'temurin'

--- a/.github/workflows/update-springboot-platform.yaml
+++ b/.github/workflows/update-springboot-platform.yaml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: knative/actions/setup-go@main
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: 21
           distribution: 'temurin'


### PR DESCRIPTION
# Changes

- :broom: Pin every `uses:` in `.github/workflows/` to a full 40-character commit SHA, with a short comment (e.g. `# v4`, `# knative@abc1234`) for the previous tag or `main` ref.
- Covers `actions/*`, `codecov/*`, `docker/*`, `imjasonh/setup-ko`, `peter-evans/create-pull-request`, `endersonmenezes/free-disk-space`, `actions-rust-lang/setup-rust-toolchain`, and all `knative/actions` setup-go and reusable workflow references that previously used `@main` or semver tags.

/kind cleanup

Fixes #3638

## References

- GitHub docs: [Using third-party actions - Pinning to a commit SHA](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- StepSecurity: Why pin GitHub Actions to commit SHAs
