### PR TITLE
refactor(delete): clean up error handling and validation

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -38,11 +37,7 @@ No local files are deleted.
 		SilenceUsage:      true, // no usage dump on error
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Layer 2: Catch technical errors and provide CLI-specific user-friendly messages
-			err := runDelete(cmd, args, newClient)
-			if err != nil && errors.Is(err, fn.ErrNameRequired) {
-				return NewErrDeleteNameRequired(err)
-			}
-			return err
+			return wrapDeleteError(runDelete(cmd, args, newClient))
 		},
 	}
 
@@ -75,8 +70,7 @@ func runDelete(cmd *cobra.Command, args []string, newClient ClientFactory) (err 
 			return err
 		}
 		if !f.Initialized() {
-			// Return technical error (Layer 1) - will be caught and enhanced by CLI
-			return fn.ErrNameRequired
+			return NewErrNotInitializedFromPath(f.Root, "delete")
 		}
 	}
 
@@ -130,7 +124,7 @@ func newDeleteConfig(cmd *cobra.Command, args []string) (cfg deleteConfig, err e
 		// logically inconsistent to provide both a name and a path to source.
 		// Either use the function's local state on disk (--path), or specify
 		// a name and a namespace to ignore any local function source.
-		err = fmt.Errorf("only one of --path and [NAME] should be provided")
+		err = ErrNameAndPathConflict
 	}
 	return
 }
@@ -174,39 +168,4 @@ func (c deleteConfig) Prompt() (deleteConfig, error) {
 	dc.All = answers.All
 
 	return dc, err
-}
-
-// ErrDeleteNameRequired wraps core library errors with CLI-specific context
-// for delete operations that require a function name or path.
-type ErrDeleteNameRequired struct {
-	// Underlying error from the core library (e.g., fn.ErrNameRequired)
-	Err error
-}
-
-// NewErrDeleteNameRequired creates a new ErrDeleteNameRequired wrapping the given error
-func NewErrDeleteNameRequired(err error) ErrDeleteNameRequired {
-	return ErrDeleteNameRequired{Err: err}
-}
-
-// Error implements the error interface with CLI-specific help text
-func (e ErrDeleteNameRequired) Error() string {
-	return fmt.Sprintf(`%v
-
-Function name is required for deletion (or --path not specified).
-
-You can delete functions in two ways:
-
-1. By name:
-   func delete myfunction                     Delete function by name
-   func delete myfunction --namespace apps    Delete from specific namespace
-
-2. By path:
-   func delete --path /path/to/function       Delete function at specific path
-
-Examples:
-   func delete myfunction                     Delete 'myfunction' from cluster
-   func delete myfunction --namespace prod    Delete from 'prod' namespace
-   func delete --path ./myfunction            Delete function at path
-
-For more options, run 'func delete --help'`, e.Err)
 }

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -315,14 +316,27 @@ func TestDelete_NameAndPathExclusivity(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatalf("expected error on conflicting flags not received")
-	}
-
-	if !strings.Contains(err.Error(), "only one of --path and [NAME] should be provided") {
-		t.Fatalf("unexpected error message: %v", err)
+	} else if !errors.Is(err, ErrNameAndPathConflict) {
+		t.Fatalf("expected ErrNameAndPathConflict, got %v", err)
 	}
 
 	// Also fail if remover's .Remove is invoked.
 	if remover.RemoveInvoked {
 		t.Fatal("fn.Remover invoked despite invalid combination and an error")
+	}
+}
+
+// TestDelete_NoFunctionAtPath ensures delete returns a not-initialized error when no function exists at path
+func TestDelete_NoFunctionAtPath(t *testing.T) {
+	_ = FromTempDirectory(t)
+
+	cmd := NewDeleteCmd(NewTestClient())
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when deleting without a function in path")
+	}
+	if !strings.Contains(err.Error(), "No function found in provided path") {
+		t.Fatalf("unexpected error message: %v", err)
 	}
 }

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,8 +13,6 @@ import (
 	"knative.dev/func/pkg/config"
 	fn "knative.dev/func/pkg/functions"
 )
