### PR TITLE
pkg/mcp: add tests for readonly enforcement, delete validation, and help resources

### DIFF
--- a/pkg/mcp/tools_delete_test.go
+++ b/pkg/mcp/tools_delete_test.go
@@ -8,6 +8,70 @@ import (
 	"knative.dev/func/pkg/mcp/mock"
 )
 
+// TestTool_Delete_Readonly ensures the delete tool returns an error when the server is in readonly mode.
+func TestTool_Delete_Readonly(t *testing.T) {
+	client, _, err := newTestPairWithReadonly(t, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "delete",
+		Arguments: map[string]any{"name": "my-function"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result for readonly server, got success")
+	}
+}
+
+// TestTool_Delete_BothPathAndName ensures the delete tool returns a validation error
+// when both path and name are provided simultaneously.
+func TestTool_Delete_BothPathAndName(t *testing.T) {
+	client, server, err := newTestPair(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.readonly = false
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "delete",
+		Arguments: map[string]any{
+			"path": "/some/path",
+			"name": "my-function",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when both path and name are provided, got success")
+	}
+}
+
+// TestTool_Delete_NeitherPathNorName ensures the delete tool returns a validation error
+// when neither path nor name is provided.
+func TestTool_Delete_NeitherPathNorName(t *testing.T) {
+	client, server, err := newTestPair(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.readonly = false
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "delete",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when neither path nor name is provided, got success")
+	}
+}
+
 // TestTool_Delete_Args ensures the delete tool executes with all arguments passed correctly.
 func TestTool_Delete_Args(t *testing.T) {
 	// Test data - defined once and used for both input and validation

--- a/pkg/mcp/tools_delete_test.go
+++ b/pkg/mcp/tools_delete_test.go
@@ -30,11 +30,10 @@ func TestTool_Delete_Readonly(t *testing.T) {
 // TestTool_Delete_BothPathAndName ensures the delete tool returns a validation error
 // when both path and name are provided simultaneously.
 func TestTool_Delete_BothPathAndName(t *testing.T) {
-	client, server, err := newTestPair(t)
+	client, _, err := newTestPair(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	server.readonly = false
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name: "delete",
@@ -54,11 +53,10 @@ func TestTool_Delete_BothPathAndName(t *testing.T) {
 // TestTool_Delete_NeitherPathNorName ensures the delete tool returns a validation error
 // when neither path nor name is provided.
 func TestTool_Delete_NeitherPathNorName(t *testing.T) {
-	client, server, err := newTestPair(t)
+	client, _, err := newTestPair(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	server.readonly = false
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "delete",

--- a/pkg/mcp/tools_deploy_test.go
+++ b/pkg/mcp/tools_deploy_test.go
@@ -8,6 +8,25 @@ import (
 	"knative.dev/func/pkg/mcp/mock"
 )
 
+// TestTool_Deploy_Readonly ensures the deploy tool returns an error when the server is in readonly mode.
+func TestTool_Deploy_Readonly(t *testing.T) {
+	client, _, err := newTestPairWithReadonly(t, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "deploy",
+		Arguments: map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result for readonly server, got success")
+	}
+}
+
 // TestTool_Deploy_Args ensures the deploy tool executes with all arguments passed correctly.
 func TestTool_Deploy_Args(t *testing.T) {
 	// Test data - defined once and used for both input and validation


### PR DESCRIPTION
## Summary

- `tools_deploy_test.go` and `tools_delete_test.go` each had a single happy-path test that manually set `server.readonly = false`, leaving the readonly guard in both handlers completely untested.
- The mutual-exclusion validation in `deleteHandler` (exactly one of `path` or `name` must be provided) had no test coverage for either branch.
- All 14 `func://help/*` resources registered in `mcp.go` had zero tests; the `newHelpResource` handler — URI construction, executor dispatch, args assembly, and response shape — was entirely unexercised.

## Changes

- `pkg/mcp/tools_deploy_test.go`: add `TestTool_Deploy_Readonly` — uses `newTestPairWithReadonly(t, true)` and asserts `result.IsError`.
- `pkg/mcp/tools_delete_test.go`: add `TestTool_Delete_Readonly`, `TestTool_Delete_BothPathAndName`, and `TestTool_Delete_NeitherPathNorName`.
- `pkg/mcp/resources_test.go`: add `TestResource_Help` — table-driven test over 6 `func://help/*` URIs that validates executor subcommand, args, response URI, MIME type, and body text.

## Test plan

- [ ] `go test ./pkg/mcp/...` passes (all 10 new tests green)
- [ ] `make test` passes
- [ ] `make check` passes