### PR TITLE
fix: apply resource validation to first-deploy path in k8s and keda deployers

### DIFF
--- a/pkg/k8s/deployer.go
+++ b/pkg/k8s/deployer.go
@@ -157,7 +157,7 @@ func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (fn.DeploymentResu
 		}
 
 		if err = CheckResourcesArePresent(ctx, namespace, &referencedSecrets, &referencedConfigMaps, &referencedPVCs, f.Deploy.ServiceAccountName, f.Deploy.ImagePullSecret); err != nil {
-			return fn.DeploymentResult{}, fmt.Errorf("failed to update deployment: %w", err)
+			return fn.DeploymentResult{}, fmt.Errorf("failed to validate referenced resources: %w", err)
 		}
 
 		svc, err := d.generateService(f, namespace, daprInstalled, existingDeployment)
@@ -206,7 +206,7 @@ func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (fn.DeploymentResu
 		}
 
 		if err = CheckResourcesArePresent(ctx, namespace, &referencedSecrets, &referencedConfigMaps, &referencedPVCs, f.Deploy.ServiceAccountName, f.Deploy.ImagePullSecret); err != nil {
-			return fn.DeploymentResult{}, fmt.Errorf("failed to create deployment: %w", err)
+			return fn.DeploymentResult{}, fmt.Errorf("failed to validate referenced resources: %w", err)
 		}
 
 		deployment, err = deploymentClient.Create(ctx, deployment, metav1.CreateOptions{})

