### PR TITLE
test: remove redundant loop variable capture in builder_test.go

### DIFF
--- a/pkg/buildpacks/builder_test.go
+++ b/pkg/buildpacks/builder_test.go
@@ -290,7 +290,6 @@ func TestBuild_Errors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc := tc
 			t.Parallel()
 			gotErr := ErrRuntimeRequired{}.Error()
 			if tc.runtime != "" {


### PR DESCRIPTION
## Summary

Remove the redundant `tc := tc` loop variable capture from `TestBuild_Errors` in `pkg/buildpacks/builder_test.go`.

Since Go 1.22, each loop iteration gets its own copy of the loop variable automatically, making the explicit shadowing idiom unnecessary. This project uses Go 1.25, so the pattern is dead code.

## Changes

- `pkg/buildpacks/builder_test.go`: remove `tc := tc` from the `TestBuild_Errors` table-driven test loop

## Testing

```
make test
```