### PR TITLE
mcp: split config tools by action for accurate tool annotations

### DIFF
--- a/pkg/mcp/instructions.md
+++ b/pkg/mcp/instructions.md
@@ -33,7 +33,7 @@ This is essential because:
 - `create` tool: path = absolute path to directory where Function will be created
 - `deploy` tool: path = absolute path to Function directory (where func.yaml exists)
 - `build` tool: path = absolute path to Function directory (where func.yaml exists)
-- `config_*` tools: path = absolute path to Function directory (where func.yaml exists)
+- `config_*_list`, `config_*_add`, `config_*_remove` tools: path = absolute path to Function directory (where func.yaml exists)
 
 **IMPORTANT:** You must use absolute paths (e.g., `/Users/name/myproject/myfunc`), NOT relative paths (e.g., `.` or `myfunc`). The MCP server process runs in a different directory than your current working directory, so relative paths will not resolve correctly.
 
@@ -140,8 +140,29 @@ A first-time deploy can be detected by checking the func.yaml for a value in the
 - Exactly ONE of 'path' or 'name' must be provided, not both
 - Deleting does not affect local files (source). Only cluster resources.
 
-### config_volumes, config_labels, config_envs
+### config_envs_list, config_envs_add, config_envs_remove
 
-- All config tools require the 'path' parameter
-- path points to the Function directory whose func.yaml will be modified
-- These tools modify local func.yaml files only (changes take effect on next deploy)
+- **BEFORE calling add/remove:** Consider reading `func://help/config/envs` for authoritative usage
+- All three tools require the 'path' parameter (absolute path to the Function directory)
+- `config_envs_list` — read-only; lists current environment variables
+- `config_envs_add` — adds an environment variable; optional `name` and `value` parameters
+- `config_envs_remove` — removes an environment variable by `name`
+- add/remove modify local func.yaml only (changes take effect on next deploy)
+
+### config_labels_list, config_labels_add, config_labels_remove
+
+- **BEFORE calling add/remove:** Consider reading `func://help/config/labels` for authoritative usage
+- All three tools require the 'path' parameter (absolute path to the Function directory)
+- `config_labels_list` — read-only; lists current labels
+- `config_labels_add` — adds a label; optional `name` and `value` parameters
+- `config_labels_remove` — removes a label by `name`
+- add/remove modify local func.yaml only (changes take effect on next deploy)
+
+### config_volumes_list, config_volumes_add, config_volumes_remove
+
+- **BEFORE calling add/remove:** Consider reading `func://help/config/volumes` for authoritative usage
+- All three tools require the 'path' parameter (absolute path to the Function directory)
+- `config_volumes_list` — read-only; lists current volume mounts
+- `config_volumes_add` — adds a volume; accepts `type` (configmap, secret, pvc, emptydir), `mountPath`, `source`, `medium`, `size`, `readOnly`
+- `config_volumes_remove` — removes a volume by `mountPath`
+- add/remove modify local func.yaml only (changes take effect on next deploy)

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -96,9 +96,15 @@ func New(options ...Option) *Server {
 	mcp.AddTool(i, deployTool, s.deployHandler)
 	mcp.AddTool(i, listTool, s.listHandler)
 	mcp.AddTool(i, deleteTool, s.deleteHandler)
-	mcp.AddTool(i, configVolumesTool, s.configVolumesHandler)
-	mcp.AddTool(i, configLabelsTool, s.configLabelsHandler)
-	mcp.AddTool(i, configEnvsTool, s.configEnvsHandler)
+	mcp.AddTool(i, configVolumesListTool, s.configVolumesListHandler)
+	mcp.AddTool(i, configVolumesAddTool, s.configVolumesAddHandler)
+	mcp.AddTool(i, configVolumesRemoveTool, s.configVolumesRemoveHandler)
+	mcp.AddTool(i, configLabelsListTool, s.configLabelsListHandler)
+	mcp.AddTool(i, configLabelsAddTool, s.configLabelsAddHandler)
+	mcp.AddTool(i, configLabelsRemoveTool, s.configLabelsRemoveHandler)
+	mcp.AddTool(i, configEnvsListTool, s.configEnvsListHandler)
+	mcp.AddTool(i, configEnvsAddTool, s.configEnvsAddHandler)
+	mcp.AddTool(i, configEnvsRemoveTool, s.configEnvsRemoveHandler)
 
 	// Resources
 	// ---------

--- a/pkg/mcp/tools_config_envs.go
+++ b/pkg/mcp/tools_config_envs.go
@@ -7,54 +7,124 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-var configEnvsTool = &mcp.Tool{
-	Name:        "config_envs",
-	Title:       "Config Environment Variables",
-	Description: "Manages environment variable configurations for a function. Can add, remove, or list.",
+// config_envs_list
+
+var configEnvsListTool = &mcp.Tool{
+	Name:        "config_envs_list",
+	Title:       "Config Environment Variables List",
+	Description: "Lists the environment variables configured for a function.",
 	Annotations: &mcp.ToolAnnotations{
-		Title:           "Config Environment Variables",
-		ReadOnlyHint:    false,
-		DestructiveHint: ptr(true),
-		IdempotentHint:  false, // Adding the same environment variable twice or removing a non-existent one will fail.
+		Title:          "Config Environment Variables List",
+		ReadOnlyHint:   true,
+		IdempotentHint: true,
 	},
 }
 
-func (s *Server) configEnvsHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigEnvsInput) (result *mcp.CallToolResult, output ConfigEnvsOutput, err error) {
+type ConfigEnvsListInput struct {
+	Path    string `json:"path" jsonschema:"required,Path to the function project directory"`
+	Verbose *bool  `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
+}
+
+func (i ConfigEnvsListInput) Args() []string {
+	args := []string{"envs", "--path", i.Path}
+	args = appendBoolFlag(args, "--verbose", i.Verbose)
+	return args
+}
+
+type ConfigEnvsListOutput struct {
+	Message string `json:"message" jsonschema:"Output message"`
+}
+
+func (s *Server) configEnvsListHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigEnvsListInput) (result *mcp.CallToolResult, output ConfigEnvsListOutput, err error) {
 	out, err := s.executor.Execute(ctx, "config", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))
 		return
 	}
-	output = ConfigEnvsOutput{
-		Message: string(out),
-	}
+	output = ConfigEnvsListOutput{Message: string(out)}
 	return
 }
 
-// ConfigEnvsInput defines the input parameters for the config_envs tool.
-type ConfigEnvsInput struct {
-	Action  string  `json:"action" jsonschema:"required,Action to perform: add, remove, or list"`
+// config_envs_add
+
+var configEnvsAddTool = &mcp.Tool{
+	Name:        "config_envs_add",
+	Title:       "Config Environment Variables Add",
+	Description: "Adds an environment variable to a function's configuration.",
+	Annotations: &mcp.ToolAnnotations{
+		Title:           "Config Environment Variables Add",
+		ReadOnlyHint:    false,
+		DestructiveHint: ptr(false), // additive only; does not overwrite or delete
+		IdempotentHint:  false,      // adding the same variable twice will fail
+	},
+}
+
+type ConfigEnvsAddInput struct {
 	Path    string  `json:"path" jsonschema:"required,Path to the function project directory"`
 	Name    *string `json:"name,omitempty" jsonschema:"Name of the environment variable"`
-	Value   *string `json:"value,omitempty" jsonschema:"Value of the environment variable (for add action)"`
+	Value   *string `json:"value,omitempty" jsonschema:"Value of the environment variable"`
 	Verbose *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
 }
 
-func (i ConfigEnvsInput) Args() []string {
-	args := []string{"envs"}
-
-	// allow "list" as alias for the default action
-	if i.Action != "list" {
-		args = append(args, i.Action)
-	}
-	args = append(args, "--path", i.Path) // required
+func (i ConfigEnvsAddInput) Args() []string {
+	args := []string{"envs", "add", "--path", i.Path}
 	args = appendStringFlag(args, "--name", i.Name)
 	args = appendStringFlag(args, "--value", i.Value)
 	args = appendBoolFlag(args, "--verbose", i.Verbose)
 	return args
 }
 
-// ConfigEnvsOutput defines the structured output returned by the config_envs tool.
-type ConfigEnvsOutput struct {
+type ConfigEnvsAddOutput struct {
 	Message string `json:"message" jsonschema:"Output message"`
+}
+
+func (s *Server) configEnvsAddHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigEnvsAddInput) (result *mcp.CallToolResult, output ConfigEnvsAddOutput, err error) {
+	out, err := s.executor.Execute(ctx, "config", input.Args()...)
+	if err != nil {
+		err = fmt.Errorf("%w\n%s", err, string(out))
+		return
+	}
+	output = ConfigEnvsAddOutput{Message: string(out)}
+	return
+}
+
+// config_envs_remove
+
+var configEnvsRemoveTool = &mcp.Tool{
+	Name:        "config_envs_remove",
+	Title:       "Config Environment Variables Remove",
+	Description: "Removes an environment variable from a function's configuration.",
+	Annotations: &mcp.ToolAnnotations{
+		Title:           "Config Environment Variables Remove",
+		ReadOnlyHint:    false,
+		DestructiveHint: ptr(true), // removes data irreversibly from function config
+		IdempotentHint:  false,     // removing a non-existent variable will fail
+	},
+}
+
+type ConfigEnvsRemoveInput struct {
+	Path    string  `json:"path" jsonschema:"required,Path to the function project directory"`
+	Name    *string `json:"name,omitempty" jsonschema:"Name of the environment variable to remove"`
+	Verbose *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
+}
+
+func (i ConfigEnvsRemoveInput) Args() []string {
+	args := []string{"envs", "remove", "--path", i.Path}
+	args = appendStringFlag(args, "--name", i.Name)
+	args = appendBoolFlag(args, "--verbose", i.Verbose)
+	return args
+}
+
+type ConfigEnvsRemoveOutput struct {
+	Message string `json:"message" jsonschema:"Output message"`
+}
+
+func (s *Server) configEnvsRemoveHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigEnvsRemoveInput) (result *mcp.CallToolResult, output ConfigEnvsRemoveOutput, err error) {
+	out, err := s.executor.Execute(ctx, "config", input.Args()...)
+	if err != nil {
+		err = fmt.Errorf("%w\n%s", err, string(out))
+		return
+	}
+	output = ConfigEnvsRemoveOutput{Message: string(out)}
+	return
 }

--- a/pkg/mcp/tools_config_envs_test.go
+++ b/pkg/mcp/tools_config_envs_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -168,5 +169,77 @@ func TestTool_ConfigEnvsRemove(t *testing.T) {
 	}
 	if !executor.ExecuteInvoked {
 		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_ConfigEnvsList_Error ensures the config_envs_list tool propagates executor errors.
+func TestTool_ConfigEnvsList_Error(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte("list failed"), errors.New("executor error")
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_envs_list",
+		Arguments: map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result, got success")
+	}
+}
+
+// TestTool_ConfigEnvsAdd_Error ensures the config_envs_add tool propagates executor errors.
+func TestTool_ConfigEnvsAdd_Error(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte("add failed"), errors.New("executor error")
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_envs_add",
+		Arguments: map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result, got success")
+	}
+}
+
+// TestTool_ConfigEnvsRemove_Error ensures the config_envs_remove tool propagates executor errors.
+func TestTool_ConfigEnvsRemove_Error(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte("remove failed"), errors.New("executor error")
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_envs_remove",
+		Arguments: map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result, got success")
 	}
 }

--- a/pkg/mcp/tools_config_envs_test.go
+++ b/pkg/mcp/tools_config_envs_test.go
@@ -8,8 +8,8 @@ import (
 	"knative.dev/func/pkg/mcp/mock"
 )
 
-// TestTool_ConfigEnvs_Add ensures the config envs tool executes with all arguments for add action.
-func TestTool_ConfigEnvs_Add(t *testing.T) {
+// TestTool_ConfigEnvsAdd ensures the config_envs_add tool executes with all arguments.
+func TestTool_ConfigEnvsAdd(t *testing.T) {
 	stringFlags := map[string]struct {
 		jsonKey string
 		flag    string
@@ -24,8 +24,6 @@ func TestTool_ConfigEnvs_Add(t *testing.T) {
 		"verbose": "--verbose",
 	}
 
-	action := "add"
-
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
 		if subcommand != "config" {
@@ -33,20 +31,17 @@ func TestTool_ConfigEnvs_Add(t *testing.T) {
 		}
 
 		if len(args) < 2 {
-			t.Fatalf("expected at least 2 args (subcommand and action), got %d: %v", len(args), args)
+			t.Fatalf("expected at least 2 args, got %d: %v", len(args), args)
 		}
 
-		// Validate "envs" subcommand
 		if args[0] != "envs" {
 			t.Fatalf("expected args[0]='envs', got %q", args[0])
 		}
-
-		// Validate action
-		if args[1] != action {
-			t.Fatalf("expected args[1]=%q, got %q", action, args[1])
+		if args[1] != "add" {
+			t.Fatalf("expected args[1]='add', got %q", args[1])
 		}
 
-		// Validate flags (skip first 2 args which are "envs" and "add")
+		// args[2:] are the flags
 		validateArgLength(t, args[2:], len(stringFlags), len(boolFlags))
 		validateStringFlags(t, args[2:], stringFlags)
 		validateBoolFlags(t, args[2:], boolFlags)
@@ -59,13 +54,10 @@ func TestTool_ConfigEnvs_Add(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Build input arguments from test data
 	inputArgs := buildInputArgs(stringFlags, boolFlags)
-	inputArgs["action"] = action
 
-	// Invoke tool with all arguments
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
-		Name:      "config_envs",
+		Name:      "config_envs_add",
 		Arguments: inputArgs,
 	})
 	if err != nil {
@@ -79,17 +71,15 @@ func TestTool_ConfigEnvs_Add(t *testing.T) {
 	}
 }
 
-// TestTool_ConfigEnvs_List ensures the config envs tool can list environment variables.
-func TestTool_ConfigEnvs_List(t *testing.T) {
-	action := "list"
-
+// TestTool_ConfigEnvsList ensures the config_envs_list tool lists environment variables.
+func TestTool_ConfigEnvsList(t *testing.T) {
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
 		if subcommand != "config" {
 			t.Fatalf("expected subcommand 'config', got %q", subcommand)
 		}
 
-		// For list action, "envs" + "--path" flag = 3 args
+		// "envs" + "--path" + "." = 3 args
 		if len(args) != 3 {
 			t.Fatalf("expected 3 args, got %d: %v", len(args), args)
 		}
@@ -97,10 +87,9 @@ func TestTool_ConfigEnvs_List(t *testing.T) {
 			t.Fatalf("expected args[0]='envs', got %q", args[0])
 		}
 
-		// Validate path flag
 		argsMap := argsToMap(args[1:])
 		if val, ok := argsMap["--path"]; !ok || val != "." {
-			t.Fatalf("expected --path flag with value '.', got %q", val)
+			t.Fatalf("expected --path='.', got %q", val)
 		}
 
 		return []byte("DATABASE_URL=postgres://localhost\nAPI_KEY=secret\n"), nil
@@ -112,11 +101,64 @@ func TestTool_ConfigEnvs_List(t *testing.T) {
 	}
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
-		Name: "config_envs",
-		Arguments: map[string]any{
-			"action": action,
-			"path":   ".",
-		},
+		Name:      "config_envs_list",
+		Arguments: map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_ConfigEnvsRemove ensures the config_envs_remove tool removes an environment variable.
+func TestTool_ConfigEnvsRemove(t *testing.T) {
+	stringFlags := map[string]struct {
+		jsonKey string
+		flag    string
+		value   string
+	}{
+		"path": {"path", "--path", "."},
+		"name": {"name", "--name", "API_KEY"},
+	}
+
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		if subcommand != "config" {
+			t.Fatalf("expected subcommand 'config', got %q", subcommand)
+		}
+
+		if len(args) < 2 {
+			t.Fatalf("expected at least 2 args, got %d: %v", len(args), args)
+		}
+
+		if args[0] != "envs" {
+			t.Fatalf("expected args[0]='envs', got %q", args[0])
+		}
+		if args[1] != "remove" {
+			t.Fatalf("expected args[1]='remove', got %q", args[1])
+		}
+
+		validateArgLength(t, args[2:], len(stringFlags), 0)
+		validateStringFlags(t, args[2:], stringFlags)
+
+		return []byte("Environment variable removed successfully\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inputArgs := buildInputArgs(stringFlags, nil)
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_envs_remove",
+		Arguments: inputArgs,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/mcp/tools_config_labels.go
+++ b/pkg/mcp/tools_config_labels.go
@@ -7,54 +7,124 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-var configLabelsTool = &mcp.Tool{
-	Name:        "config_labels",
-	Title:       "Config Labels",
-	Description: "Manages label configurations for a function. Can add, remove, or list.",
+// config_labels_list
+
+var configLabelsListTool = &mcp.Tool{
+	Name:        "config_labels_list",
+	Title:       "Config Labels List",
+	Description: "Lists the labels configured for a function.",
 	Annotations: &mcp.ToolAnnotations{
-		Title:           "Config Labels",
-		ReadOnlyHint:    false,
-		DestructiveHint: ptr(true),
-		IdempotentHint:  false, // Adding the same label twice or removing a non-existent label will fail.
+		Title:          "Config Labels List",
+		ReadOnlyHint:   true,
+		IdempotentHint: true,
 	},
 }
 
-func (s *Server) configLabelsHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigLabelsInput) (result *mcp.CallToolResult, output ConfigLabelsOutput, err error) {
+type ConfigLabelsListInput struct {
+	Path    string `json:"path" jsonschema:"required,Path to the function project directory"`
+	Verbose *bool  `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
+}
+
+func (i ConfigLabelsListInput) Args() []string {
+	args := []string{"labels", "--path", i.Path}
+	args = appendBoolFlag(args, "--verbose", i.Verbose)
+	return args
+}
+
+type ConfigLabelsListOutput struct {
+	Message string `json:"message" jsonschema:"Output message"`
+}
+
+func (s *Server) configLabelsListHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigLabelsListInput) (result *mcp.CallToolResult, output ConfigLabelsListOutput, err error) {
 	out, err := s.executor.Execute(ctx, "config", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))
 		return
 	}
