### PR TITLE
fix(knative): handle multi-path KUBECONFIG entries

### DIFF
--- a/pkg/knative/client.go
+++ b/pkg/knative/client.go
@@ -3,6 +3,7 @@ package knative
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	clienteventingv1 "knative.dev/client/pkg/eventing/v1"
 	clientservingv1 "knative.dev/client/pkg/serving/v1"
@@ -60,9 +61,18 @@ func validateKubeconfigFile() error {
 		return nil
 	}
 
-	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("%w: kubeconfig file does not exist at path: %s", fn.ErrInvalidKubeconfig, kubeconfigPath)
+	for _, path := range filepath.SplitList(kubeconfigPath) {
+		if path == "" {
+			continue
+		}
+		_, statErr := os.Stat(path)
+		if statErr == nil {
+			return nil
+		}
+		if !os.IsNotExist(statErr) {
+			return fmt.Errorf("%w: kubeconfig file is not accessible at path: %s", fn.ErrInvalidKubeconfig, path)
+		}
 	}
 
-	return nil
+	return fmt.Errorf("%w: kubeconfig file does not exist at path: %s", fn.ErrInvalidKubeconfig, kubeconfigPath)
 }

--- a/pkg/knative/client_test.go
+++ b/pkg/knative/client_test.go
@@ -1,0 +1,79 @@
+package knative
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	fn "knative.dev/func/pkg/functions"
+)
+
+func TestValidateKubeconfigFile(t *testing.T) {
+	testDir := t.TempDir()
+	existingPath := filepath.Join(testDir, "kubeconfig")
+	if err := os.WriteFile(existingPath, []byte("apiVersion: v1\n"), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+	missingPath := filepath.Join(testDir, "missing")
+	listSep := string(filepath.ListSeparator)
+
+	cases := []struct {
+		name        string
+		kubeconfig  string
+		wantErr     bool
+		wantErrText string
+	}{
+		{
+			name:       "empty env",
+			kubeconfig: "",
+			wantErr:    false,
+		},
+		{
+			name:       "single existing",
+			kubeconfig: existingPath,
+			wantErr:    false,
+		},
+		{
+			name:        "single missing",
+			kubeconfig:  missingPath,
+			wantErr:     true,
+			wantErrText: "kubeconfig file does not exist at path",
+		},
+		{
+			name:       "multiple with existing",
+			kubeconfig: missingPath + listSep + existingPath,
+			wantErr:    false,
+		},
+		{
+			name:        "multiple all missing",
+			kubeconfig:  missingPath + listSep + filepath.Join(testDir, "missing2"),
+			wantErr:     true,
+			wantErrText: "kubeconfig file does not exist at path",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("KUBECONFIG", tc.kubeconfig)
+
+			err := validateKubeconfigFile()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				if !errors.Is(err, fn.ErrInvalidKubeconfig) {
+					t.Fatalf("expected ErrInvalidKubeconfig, got: %v", err)
+				}
+				if tc.wantErrText != "" && !strings.Contains(err.Error(), tc.wantErrText) {
+					t.Fatalf("expected error to contain %q, got: %v", tc.wantErrText, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Reproduction
Successfully reproduced the bug

# Changes

- Fix validation of KUBECONFIG when multiple paths are provided
- Use filepath.SplitList to correctly handle OS-specific path separators
- Treat KUBECONFIG as a list of paths instead of a single file path
- Validation now succeeds if at least one kubeconfig file exists
- Return ErrInvalidKubeconfig only when all paths are missing or unreadable
- Add unit tests covering:
  - empty KUBECONFIG
  - single valid path
  - multiple paths (valid + missing)
  - all paths missing

/kind bug

Fixes #3534


## Testing (After Fix)

### Case 1: Multiple valid paths

```sh
export KUBECONFIG=~/.kube/config:/tmp/second-config
func list
```

**Expected:**

- Validation succeeds (no invalid path error)
- Command proceeds to cluster connection stage

### Case 2: One valid + one missing

```sh
export KUBECONFIG=~/.kube/config:/tmp/missing
func list
```

**Expected:**

- Validation succeeds

### Case 3: All paths missing

```sh
export KUBECONFIG=/tmp/miss1:/tmp/miss2
func list
```

**Expected:**

- invalid kubeconfig: kubeconfig file does not exist at path: /tmp/miss1:/tmp/miss2

### Case 4: Empty KUBECONFIG

```sh
unset KUBECONFIG
func list
```

**Expected:**

- No validation error

# Extra

make test ; passed
make check ;passed

**Release Note**

```release-note
func commands now correctly support multi-path KUBECONFIG values. Validation succeeds if at least one referenced kubeconfig file exists, aligning behavior with kubectl and client-go.```