--- a/pkg/k8s/deployer.go
+++ b/pkg/k8s/deployer.go
@@ -147,9 +147,17 @@ func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (fn.DeploymentResu
 	var status fn.Status
 	if err == nil {
 		// Update the existing function
-		deployment, err := d.generateDeployment(f, namespace, daprInstalled)
+		referencedSecrets := sets.New[string]()
+		referencedConfigMaps := sets.New[string]()
+		referencedPVCs := sets.New[string]()
+
+		deployment, err := d.generateDeployment(f, namespace, daprInstalled, &referencedSecrets, &referencedConfigMaps, &referencedPVCs)
 		if err != nil {
 			return fn.DeploymentResult{}, fmt.Errorf("failed to generate deployment resources: %w", err)
+		}
+
+		if err = CheckResourcesArePresent(ctx, namespace, &referencedSecrets, &referencedConfigMaps, &referencedPVCs, f.Deploy.ServiceAccountName, f.Deploy.ImagePullSecret); err != nil {
+			return fn.DeploymentResult{}, fmt.Errorf("failed to update deployment: %w", err)
 		}
 
 		svc, err := d.generateService(f, namespace, daprInstalled, existingDeployment)
@@ -188,9 +196,17 @@ func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (fn.DeploymentResu
 			return fn.DeploymentResult{}, fmt.Errorf("failed to check for existing deployment: %w", err)
 		}
 
-		deployment, err := d.generateDeployment(f, namespace, daprInstalled)
+		referencedSecrets := sets.New[string]()
+		referencedConfigMaps := sets.New[string]()
+		referencedPVCs := sets.New[string]()
+
+		deployment, err := d.generateDeployment(f, namespace, daprInstalled, &referencedSecrets, &referencedConfigMaps, &referencedPVCs)
 		if err != nil {
 			return fn.DeploymentResult{}, fmt.Errorf("failed to generate deployment resources: %w", err)
+		}
+
+		if err = CheckResourcesArePresent(ctx, namespace, &referencedSecrets, &referencedConfigMaps, &referencedPVCs, f.Deploy.ServiceAccountName, f.Deploy.ImagePullSecret); err != nil {
+			return fn.DeploymentResult{}, fmt.Errorf("failed to create deployment: %w", err)
 		}
 
 		deployment, err = deploymentClient.Create(ctx, deployment, metav1.CreateOptions{})
@@ -363,7 +379,7 @@ func deleteStaleTriggers(ctx context.Context, eventingClient clienteventingv1.Kn
 	return nil
 }
 
-func (d *Deployer) generateDeployment(f fn.Function, namespace string, daprInstalled bool) (*appsv1.Deployment, error) {
+func (d *Deployer) generateDeployment(f fn.Function, namespace string, daprInstalled bool, referencedSecrets, referencedConfigMaps, referencedPVCs *sets.Set[string]) (*appsv1.Deployment, error) {
 	labels, err := deployer.GenerateCommonLabels(f, d.decorator)
 	if err != nil {
 		return nil, err
@@ -375,17 +391,12 @@ func (d *Deployer) generateDeployment(f fn.Function, namespace string, daprInsta
 	podAnnotations := make(map[string]string)
 	maps.Copy(podAnnotations, annotations)
 
-	// Process environment variables and volumes
-	referencedSecrets := sets.New[string]()
-	referencedConfigMaps := sets.New[string]()
-	referencedPVCs := sets.New[string]()
-
-	envVars, envFrom, err := ProcessEnvs(f.Run.Envs, &referencedSecrets, &referencedConfigMaps)
+	envVars, envFrom, err := ProcessEnvs(f.Run.Envs, referencedSecrets, referencedConfigMaps)
 	if err != nil {
 		return nil, fmt.Errorf("failed to process environment variables: %w", err)
 	}
 
-	volumes, volumeMounts, err := ProcessVolumes(f.Run.Volumes, &referencedSecrets, &referencedConfigMaps, &referencedPVCs)
+	volumes, volumeMounts, err := ProcessVolumes(f.Run.Volumes, referencedSecrets, referencedConfigMaps, referencedPVCs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to process volumes: %w", err)
 	}

--- a/pkg/k8s/deployer_int_test.go
+++ b/pkg/k8s/deployer_int_test.go
@@ -59,3 +59,11 @@ func TestInt_EnvsUpdate(t *testing.T) {
 		k8s.NewDescriber(false),
 		k8s.KubernetesDeployerName)
 }
+
+func TestInt_ResourceValidationOnFirstDeploy(t *testing.T) {
+	deployertesting.TestInt_ResourceValidationOnFirstDeploy(t,
+		k8s.NewDeployer(k8s.WithDeployerVerbose(false)),
+		k8s.NewRemover(false),
+		k8s.NewDescriber(false),
+		k8s.KubernetesDeployerName)
+}

--- a/pkg/k8s/deployer_test.go
+++ b/pkg/k8s/deployer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	fn "knative.dev/func/pkg/functions"
 )
 
@@ -120,7 +121,8 @@ func Test_generateDeployment_ImagePullSecret(t *testing.T) {
 				ImagePullSecret: "my-registry-secret",
 			},
 		}
-		deployment, err := d.generateDeployment(f, "default", false)
+		rs, rcm, rpvc := sets.New[string](), sets.New[string](), sets.New[string]()
+		deployment, err := d.generateDeployment(f, "default", false, &rs, &rcm, &rpvc)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -137,7 +139,8 @@ func Test_generateDeployment_ImagePullSecret(t *testing.T) {
 				Image: "registry.example.com/test:latest",
 			},
 		}
-		deployment, err := d.generateDeployment(f, "default", false)
+		rs, rcm, rpvc := sets.New[string](), sets.New[string](), sets.New[string]()
+		deployment, err := d.generateDeployment(f, "default", false, &rs, &rcm, &rpvc)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/keda/deployer_int_test.go
+++ b/pkg/keda/deployer_int_test.go
@@ -59,3 +59,11 @@ func TestInt_EnvsUpdate(t *testing.T) {
 		keda.NewDescriber(false),
 		keda.KedaDeployerName)
 }
+
+func TestInt_ResourceValidationOnFirstDeploy(t *testing.T) {
+	deployertesting.TestInt_ResourceValidationOnFirstDeploy(t,
+		keda.NewDeployer(keda.WithDeployerVerbose(false)),
+		keda.NewRemover(false),
+		keda.NewDescriber(false),
+		keda.KedaDeployerName)
+}


### PR DESCRIPTION
## Problem

`generateDeployment` in `pkg/k8s/deployer.go` allocated its own local
`referencedSecrets`, `referencedConfigMaps`, and `referencedPVCs` sets
internally. Those sets were never visible to the caller, so
`CheckResourcesArePresent` was never called on the k8s deploy path —
silently passing validation regardless of whether referenced Secrets,
ConfigMaps, or PVCs actually existed on the cluster.

The keda deployer is a thin wrapper around the k8s deployer and inherited
the same gap.

This is the same class of bug fixed for the knative deployer in #3579.


Pass the three sets as parameters into `generateDeployment` instead of
allocating them locally. `Deploy()` now:

1. Allocates the sets before calling `generateDeployment`
2. Calls `CheckResourcesArePresent` after `generateDeployment` on both the
   create path (first deploy) and the update path (redeployment), before
   touching the API

The keda deployer gets the fix for free since it delegates to the k8s
deployer.

## Tests

- `TestInt_ResourceValidationOnFirstDeploy` wired in `pkg/k8s/deployer_int_test.go`
  and `pkg/keda/deployer_int_test.go` — exercises the same shared scenario
  from `pkg/deployer/testing/integration_test_helper.go` used by the
  knative deployer since #3579
- Existing unit tests in `pkg/k8s/deployer_test.go` updated to match the
  new `generateDeployment` signature