### PR TITLE
test: add resource validation integration test to k8s and keda deployers

### DIFF
--- a/pkg/k8s/deployer_int_test.go
+++ b/pkg/k8s/deployer_int_test.go
@@ -59,3 +59,11 @@ func TestInt_EnvsUpdate(t *testing.T) {
 		k8s.NewDescriber(false),
 		k8s.KubernetesDeployerName)
 }
+
+func TestInt_ResourceValidationOnFirstDeploy(t *testing.T) {
+	deployertesting.TestInt_ResourceValidationOnFirstDeploy(t,
+		k8s.NewDeployer(k8s.WithDeployerVerbose(false)),
+		k8s.NewRemover(false),
+		k8s.NewDescriber(false),
+		k8s.KubernetesDeployerName)
+}

--- a/pkg/keda/deployer_int_test.go
+++ b/pkg/keda/deployer_int_test.go
@@ -59,3 +59,11 @@ func TestInt_EnvsUpdate(t *testing.T) {
 		keda.NewDescriber(false),
 		keda.KedaDeployerName)
 }
+
+func TestInt_ResourceValidationOnFirstDeploy(t *testing.T) {
+	deployertesting.TestInt_ResourceValidationOnFirstDeploy(t,
+		keda.NewDeployer(keda.WithDeployerVerbose(false)),
+		keda.NewRemover(false),
+		keda.NewDescriber(false),
+		keda.KedaDeployerName)
+}


### PR DESCRIPTION
## Summary
- Wire up `TestInt_ResourceValidationOnFirstDeploy` for the k8s and keda deployers, matching the existing Knative deployer coverage
- No new test logic — both delegate to the shared helper in `pkg/deployer/testing`

## Test plan
- [ ] Run `go build -tags integration ./pkg/k8s/... ./pkg/keda/...` to verify compilation
- [ ] Run the integration test suite against a cluster with all three deployers

Ref #3514
