### PR TITLE
fix(mcp): correct command prefix in Remove Help resources

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -122,15 +122,15 @@ func New(options ...Option) *Server {
 
 	i.AddResource(newHelpResource(s, "Volumes Help", "general help for volumes", "config", "volumes"))
 	i.AddResource(newHelpResource(s, "Volumes Add Help", "help for 'config volumes add'", "config", "volumes", "add"))
-	i.AddResource(newHelpResource(s, "Volumes Remove Help", "help for 'config volumes remove'", "list", "volumes", "remove"))
+	i.AddResource(newHelpResource(s, "Volumes Remove Help", "help for 'config volumes remove'", "config", "volumes", "remove"))
 
 	i.AddResource(newHelpResource(s, "Labels Help", "general help for labels", "config", "labels"))
 	i.AddResource(newHelpResource(s, "Labels Add Help", "help for 'config labels add'", "config", "labels", "add"))
-	i.AddResource(newHelpResource(s, "Labels Remove Help", "help for 'config labels remove'", "list", "labels", "remove"))
+	i.AddResource(newHelpResource(s, "Labels Remove Help", "help for 'config labels remove'", "config", "labels", "remove"))
 
 	i.AddResource(newHelpResource(s, "Envs Help", "general help for environment variables", "config", "envs"))
 	i.AddResource(newHelpResource(s, "Envs Add Help", "help for 'config envs add'", "config", "envs", "add"))
-	i.AddResource(newHelpResource(s, "Envs Remove Help", "help for 'config envs remove'", "list", "envs", "remove"))
+	i.AddResource(newHelpResource(s, "Envs Remove Help", "help for 'config envs remove'", "config", "envs", "remove"))
 
 	s.impl = i
 


### PR DESCRIPTION
## Problem

Three MCP help resources for `config volumes/labels/envs remove` were registered with `"list"` as their first path segment instead of `"config"`. This caused two bugs:

1. **Wrong URI** — `func://help/list/volumes/remove` instead of `func://help/config/volumes/remove`
2. **Wrong command** — the handler executed `func list volumes remove --help` instead of `func config volumes remove --help`

The description strings on all three lines already said `"help for 'config volumes/labels/envs remove'"`, making the intent unambiguous.

## Root cause

Copy-paste error in `pkg/mcp/mcp.go`. The neighboring `*Add Help` resources on the same lines correctly used `"config"`; only the three `*Remove Help` lines were wrong.

## Fix

Replace `"list"` with `"config"` as the first variadic argument to `newHelpResource` on lines 125, 129, and 133 of `pkg/mcp/mcp.go`.

```go
// before
i.AddResource(newHelpResource(s, "Volumes Remove Help", "help for 'config volumes remove'", "list", "volumes", "remove"))
i.AddResource(newHelpResource(s, "Labels Remove Help",  "help for 'config labels remove'",  "list", "labels",  "remove"))
i.AddResource(newHelpResource(s, "Envs Remove Help",    "help for 'config envs remove'",    "list", "envs",    "remove"))

// after
i.AddResource(newHelpResource(s, "Volumes Remove Help", "help for 'config volumes remove'", "config", "volumes", "remove"))
i.AddResource(newHelpResource(s, "Labels Remove Help",  "help for 'config labels remove'",  "config", "labels",  "remove"))
i.AddResource(newHelpResource(s, "Envs Remove Help",    "help for 'config envs remove'",    "config", "envs",    "remove"))
```

## Testing

- `pkg/mcp` unit tests pass: `ok knative.dev/func/pkg/mcp 2.349s coverage: 83.8%`