### PR TITLE
Fix remote Quarkus builds failing on s390x and ppc64le clusters

### DIFF
--- a/pkg/pipelines/tekton/templates_pack.go
+++ b/pkg/pipelines/tekton/templates_pack.go
@@ -125,6 +125,11 @@ spec:
       value: "{{.Commit}}"
   pipelineRef:
    name: {{.PipelineName}}
+  podTemplate:
+    securityContext:
+      runAsUser: 1001
+      runAsGroup: 0
+      fsGroup: 1002
   workspaces:
     - name: source-workspace
       persistentVolumeClaim:
@@ -185,6 +190,11 @@ spec:
         {{end}}
   pipelineRef:
    name: {{.PipelineName}}
+  podTemplate:
+    securityContext:
+      runAsUser: 1001
+      runAsGroup: 0
+      fsGroup: 1002
   workspaces:
     - name: source-workspace
       persistentVolumeClaim:

--- a/pkg/pipelines/tekton/templates_s2i.go
+++ b/pkg/pipelines/tekton/templates_s2i.go
@@ -136,6 +136,11 @@ spec:
       value: "{{.Commit}}"
   pipelineRef:
    name: {{.PipelineName}}
+  podTemplate:
+    securityContext:
+      runAsUser: 1001
+      runAsGroup: 0
+      fsGroup: 1002
   workspaces:
     - name: source-workspace
       persistentVolumeClaim:
@@ -203,6 +208,11 @@ spec:
       value: {{.TlsVerify}}
   pipelineRef:
    name: {{.PipelineName}}
+  podTemplate:
+    securityContext:
+      runAsUser: 1001
+      runAsGroup: 0
+      fsGroup: 1002
   workspaces:
     - name: source-workspace
       persistentVolumeClaim:

--- a/pkg/pipelines/tekton/templates_test.go
+++ b/pkg/pipelines/tekton/templates_test.go
@@ -1,7 +1,9 @@
 package tekton
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/manifestival/manifestival"
@@ -318,6 +320,85 @@ func Test_createAndApplyPipelineRunTemplate(t *testing.T) {
 
 			if err := createAndApplyPipelineRunTemplate(f, tt.namespace, tt.labels); (err != nil) != tt.wantErr {
 				t.Errorf("createAndApplyPipelineRunTemplate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_PipelineRunHasPodTemplateSecurityContext(t *testing.T) {
+	tests := []struct {
+		name    string
+		root    string
+		builder string
+		runtime string
+	}{
+		{
+			name:    "pack builder with quarkus",
+			root:    "testdata/testCreatePipelinePackQuarkus",
+			builder: builders.Pack,
+			runtime: "quarkus",
+		},
+		{
+			name:    "s2i builder with quarkus",
+			root:    "testdata/testCreatePipelineS2IQuarkus",
+			builder: builders.S2I,
+			runtime: "quarkus",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := tt.root + "Run"
+			defer Using(t, root)()
+
+			f, err := fn.NewFunction(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			f.Build.Builder = tt.builder
+			f.Runtime = tt.runtime
+			f.Image = "docker.io/alice/" + f.Name
+			f.Registry = TestRegistry
+
+			// Create the PipelineRun template
+			err = createPipelineRunTemplatePAC(f, make(map[string]string))
+			if err != nil {
+				t.Fatalf("createPipelineRunTemplatePAC() error = %v", err)
+			}
+
+			// Read the generated file and verify it contains podTemplate with securityContext
+			fp := filepath.Join(root, resourcesDirectory, pipelineRunFilenamePAC)
+			content, err := os.ReadFile(fp)
+			if err != nil {
+				t.Fatalf("failed to read generated PipelineRun: %v", err)
+			}
+
+			contentStr := string(content)
+
+			// Verify podTemplate is present
+			if !strings.Contains(contentStr, "podTemplate:") {
+				t.Error("podTemplate not found in generated PipelineRun")
+			}
+
+			// Verify securityContext is present
+			if !strings.Contains(contentStr, "securityContext:") {
+				t.Error("securityContext not found in podTemplate")
+			}
+
+			// Verify fsGroup is set
+			if !strings.Contains(contentStr, "fsGroup: 1002") {
+				t.Error("fsGroup not set to 1002 in securityContext")
+			}
+
+			// Verify runAsUser is set
+			if !strings.Contains(contentStr, "runAsUser: 1001") {
+				t.Error("runAsUser not set to 1001 in securityContext")
+			}
+
+			// Verify runAsGroup is set
+			if !strings.Contains(contentStr, "runAsGroup: 0") {
+				t.Error("runAsGroup not set to 0 in securityContext")
 			}
 		})
 	}


### PR DESCRIPTION
This fix addresses the issue where remote Quarkus builds fail on s390x and ppc64le clusters.

The problem was that FSGroup permissions were not being honored on the build PersistentVolume, which prevented the build process from accessing its workspace correctly.

The solution adds a podTemplate with proper security context settings to both the Pack and S2I PipelineRun templates. This ensures that all Tekton task pods inherit the correct security context for volume access. On s390x and ppc64le architectures, some storage backends require explicit FSGroup configuration to properly handle volume permissions.

What changed:
- Added podTemplate with securityContext to the Pack builder PipelineRun templates
- Added podTemplate with securityContext to the S2I builder PipelineRun templates
- Added a test to verify the podTemplate with securityContext is present in generated PipelineRuns

The security context is configured with:
- runAsUser: 1001 (matches the Tekton buildpack task requirements)
- runAsGroup: 0 (matches the Tekton buildpack task requirements)
- fsGroup: 1002 (ensures proper volume ownership for non-root users)

All tests pass and linting checks are clean. This fix is compatible with all architectures and will not affect existing functionality on amd64 systems.

Fixes #3515