-
-var ErrNameAndPathConflict = errors.New("cannot specify both name and path")
 
 func NewDescribeCmd(newClient ClientFactory) *cobra.Command {
 	cmd := &cobra.Command{

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -69,6 +69,32 @@ func wrapPromptError(err error, cmd string) error {
 	return err
 }
 
+// wrapDeleteError wraps errors from delete command with CLI-specific guidance
+func wrapDeleteError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var cliNotInit *ErrNotInitialized
+	if errors.As(err, &cliNotInit) {
+		return err
+	}
+
+	var coreNotInit *fn.ErrNotInitialized
+	if errors.As(err, &coreNotInit) {
+		return NewErrNotInitialized(err, "delete")
+	}
+
+	if errors.Is(err, fn.ErrNameRequired) {
+		return NewErrDeleteNameRequired(err)
+	}
+	if errors.Is(err, fn.ErrNamespaceRequired) {
+		return NewErrDeleteNamespaceRequired(err)
+	}
+
+	return err
+}
+
 // ---------------------------- TYPES AND METHODS --------------------------- //
 
 type ErrPlatformNotSupported struct {
@@ -366,11 +392,110 @@ Or use --path to describe from anywhere:
 
 For more options, run 'func describe --help'`, e.Err)
 
+	case "delete":
+		return fmt.Sprintf(`%v
+
+No function found in provided path (current directory or via --path).
+You need to be in a function directory (or use --path).
+
+Try this:
+	func create --language go myfunction    Create a new function
+	cd myfunction                          Go into the function directory
+	func delete                            Delete the deployed function
+
+Or if you have an existing function:
+	cd path/to/your/function              Go to your function directory
+	func delete                            Delete the deployed function
+
+Or use --path to delete from anywhere:
+	func delete --path /path/to/function
+
+For more options, run 'func delete --help'`, e.Err)
+
 	default:
 		return e.Err.Error()
 	}
 }
 func (e *ErrNotInitialized) Unwrap() error {
+	return e.Err
+}
+
+// -------------------------------------------------------------------------- //
+
+// ErrNameAndPathConflict is returned when both a name and a path are provided.
+var ErrNameAndPathConflict = errors.New("cannot specify both name and path")
+
+// -------------------------------------------------------------------------- //
+
+// ErrDeleteNameRequired wraps core library errors with CLI-specific context
+// for delete operations that require a function name or path.
+type ErrDeleteNameRequired struct {
+	// Underlying error from the core library (e.g., fn.ErrNameRequired)
+	Err error
+}
+
+// NewErrDeleteNameRequired creates a new ErrDeleteNameRequired wrapping the given error
+func NewErrDeleteNameRequired(err error) error {
+	return &ErrDeleteNameRequired{Err: err}
+}
+
+// Error implements the error interface with CLI-specific help text
+func (e *ErrDeleteNameRequired) Error() string {
+	return fmt.Sprintf(`%v
+
+Function name is required for deletion (or --path not specified).
+
+You can delete functions in two ways:
+
+1. By name:
+   func delete myfunction                     Delete function by name
+   func delete myfunction --namespace apps    Delete from specific namespace
+
+2. By path:
+   func delete --path /path/to/function       Delete function at specific path
+
+Examples:
+   func delete myfunction                     Delete 'myfunction' from cluster
+   func delete myfunction --namespace prod    Delete from 'prod' namespace
+   func delete --path ./myfunction            Delete function at path
+
+For more options, run 'func delete --help'`, e.Err)
+}
+
+// Unwrap returns the underlying error for errors.Is/As
+func (e *ErrDeleteNameRequired) Unwrap() error {
+	return e.Err
+}
+
+// -------------------------------------------------------------------------- //
+
+// ErrDeleteNamespaceRequired wraps core library errors when namespace is missing for delete
+type ErrDeleteNamespaceRequired struct {
+	Err error
+}
+
+// NewErrDeleteNamespaceRequired creates a new ErrDeleteNamespaceRequired
+func NewErrDeleteNamespaceRequired(err error) error {
+	return &ErrDeleteNamespaceRequired{Err: err}
+}
+
+// Error implements the error interface with CLI-specific help text
+func (e *ErrDeleteNamespaceRequired) Error() string {
+	return fmt.Sprintf(`%v
+
+Namespace is required to delete a deployed function.
+
+Try this:
+  func delete myfunction --namespace apps    Delete from a specific namespace
+
+Or delete by path if the function has a recorded namespace:
+  func delete --path /path/to/function
+
+For more options, run 'func delete --help'`, e.Err)
+}
+
+// Unwrap returns the underlying error for errors.Is/As
+func (e *ErrDeleteNamespaceRequired) Unwrap() error {
 	return e.Err
 }
 


### PR DESCRIPTION
## Changes

- add wrapDeleteError to unify delete-specific error handling
- move delete error types to cmd/errors.go
- implement Unwrap() for errors.Is/As compatibility
- use NewErrNotInitializedFromPath for delete command
- introduce shared ErrNameAndPathConflict (reuse across delete and describe)
- simplify delete command flow
- update and add tests for validation and edge cases

## Tests

- Updated:
  - `TestDelete_NameAndPathExclusivity` to assert `ErrNameAndPathConflict`
- Added:
  - `TestDelete_NoFunctionAtPath`


/kind cleanup

**Release Note**
```release-note
Refactored delete command error handling for consistency and improved validation messages.