### PR TITLE
mcp: populate Image and URL structured output fields

### DIFF
--- a/pkg/mcp/tools_build.go
+++ b/pkg/mcp/tools_build.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	fn "knative.dev/func/pkg/functions"
 )
 
 var buildTool = &mcp.Tool{
@@ -27,6 +28,9 @@ func (s *Server) buildHandler(ctx context.Context, r *mcp.CallToolRequest, input
 	}
 	output = BuildOutput{
 		Message: string(out),
+	}
+	if f, ferr := fn.NewFunction(input.Path); ferr == nil {
+		output.Image = f.Build.Image
 	}
 	return
 }

--- a/pkg/mcp/tools_build.go
+++ b/pkg/mcp/tools_build.go
@@ -31,6 +31,8 @@ func (s *Server) buildHandler(ctx context.Context, r *mcp.CallToolRequest, input
 	}
 	if f, ferr := fn.NewFunction(input.Path); ferr == nil {
 		output.Image = f.Build.Image
+	} else {
+		output.Message += fmt.Sprintf("\n(warning: could not read built image from func.yaml: %v)", ferr)
 	}
 	return
 }

--- a/pkg/mcp/tools_build_test.go
+++ b/pkg/mcp/tools_build_test.go
@@ -2,6 +2,9 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -65,5 +68,88 @@ func TestTool_Build_Args(t *testing.T) {
 	}
 	if !executor.ExecuteInvoked {
 		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_Build_StructuredOutput verifies that the Image field is populated
+// from the .func/built-image file written by the func CLI after a successful build.
+func TestTool_Build_StructuredOutput(t *testing.T) {
+	const wantImage = "ghcr.io/user/my-func:latest"
+
+	// Create a minimal function directory that fn.NewFunction can read.
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "func.yaml"), []byte("name: my-func\nruntime: go\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	funcDir := filepath.Join(root, ".func")
+	if err := os.MkdirAll(funcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(funcDir, "built-image"), []byte(wantImage), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte("Build successful\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "build",
+		Arguments: map[string]any{"path": root},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+
+	raw := resultToString(result)
+	var output BuildOutput
+	if err := json.Unmarshal([]byte(raw), &output); err != nil {
+		t.Fatalf("failed to unmarshal output: %v\nraw: %s", err, raw)
+	}
+	if output.Image != wantImage {
+		t.Errorf("Image = %q, want %q", output.Image, wantImage)
+	}
+}
+
+// TestTool_Build_StructuredOutput_NoFuncYaml verifies that a missing func.yaml
+// (e.g. an invalid path) does not cause the handler to fail — Image is just empty.
+func TestTool_Build_StructuredOutput_NoFuncYaml(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte("Build successful\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "build",
+		Arguments: map[string]any{"path": t.TempDir()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+
+	raw := resultToString(result)
+	var output BuildOutput
+	if err := json.Unmarshal([]byte(raw), &output); err != nil {
+		t.Fatalf("failed to unmarshal output: %v\nraw: %s", err, raw)
+	}
+	if output.Image != "" {
+		t.Errorf("expected empty Image when func.yaml absent, got %q", output.Image)
 	}
 }

--- a/pkg/mcp/tools_deploy.go
+++ b/pkg/mcp/tools_deploy.go
@@ -1,10 +1,14 @@
 package mcp
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	fn "knative.dev/func/pkg/functions"
 )
 
 var deployTool = &mcp.Tool{
@@ -31,8 +35,46 @@ func (s *Server) deployHandler(ctx context.Context, r *mcp.CallToolRequest, inpu
 	}
 	output = DeployOutput{
 		Message: string(out),
+		URL:     parseDeployedURL(out),
+	}
+	if f, ferr := fn.NewFunction(input.Path); ferr == nil {
+		output.Image = f.Deploy.Image
 	}
 	return
+}
+
+// parseDeployedURL extracts the deployed function URL from combined command
+// output. It handles two formats produced by the func CLI:
+//
+//   - Local deploy (written to stderr by the functions client):
+//     "✅ Function deployed/updated in namespace "ns" and exposed at URL: \n   <url>"
+//
+//   - Remote pipeline deploy (written to stdout by cmd/deploy.go):
+//     "Function Deployed at <url>"
+func parseDeployedURL(out []byte) string {
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	urlNext := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if urlNext {
+			if u := strings.TrimSpace(line); u != "" {
+				return u
+			}
+		}
+		// Local deploy: URL follows on the next non-empty line after this marker.
+		if strings.Contains(line, "exposed at URL:") {
+			urlNext = true
+			continue
+		}
+		// Remote pipeline deploy: URL is on the same line after the prefix.
+		const remotePrefix = "Function Deployed at "
+		if idx := strings.Index(line, remotePrefix); idx >= 0 {
+			if u := strings.TrimSpace(line[idx+len(remotePrefix):]); u != "" {
+				return u
+			}
+		}
+	}
+	return ""
 }
 
 // DeployInput defines the input parameters for the deploy tool.

--- a/pkg/mcp/tools_deploy.go
+++ b/pkg/mcp/tools_deploy.go
@@ -49,12 +49,17 @@ func (s *Server) deployHandler(ctx context.Context, r *mcp.CallToolRequest, inpu
 	return
 }
 
-// parseDeployedURL extracts the deployed URL from deploy output.
-// Handles two formats: local deploy prints the URL on the line after
-// "exposed at URL:", remote pipeline prints it inline after "Function Deployed at ".
+// parseDeployedURL extracts the deployed function URL from combined command
+// output. It handles two formats produced by the func CLI:
+//
+//   - Local deploy (written to stderr by the functions client):
+//     "✅ Function deployed/updated in namespace "ns" and exposed at URL: \n   <url>"
+//
+//   - Remote pipeline deploy (written to stdout by cmd/deploy.go):
+//     "Function Deployed at <url>"
 func parseDeployedURL(out []byte) (string, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(out))
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // handle large/verbose deploy output
 	urlNext := false
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -63,10 +68,12 @@ func parseDeployedURL(out []byte) (string, error) {
 				return u, nil
 			}
 		}
+		// Local deploy: URL follows on the next non-empty line after this marker.
 		if strings.Contains(line, "exposed at URL:") {
 			urlNext = true
 			continue
 		}
+		// Remote pipeline deploy: URL is on the same line after the prefix.
 		const remotePrefix = "Function Deployed at "
 		if idx := strings.Index(line, remotePrefix); idx >= 0 {
 			if u := strings.TrimSpace(line[idx+len(remotePrefix):]); u != "" {

--- a/pkg/mcp/tools_deploy.go
+++ b/pkg/mcp/tools_deploy.go
@@ -49,17 +49,12 @@ func (s *Server) deployHandler(ctx context.Context, r *mcp.CallToolRequest, inpu
 	return
 }
 
-// parseDeployedURL extracts the deployed function URL from combined command
-// output. It handles two formats produced by the func CLI:
-//
-//   - Local deploy (written to stderr by the functions client):
-//     "✅ Function deployed/updated in namespace "ns" and exposed at URL: \n   <url>"
-//
-//   - Remote pipeline deploy (written to stdout by cmd/deploy.go):
-//     "Function Deployed at <url>"
+// parseDeployedURL extracts the deployed URL from deploy output.
+// Handles two formats: local deploy prints the URL on the line after
+// "exposed at URL:", remote pipeline prints it inline after "Function Deployed at ".
 func parseDeployedURL(out []byte) (string, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(out))
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // handle large/verbose deploy output
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
 	urlNext := false
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -68,12 +63,10 @@ func parseDeployedURL(out []byte) (string, error) {
 				return u, nil
 			}
 		}
-		// Local deploy: URL follows on the next non-empty line after this marker.
 		if strings.Contains(line, "exposed at URL:") {
 			urlNext = true
 			continue
 		}
-		// Remote pipeline deploy: URL is on the same line after the prefix.
 		const remotePrefix = "Function Deployed at "
 		if idx := strings.Index(line, remotePrefix); idx >= 0 {
 			if u := strings.TrimSpace(line[idx+len(remotePrefix):]); u != "" {

--- a/pkg/mcp/tools_deploy.go
+++ b/pkg/mcp/tools_deploy.go
@@ -33,12 +33,18 @@ func (s *Server) deployHandler(ctx context.Context, r *mcp.CallToolRequest, inpu
 		err = fmt.Errorf("%w\n%s", err, string(out))
 		return
 	}
+	url, urlErr := parseDeployedURL(out)
 	output = DeployOutput{
 		Message: string(out),
-		URL:     parseDeployedURL(out),
+		URL:     url,
+	}
+	if urlErr != nil {
+		output.Message += fmt.Sprintf("\n(warning: could not parse deployed URL from output: %v)", urlErr)
 	}
 	if f, ferr := fn.NewFunction(input.Path); ferr == nil {
 		output.Image = f.Deploy.Image
+	} else {
+		output.Message += fmt.Sprintf("\n(warning: could not read deployed image from func.yaml: %v)", ferr)
 	}
 	return
 }
@@ -51,14 +57,15 @@ func (s *Server) deployHandler(ctx context.Context, r *mcp.CallToolRequest, inpu
 //
 //   - Remote pipeline deploy (written to stdout by cmd/deploy.go):
 //     "Function Deployed at <url>"
-func parseDeployedURL(out []byte) string {
+func parseDeployedURL(out []byte) (string, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(out))
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // handle large/verbose deploy output
 	urlNext := false
 	for scanner.Scan() {
 		line := scanner.Text()
 		if urlNext {
 			if u := strings.TrimSpace(line); u != "" {
-				return u
+				return u, nil
 			}
 		}
 		// Local deploy: URL follows on the next non-empty line after this marker.
@@ -70,11 +77,11 @@ func parseDeployedURL(out []byte) string {
 		const remotePrefix = "Function Deployed at "
 		if idx := strings.Index(line, remotePrefix); idx >= 0 {
 			if u := strings.TrimSpace(line[idx+len(remotePrefix):]); u != "" {
-				return u
+				return u, nil
 			}
 		}
 	}
-	return ""
+	return "", scanner.Err()
 }
 
 // DeployInput defines the input parameters for the deploy tool.

--- a/pkg/mcp/tools_deploy_test.go
+++ b/pkg/mcp/tools_deploy_test.go
@@ -121,7 +121,10 @@ func TestParseDeployedURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseDeployedURL([]byte(tt.out))
+			got, err := parseDeployedURL([]byte(tt.out))
+			if err != nil {
+				t.Fatalf("parseDeployedURL(%q) unexpected error: %v", tt.out, err)
+			}
 			if got != tt.want {
 				t.Errorf("parseDeployedURL(%q) = %q, want %q", tt.out, got, tt.want)
 			}

--- a/pkg/mcp/tools_deploy_test.go
+++ b/pkg/mcp/tools_deploy_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -77,5 +78,90 @@ func TestTool_Deploy_Args(t *testing.T) {
 	}
 	if !executor.ExecuteInvoked {
 		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestParseDeployedURL verifies URL extraction from both local and remote deploy output.
+func TestParseDeployedURL(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{
+			name: "local deploy",
+			out:  "✅ Function deployed in namespace \"default\" and exposed at URL: \n   https://my-func.default.example.com\n",
+			want: "https://my-func.default.example.com",
+		},
+		{
+			name: "local update",
+			out:  "✅ Function updated in namespace \"prod\" and exposed at URL: \n   https://my-func.prod.example.com\n",
+			want: "https://my-func.prod.example.com",
+		},
+		{
+			name: "remote pipeline deploy",
+			out:  "Function Deployed at https://my-func.remote.example.com\n",
+			want: "https://my-func.remote.example.com",
+		},
+		{
+			name: "remote pipeline deploy with surrounding output",
+			out:  "Building...\nPushing...\nFunction Deployed at https://my-func.remote.example.com\nDone.\n",
+			want: "https://my-func.remote.example.com",
+		},
+		{
+			name: "no url in output",
+			out:  "function up-to-date. Force rebuild with --build\n",
+			want: "",
+		},
+		{
+			name: "empty output",
+			out:  "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDeployedURL([]byte(tt.out))
+			if got != tt.want {
+				t.Errorf("parseDeployedURL(%q) = %q, want %q", tt.out, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTool_Deploy_StructuredOutput verifies that URL is populated from parsed output.
+func TestTool_Deploy_StructuredOutput(t *testing.T) {
+	const wantURL = "https://my-func.default.example.com"
+
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		out := "✅ Function deployed in namespace \"default\" and exposed at URL: \n   " + wantURL + "\n"
+		return []byte(out), nil
+	}
+
+	client, server, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.readonly = false
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "deploy",
+		Arguments: map[string]any{"path": t.TempDir()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+
+	raw := resultToString(result)
+	var output DeployOutput
+	if err := json.Unmarshal([]byte(raw), &output); err != nil {
+		t.Fatalf("failed to unmarshal output: %v\nraw: %s", err, raw)
+	}
+	if output.URL != wantURL {
+		t.Errorf("URL = %q, want %q", output.URL, wantURL)
 	}
 }


### PR DESCRIPTION
## What

The `build` and `deploy` MCP tool handlers declared structured output fields
(`image`, `url`) that were never populated — only the raw `message` string was
set. Agents inspecting the structured response to learn the deployed URL or
built image name always received empty strings and had to parse raw text instead.

## Why

Structured output fields exist so MCP clients can consume typed values without
text scraping. Empty fields make the schema misleading and break any agent that
relies on them.

## How

**`tools_build.go`** — after `func build` exits, reload the function from disk
and read `f.Build.Image`. The build CLI writes the final image reference (with
digest) to `.func/built-image`; `fn.NewFunction` picks it up via
`getLastBuiltImage()`.

**`tools_deploy.go`** — two changes:
- Added `parseDeployedURL` to extract the route URL from combined stdout. Handles
  both the local-deploy format (`exposed at URL:\n   <url>`) and the remote
  pipeline format (`Function Deployed at <url>`).
- After the subprocess exits, reload the function and read `f.Deploy.Image` from
  `func.yaml` (where the deploy step persists it).

## Tests

- `TestTool_Build_StructuredOutput` — verifies `Image` is read from
  `.func/built-image` after a successful build.
- `TestTool_Build_StructuredOutput_NoFuncYaml` — verifies that a missing
  `func.yaml` does not cause the handler to fail; `Image` is empty but no
  error is returned.
- `TestParseDeployedURL` — table-driven coverage of both output formats,
  surrounding noise, and the empty / no-URL cases.
- `TestTool_Deploy_StructuredOutput` — end-to-end: mock executor returns
  local-deploy output; asserts `URL` is correctly extracted.