-	output = ConfigLabelsOutput{
-		Message: string(out),
-	}
+	output = ConfigLabelsListOutput{Message: string(out)}
 	return
 }
 
-// ConfigLabelsInput defines the input parameters for the config_labels tool.
-type ConfigLabelsInput struct {
-	Action  string  `json:"action" jsonschema:"required,Action to perform: add, remove, or list"`
+// config_labels_add
+
+var configLabelsAddTool = &mcp.Tool{
+	Name:        "config_labels_add",
+	Title:       "Config Labels Add",
+	Description: "Adds a label to a function's configuration.",
+	Annotations: &mcp.ToolAnnotations{
+		Title:           "Config Labels Add",
+		ReadOnlyHint:    false,
+		DestructiveHint: ptr(false), // additive only; does not overwrite or delete
+		IdempotentHint:  false,      // adding the same label twice will fail
+	},
+}
+
+type ConfigLabelsAddInput struct {
 	Path    string  `json:"path" jsonschema:"required,Path to the function project directory"`
 	Name    *string `json:"name,omitempty" jsonschema:"Name of the label"`
-	Value   *string `json:"value,omitempty" jsonschema:"Value of the label (for add action)"`
+	Value   *string `json:"value,omitempty" jsonschema:"Value of the label"`
 	Verbose *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
 }
 
-func (i ConfigLabelsInput) Args() []string {
-	args := []string{"labels"}
-
-	// allow "list" as an alias for the default action
-	if i.Action != "list" {
-		args = append(args, i.Action)
-	}
-	args = append(args, "--path", i.Path)
+func (i ConfigLabelsAddInput) Args() []string {
+	args := []string{"labels", "add", "--path", i.Path}
 	args = appendStringFlag(args, "--name", i.Name)
 	args = appendStringFlag(args, "--value", i.Value)
 	args = appendBoolFlag(args, "--verbose", i.Verbose)
 	return args
 }
 
-// ConfigLabelsOutput defines the structured output returned by the config_labels tool.
-type ConfigLabelsOutput struct {
+type ConfigLabelsAddOutput struct {
 	Message string `json:"message" jsonschema:"Output message"`
+}
+
+func (s *Server) configLabelsAddHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigLabelsAddInput) (result *mcp.CallToolResult, output ConfigLabelsAddOutput, err error) {
+	out, err := s.executor.Execute(ctx, "config", input.Args()...)
+	if err != nil {
+		err = fmt.Errorf("%w\n%s", err, string(out))
+		return
+	}
+	output = ConfigLabelsAddOutput{Message: string(out)}
+	return
+}
+
+// config_labels_remove
+
+var configLabelsRemoveTool = &mcp.Tool{
+	Name:        "config_labels_remove",
+	Title:       "Config Labels Remove",
+	Description: "Removes a label from a function's configuration.",
+	Annotations: &mcp.ToolAnnotations{
+		Title:           "Config Labels Remove",
+		ReadOnlyHint:    false,
+		DestructiveHint: ptr(true), // removes data irreversibly from function config
+		IdempotentHint:  false,     // removing a non-existent label will fail
+	},
+}
+
+type ConfigLabelsRemoveInput struct {
+	Path    string  `json:"path" jsonschema:"required,Path to the function project directory"`
+	Name    *string `json:"name,omitempty" jsonschema:"Name of the label to remove"`
+	Verbose *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
+}
+
+func (i ConfigLabelsRemoveInput) Args() []string {
+	args := []string{"labels", "remove", "--path", i.Path}
+	args = appendStringFlag(args, "--name", i.Name)
+	args = appendBoolFlag(args, "--verbose", i.Verbose)
+	return args
+}
+
+type ConfigLabelsRemoveOutput struct {
+	Message string `json:"message" jsonschema:"Output message"`
+}
+
+func (s *Server) configLabelsRemoveHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigLabelsRemoveInput) (result *mcp.CallToolResult, output ConfigLabelsRemoveOutput, err error) {
+	out, err := s.executor.Execute(ctx, "config", input.Args()...)
+	if err != nil {
+		err = fmt.Errorf("%w\n%s", err, string(out))
+		return
+	}
+	output = ConfigLabelsRemoveOutput{Message: string(out)}
+	return
 }

--- a/pkg/mcp/tools_config_labels_test.go
+++ b/pkg/mcp/tools_config_labels_test.go
@@ -8,9 +8,8 @@ import (
 	"knative.dev/func/pkg/mcp/mock"
 )
 
-// TestTool_ConfigLabels_Add ensures the config labels tool executes with all arguments for add action.
-func TestTool_ConfigLabels_Add(t *testing.T) {
-	// Test data - defined once and used for both input and validation
+// TestTool_ConfigLabelsAdd ensures the config_labels_add tool executes with all arguments.
+func TestTool_ConfigLabelsAdd(t *testing.T) {
 	stringFlags := map[string]struct {
 		jsonKey string
 		flag    string
@@ -25,9 +24,6 @@ func TestTool_ConfigLabels_Add(t *testing.T) {
 		"verbose": "--verbose",
 	}
 
-	// Required field
-	action := "add"
-
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
 		if subcommand != "config" {
@@ -35,20 +31,16 @@ func TestTool_ConfigLabels_Add(t *testing.T) {
 		}
 
 		if len(args) < 2 {
-			t.Fatalf("expected at least 2 args (subcommand and action), got %d: %v", len(args), args)
+			t.Fatalf("expected at least 2 args, got %d: %v", len(args), args)
 		}
 
-		// Validate "labels" subcommand
 		if args[0] != "labels" {
 			t.Fatalf("expected args[0]='labels', got %q", args[0])
 		}
-
-		// Validate action
-		if args[1] != action {
-			t.Fatalf("expected args[1]=%q, got %q", action, args[1])
+		if args[1] != "add" {
+			t.Fatalf("expected args[1]='add', got %q", args[1])
 		}
 
-		// Validate flags (skip first 2 args which are "labels" and "add")
 		validateArgLength(t, args[2:], len(stringFlags), len(boolFlags))
 		validateStringFlags(t, args[2:], stringFlags)
 		validateBoolFlags(t, args[2:], boolFlags)
@@ -61,13 +53,10 @@ func TestTool_ConfigLabels_Add(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Build input arguments from test data
 	inputArgs := buildInputArgs(stringFlags, boolFlags)
-	inputArgs["action"] = action
 
-	// Invoke tool with all arguments
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
-		Name:      "config_labels",
+		Name:      "config_labels_add",
 		Arguments: inputArgs,
 	})
 	if err != nil {
@@ -81,17 +70,15 @@ func TestTool_ConfigLabels_Add(t *testing.T) {
 	}
 }
 
-// TestTool_ConfigLabels_List ensures the config labels tool can list labels.
-func TestTool_ConfigLabels_List(t *testing.T) {
-	action := "list"
-
+// TestTool_ConfigLabelsList ensures the config_labels_list tool lists labels.
+func TestTool_ConfigLabelsList(t *testing.T) {
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
 		if subcommand != "config" {
 			t.Fatalf("expected subcommand 'config', got %q", subcommand)
 		}
 
-		// For list action, "labels" + "--path" flag = 3 args
+		// "labels" + "--path" + "." = 3 args
 		if len(args) != 3 {
 			t.Fatalf("expected 3 args, got %d: %v", len(args), args)
 		}
@@ -99,10 +86,9 @@ func TestTool_ConfigLabels_List(t *testing.T) {
 			t.Fatalf("expected args[0]='labels', got %q", args[0])
 		}
 
-		// Validate path flag
 		argsMap := argsToMap(args[1:])
 		if val, ok := argsMap["--path"]; !ok || val != "." {
-			t.Fatalf("expected --path flag with value '.', got %q", val)
+			t.Fatalf("expected --path='.', got %q", val)
 		}
 
 		return []byte("app=my-function\nenvironment=prod\n"), nil
@@ -114,11 +100,64 @@ func TestTool_ConfigLabels_List(t *testing.T) {
 	}
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
-		Name: "config_labels",
-		Arguments: map[string]any{
-			"action": action,
-			"path":   ".",
-		},
+		Name:      "config_labels_list",
+		Arguments: map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_ConfigLabelsRemove ensures the config_labels_remove tool removes a label.
+func TestTool_ConfigLabelsRemove(t *testing.T) {
+	stringFlags := map[string]struct {
+		jsonKey string
+		flag    string
+		value   string
+	}{
+		"path": {"path", "--path", "."},
+		"name": {"name", "--name", "environment"},
+	}
+
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		if subcommand != "config" {
+			t.Fatalf("expected subcommand 'config', got %q", subcommand)
+		}
+
+		if len(args) < 2 {
+			t.Fatalf("expected at least 2 args, got %d: %v", len(args), args)
+		}
+
+		if args[0] != "labels" {
+			t.Fatalf("expected args[0]='labels', got %q", args[0])
+		}
+		if args[1] != "remove" {
+			t.Fatalf("expected args[1]='remove', got %q", args[1])
+		}
+
+		validateArgLength(t, args[2:], len(stringFlags), 0)
+		validateStringFlags(t, args[2:], stringFlags)
+
+		return []byte("Label removed successfully\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inputArgs := buildInputArgs(stringFlags, nil)
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_labels_remove",
+		Arguments: inputArgs,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/mcp/tools_config_labels_test.go
+++ b/pkg/mcp/tools_config_labels_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -167,5 +168,77 @@ func TestTool_ConfigLabelsRemove(t *testing.T) {
 	}
 	if !executor.ExecuteInvoked {
 		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_ConfigLabelsList_Error ensures the config_labels_list tool propagates executor errors.
+func TestTool_ConfigLabelsList_Error(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte("list failed"), errors.New("executor error")
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_labels_list",
+		Arguments: map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result, got success")
+	}
+}
+
+// TestTool_ConfigLabelsAdd_Error ensures the config_labels_add tool propagates executor errors.
+func TestTool_ConfigLabelsAdd_Error(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte("add failed"), errors.New("executor error")
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_labels_add",
+		Arguments: map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result, got success")
+	}
+}
+
+// TestTool_ConfigLabelsRemove_Error ensures the config_labels_remove tool propagates executor errors.
+func TestTool_ConfigLabelsRemove_Error(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte("remove failed"), errors.New("executor error")
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_labels_remove",
+		Arguments: map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result, got success")
 	}
 }

--- a/pkg/mcp/tools_config_volumes.go
+++ b/pkg/mcp/tools_config_volumes.go
@@ -7,35 +7,61 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-var configVolumesTool = &mcp.Tool{
-	Name:        "config_volumes",
-	Title:       "Config Volumes",
-	Description: "Manages volume configurations for a function. Can add, remove, or list.",
+// config_volumes_list
+
+var configVolumesListTool = &mcp.Tool{
+	Name:        "config_volumes_list",
+	Title:       "Config Volumes List",
+	Description: "Lists the volume configurations for a function.",
 	Annotations: &mcp.ToolAnnotations{
-		Title:           "Config Volumes",
-		ReadOnlyHint:    false,
-		DestructiveHint: ptr(true),
-		IdempotentHint:  false, // Adding the same volume twice or removing a non-existent volume will fail.
+		Title:          "Config Volumes List",
+		ReadOnlyHint:   true,
+		IdempotentHint: true,
 	},
 }
 
-func (s *Server) configVolumesHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigVolumesInput) (result *mcp.CallToolResult, output ConfigVolumesOutput, err error) {
+type ConfigVolumesListInput struct {
+	Path    string `json:"path" jsonschema:"required,Path to the function project directory"`
+	Verbose *bool  `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
+}
+
+func (i ConfigVolumesListInput) Args() []string {
+	args := []string{"volumes", "--path", i.Path}
+	args = appendBoolFlag(args, "--verbose", i.Verbose)
+	return args
+}
+
+type ConfigVolumesListOutput struct {
+	Message string `json:"message" jsonschema:"Output message"`
+}
+
+func (s *Server) configVolumesListHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigVolumesListInput) (result *mcp.CallToolResult, output ConfigVolumesListOutput, err error) {
 	out, err := s.executor.Execute(ctx, "config", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))
 		return
 	}
-	output = ConfigVolumesOutput{
-		Message: string(out),
-	}
+	output = ConfigVolumesListOutput{Message: string(out)}
 	return
 }
 
-// ConfigVolumesInput defines the input parameters for the config_volumes tool.
-type ConfigVolumesInput struct {
-	Action    string  `json:"action" jsonschema:"required,Action to perform: add, remove, or list"`
+// config_volumes_add
+
+var configVolumesAddTool = &mcp.Tool{
+	Name:        "config_volumes_add",
+	Title:       "Config Volumes Add",
+	Description: "Adds a volume to a function's configuration.",
+	Annotations: &mcp.ToolAnnotations{
+		Title:           "Config Volumes Add",
+		ReadOnlyHint:    false,
+		DestructiveHint: ptr(false), // additive only; does not overwrite or delete
+		IdempotentHint:  false,      // adding the same volume twice will fail
+	},
+}
+
+type ConfigVolumesAddInput struct {
 	Path      string  `json:"path" jsonschema:"required,Path to the function project directory"`
-	Type      *string `json:"type,omitempty" jsonschema:"Volume type for add action: configmap, secret, pvc, or emptydir"`
+	Type      *string `json:"type,omitempty" jsonschema:"Volume type: configmap, secret, pvc, or emptydir"`
 	MountPath *string `json:"mountPath,omitempty" jsonschema:"Mount path for the volume in the container"`
 	Source    *string `json:"source,omitempty" jsonschema:"Name of the ConfigMap, Secret, or PVC to mount"`
 	Medium    *string `json:"medium,omitempty" jsonschema:"Storage medium for EmptyDir volume: Memory or empty string"`
@@ -44,15 +70,8 @@ type ConfigVolumesInput struct {
 	Verbose   *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
 }
 
-func (i ConfigVolumesInput) Args() []string {
-	args := []string{"volumes"}
-
-	// Allow "list" as an alias for the default action
-	if i.Action != "list" {
-		args = append(args, i.Action)
-	}
-
-	args = append(args, "--path", i.Path)
+func (i ConfigVolumesAddInput) Args() []string {
+	args := []string{"volumes", "add", "--path", i.Path}
 	args = appendStringFlag(args, "--type", i.Type)
 	args = appendStringFlag(args, "--mount-path", i.MountPath)
 	args = appendStringFlag(args, "--source", i.Source)
@@ -60,11 +79,60 @@ func (i ConfigVolumesInput) Args() []string {
 	args = appendStringFlag(args, "--size", i.Size)
 	args = appendBoolFlag(args, "--read-only", i.ReadOnly)
 	args = appendBoolFlag(args, "--verbose", i.Verbose)
-
 	return args
 }
 
-// ConfigVolumesOutput defines the structured output returned by the config_volumes tool.
-type ConfigVolumesOutput struct {
+type ConfigVolumesAddOutput struct {
 	Message string `json:"message" jsonschema:"Output message"`
+}
+
+func (s *Server) configVolumesAddHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigVolumesAddInput) (result *mcp.CallToolResult, output ConfigVolumesAddOutput, err error) {
+	out, err := s.executor.Execute(ctx, "config", input.Args()...)
+	if err != nil {
+		err = fmt.Errorf("%w\n%s", err, string(out))
+		return
+	}
+	output = ConfigVolumesAddOutput{Message: string(out)}
+	return
+}
+
+// config_volumes_remove
+
+var configVolumesRemoveTool = &mcp.Tool{
+	Name:        "config_volumes_remove",
+	Title:       "Config Volumes Remove",
+	Description: "Removes a volume from a function's configuration.",
+	Annotations: &mcp.ToolAnnotations{
+		Title:           "Config Volumes Remove",
+		ReadOnlyHint:    false,
+		DestructiveHint: ptr(true), // removes data irreversibly from function config
+		IdempotentHint:  false,     // removing a non-existent volume will fail
+	},
+}
+
+type ConfigVolumesRemoveInput struct {
+	Path      string  `json:"path" jsonschema:"required,Path to the function project directory"`
+	MountPath *string `json:"mountPath,omitempty" jsonschema:"Mount path of the volume to remove"`
+	Verbose   *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
+}
+
+func (i ConfigVolumesRemoveInput) Args() []string {
+	args := []string{"volumes", "remove", "--path", i.Path}
+	args = appendStringFlag(args, "--mount-path", i.MountPath)
+	args = appendBoolFlag(args, "--verbose", i.Verbose)
+	return args
+}
+
+type ConfigVolumesRemoveOutput struct {
+	Message string `json:"message" jsonschema:"Output message"`
+}
+
+func (s *Server) configVolumesRemoveHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigVolumesRemoveInput) (result *mcp.CallToolResult, output ConfigVolumesRemoveOutput, err error) {
+	out, err := s.executor.Execute(ctx, "config", input.Args()...)
+	if err != nil {
+		err = fmt.Errorf("%w\n%s", err, string(out))
+		return
+	}
+	output = ConfigVolumesRemoveOutput{Message: string(out)}
+	return
 }

--- a/pkg/mcp/tools_config_volumes_test.go
+++ b/pkg/mcp/tools_config_volumes_test.go
@@ -8,9 +8,8 @@ import (
 	"knative.dev/func/pkg/mcp/mock"
 )
 
-// TestTool_ConfigVolumes_Add ensures the config volumes tool executes with all arguments for add action.
-func TestTool_ConfigVolumes_Add(t *testing.T) {
-	// Test data - defined once and used for both input and validation
+// TestTool_ConfigVolumesAdd ensures the config_volumes_add tool executes with all arguments.
+func TestTool_ConfigVolumesAdd(t *testing.T) {
 	stringFlags := map[string]struct {
 		jsonKey string
 		flag    string
@@ -29,9 +28,6 @@ func TestTool_ConfigVolumes_Add(t *testing.T) {
 		"verbose":  "--verbose",
 	}
 
-	// Required field
-	action := "add"
-
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
 		if subcommand != "config" {
@@ -39,20 +35,16 @@ func TestTool_ConfigVolumes_Add(t *testing.T) {
 		}
 
 		if len(args) < 2 {
-			t.Fatalf("expected at least 2 args (subcommand and action), got %d: %v", len(args), args)
+			t.Fatalf("expected at least 2 args, got %d: %v", len(args), args)
 		}
 
-		// Validate "volumes" subcommand
 		if args[0] != "volumes" {
 			t.Fatalf("expected args[0]='volumes', got %q", args[0])
 		}
-
-		// Validate action
-		if args[1] != action {
-			t.Fatalf("expected args[1]=%q, got %q", action, args[1])
+		if args[1] != "add" {
+			t.Fatalf("expected args[1]='add', got %q", args[1])
 		}
 
-		// Validate flags (skip first 2 args which are "volumes" and "add")
 		validateArgLength(t, args[2:], len(stringFlags), len(boolFlags))
 		validateStringFlags(t, args[2:], stringFlags)
 		validateBoolFlags(t, args[2:], boolFlags)
@@ -65,13 +57,10 @@ func TestTool_ConfigVolumes_Add(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Build input arguments from test data
 	inputArgs := buildInputArgs(stringFlags, boolFlags)
-	inputArgs["action"] = action
 
-	// Invoke tool with all arguments
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
-		Name:      "config_volumes",
+		Name:      "config_volumes_add",
 		Arguments: inputArgs,
 	})
 	if err != nil {
@@ -85,17 +74,15 @@ func TestTool_ConfigVolumes_Add(t *testing.T) {
 	}
 }
 
-// TestTool_ConfigVolumes_List ensures the config volumes tool can list volumes.
-func TestTool_ConfigVolumes_List(t *testing.T) {
-	action := "list"
-
+// TestTool_ConfigVolumesList ensures the config_volumes_list tool lists volumes.
+func TestTool_ConfigVolumesList(t *testing.T) {
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
 		if subcommand != "config" {
 			t.Fatalf("expected subcommand 'config', got %q", subcommand)
 		}
 
-		// For list action, "volumes" + "--path" flag = 3 args
+		// "volumes" + "--path" + "." = 3 args
 		if len(args) != 3 {
 			t.Fatalf("expected 3 args, got %d: %v", len(args), args)
 		}
@@ -103,10 +90,9 @@ func TestTool_ConfigVolumes_List(t *testing.T) {
 			t.Fatalf("expected args[0]='volumes', got %q", args[0])
 		}
 
-		// Validate path flag
 		argsMap := argsToMap(args[1:])
 		if val, ok := argsMap["--path"]; !ok || val != "." {
-			t.Fatalf("expected --path flag with value '.', got %q", val)
+			t.Fatalf("expected --path='.', got %q", val)
 		}
 
 		return []byte("secret:my-secret:/workspace/secret\n"), nil
@@ -118,11 +104,64 @@ func TestTool_ConfigVolumes_List(t *testing.T) {
 	}
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
-		Name: "config_volumes",
-		Arguments: map[string]any{
-			"action": action,
-			"path":   ".",
-		},
+		Name:      "config_volumes_list",
+		Arguments: map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_ConfigVolumesRemove ensures the config_volumes_remove tool removes a volume.
+func TestTool_ConfigVolumesRemove(t *testing.T) {
+	stringFlags := map[string]struct {
+		jsonKey string
+		flag    string
+		value   string
+	}{
+		"path":      {"path", "--path", "."},
+		"mountPath": {"mountPath", "--mount-path", "/workspace/secret"},
+	}
+
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		if subcommand != "config" {
+			t.Fatalf("expected subcommand 'config', got %q", subcommand)
+		}
+
+		if len(args) < 2 {
+			t.Fatalf("expected at least 2 args, got %d: %v", len(args), args)
+		}
+
+		if args[0] != "volumes" {
+			t.Fatalf("expected args[0]='volumes', got %q", args[0])
+		}
+		if args[1] != "remove" {
+			t.Fatalf("expected args[1]='remove', got %q", args[1])
+		}
+
+		validateArgLength(t, args[2:], len(stringFlags), 0)
+		validateStringFlags(t, args[2:], stringFlags)
+
+		return []byte("Volume removed successfully\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inputArgs := buildInputArgs(stringFlags, nil)
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_volumes_remove",
+		Arguments: inputArgs,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/mcp/tools_config_volumes_test.go
+++ b/pkg/mcp/tools_config_volumes_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -171,5 +172,77 @@ func TestTool_ConfigVolumesRemove(t *testing.T) {
 	}
 	if !executor.ExecuteInvoked {
 		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_ConfigVolumesList_Error ensures the config_volumes_list tool propagates executor errors.
+func TestTool_ConfigVolumesList_Error(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte("list failed"), errors.New("executor error")
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_volumes_list",
+		Arguments: map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result, got success")
+	}
+}
+
+// TestTool_ConfigVolumesAdd_Error ensures the config_volumes_add tool propagates executor errors.
+func TestTool_ConfigVolumesAdd_Error(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte("add failed"), errors.New("executor error")
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_volumes_add",
+		Arguments: map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result, got success")
+	}
+}
+
+// TestTool_ConfigVolumesRemove_Error ensures the config_volumes_remove tool propagates executor errors.
+func TestTool_ConfigVolumesRemove_Error(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte("remove failed"), errors.New("executor error")
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_volumes_remove",
+		Arguments: map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result, got success")
 	}
 }


### PR DESCRIPTION
## Problem

`config_envs`, `config_labels`, and `config_volumes` each accepted an `action`
parameter (`list`, `add`, `remove`) but declared `DestructiveHint: true` at the
tool level. MCP tool annotations are static metadata evaluated at discovery time,
before any invocation arguments exist. A client that respects hints treats the tool
as destructive on every call — including a read-only `list`.

## Changes

Split each combined tool into three single-action tools, each carrying annotations
that accurately describe that action's semantics:

| Tool | ReadOnlyHint | DestructiveHint |
|---|---|---|
| `config_{envs,labels,volumes}_list` | true | — (irrelevant per spec when ReadOnly) |
| `config_{envs,labels,volumes}_add` | false | false (additive only) |
| `config_{envs,labels,volumes}_remove` | false | true |

The `action` field is removed from all input structs. Each tool's `Args()` method
hardcodes the correct subcommand. `IdempotentHint` is set to `true` on list tools.

## Tests

Nine dedicated tests (list/add/remove per resource) replace the previous six combined
tests. All pass.