### PR TITLE
feat(mcp): add secret and ConfigMap support to config_envs_add tool

### DIFF
--- a/pkg/mcp/tools_config_envs.go
+++ b/pkg/mcp/tools_config_envs.go
@@ -82,7 +82,7 @@ The explicit Value field takes precedence if provided alongside source fields.`,
 type ConfigEnvsAddInput struct {
 	Path          string  `json:"path" jsonschema:"required,Path to the function project directory"`
 	Name          *string `json:"name,omitempty" jsonschema:"Name of the environment variable"`
-	Value         *string `json:"value,omitempty" jsonschema:"Literal value for the environment variable"`
+	Value         *string `json:"value,omitempty" jsonschema:"Literal value or template expression (e.g. '{{ env:MY_VAR }}') for the environment variable"`
 	SecretName    *string `json:"secretName,omitempty" jsonschema:"Name of the Kubernetes Secret to source the value from"`
 	SecretKey     *string `json:"secretKey,omitempty" jsonschema:"Key within the Secret; omit to import all keys as env vars"`
 	ConfigMapName *string `json:"configMapName,omitempty" jsonschema:"Name of the Kubernetes ConfigMap to source the value from"`
@@ -98,6 +98,21 @@ func (i ConfigEnvsAddInput) validate() error {
 	}
 	if i.ConfigMapKey != nil && i.ConfigMapName == nil {
 		return fmt.Errorf("configMapKey requires configMapName to be set")
+	}
+	if i.SecretName != nil && i.ConfigMapName != nil {
+		return fmt.Errorf("secretName and configMapName are mutually exclusive; provide only one source")
+	}
+	// All-keys import (no secretKey/configMapKey) is incompatible with --name: the
+	// underlying env validation only allows whole-secret/configMap templates when name is nil.
+	// The guard is skipped when an explicit Value is present because Value takes precedence
+	// and SecretName/ConfigMapName is effectively ignored in that path.
+	if i.Value == nil {
+		if i.SecretName != nil && i.SecretKey == nil && i.Name != nil {
+			return fmt.Errorf("name must not be set when importing all keys from a Secret (omit secretKey to import all keys)")
+		}
+		if i.ConfigMapName != nil && i.ConfigMapKey == nil && i.Name != nil {
+			return fmt.Errorf("name must not be set when importing all keys from a ConfigMap (omit configMapKey to import all keys)")
+		}
 	}
 	if i.SecretName != nil && !validResourceName.MatchString(*i.SecretName) {
 		return fmt.Errorf("invalid secretName %q: only word characters, hyphens and apostrophes are allowed", *i.SecretName)

--- a/pkg/mcp/tools_config_envs.go
+++ b/pkg/mcp/tools_config_envs.go
@@ -3,17 +3,9 @@ package mcp
 import (
 	"context"
 	"fmt"
-	"regexp"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
-
-// validResourceName matches Kubernetes resource names as accepted by the env template syntax.
-// Mirrors the name capture group used in pkg/functions/function.go validation regexes.
-var validResourceName = regexp.MustCompile(`^((?:\w|['-]\w)+)$`)
-
-// validKeyName matches Secret/ConfigMap key names as accepted by the env template syntax.
-var validKeyName = regexp.MustCompile(`^[-._a-zA-Z0-9]+$`)
 
 // config_envs_list
 
@@ -70,7 +62,7 @@ Supports six source types:
 
 When SecretName or ConfigMapName is provided, the tool constructs the
 appropriate "{{ secret:… }}" or "{{ configMap:… }}" value template automatically.
-The explicit Value field takes precedence if provided alongside source fields.`,
+Value is mutually exclusive with SecretName and ConfigMapName.`,
 	Annotations: &mcp.ToolAnnotations{
 		Title:           "Config Environment Variables Add",
 		ReadOnlyHint:    false,
@@ -90,9 +82,13 @@ type ConfigEnvsAddInput struct {
 	Verbose       *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
 }
 
-// validate returns an error for any illegal input combination or character set
-// violation before args are constructed and forwarded to the CLI.
+// validate returns an error for any illegal input combination before args are
+// constructed and forwarded to the CLI. Character-set validation is deferred to
+// func's own parser, keeping this layer as a thin pass-through.
 func (i ConfigEnvsAddInput) validate() error {
+	if i.Value != nil && (i.SecretName != nil || i.ConfigMapName != nil) {
+		return fmt.Errorf("value is mutually exclusive with secretName/configMapName; provide one or the other")
+	}
 	if i.SecretKey != nil && i.SecretName == nil {
 		return fmt.Errorf("secretKey requires secretName to be set")
 	}
@@ -104,27 +100,11 @@ func (i ConfigEnvsAddInput) validate() error {
 	}
 	// All-keys import (no secretKey/configMapKey) is incompatible with --name: the
 	// underlying env validation only allows whole-secret/configMap templates when name is nil.
-	// The guard is skipped when an explicit Value is present because Value takes precedence
-	// and SecretName/ConfigMapName is effectively ignored in that path.
-	if i.Value == nil {
-		if i.SecretName != nil && i.SecretKey == nil && i.Name != nil {
-			return fmt.Errorf("name must not be set when importing all keys from a Secret (omit secretKey to import all keys)")
-		}
-		if i.ConfigMapName != nil && i.ConfigMapKey == nil && i.Name != nil {
-			return fmt.Errorf("name must not be set when importing all keys from a ConfigMap (omit configMapKey to import all keys)")
-		}
+	if i.SecretName != nil && i.SecretKey == nil && i.Name != nil {
+		return fmt.Errorf("name must not be set when importing all keys from a Secret (omit secretKey to import all keys)")
 	}
-	if i.SecretName != nil && !validResourceName.MatchString(*i.SecretName) {
-		return fmt.Errorf("invalid secretName %q: only word characters, hyphens and apostrophes are allowed", *i.SecretName)
-	}
-	if i.SecretKey != nil && !validKeyName.MatchString(*i.SecretKey) {
-		return fmt.Errorf("invalid secretKey %q: only alphanumeric characters, hyphens, dots and underscores are allowed", *i.SecretKey)
-	}
-	if i.ConfigMapName != nil && !validResourceName.MatchString(*i.ConfigMapName) {
-		return fmt.Errorf("invalid configMapName %q: only word characters, hyphens and apostrophes are allowed", *i.ConfigMapName)
-	}
-	if i.ConfigMapKey != nil && !validKeyName.MatchString(*i.ConfigMapKey) {
-		return fmt.Errorf("invalid configMapKey %q: only alphanumeric characters, hyphens, dots and underscores are allowed", *i.ConfigMapKey)
+	if i.ConfigMapName != nil && i.ConfigMapKey == nil && i.Name != nil {
+		return fmt.Errorf("name must not be set when importing all keys from a ConfigMap (omit configMapKey to import all keys)")
 	}
 	return nil
 }
@@ -133,7 +113,6 @@ func (i ConfigEnvsAddInput) Args() []string {
 	args := []string{"envs", "add", "--path", i.Path}
 	args = appendStringFlag(args, "--name", i.Name)
 
-	// Explicit Value takes precedence over structured secret/configmap fields.
 	if i.Value != nil {
 		args = appendStringFlag(args, "--value", i.Value)
 	} else if i.SecretName != nil {

--- a/pkg/mcp/tools_config_envs.go
+++ b/pkg/mcp/tools_config_envs.go
@@ -48,9 +48,21 @@ func (s *Server) configEnvsListHandler(ctx context.Context, r *mcp.CallToolReque
 // config_envs_add
 
 var configEnvsAddTool = &mcp.Tool{
-	Name:        "config_envs_add",
-	Title:       "Config Environment Variables Add",
-	Description: "Adds an environment variable to a function's configuration.",
+	Name:  "config_envs_add",
+	Title: "Config Environment Variables Add",
+	Description: `Adds an environment variable to a function's configuration.
+
+Supports four source types:
+  1. Literal value:      set Name and Value directly.
+  2. Local env var:      set Name and Value to "{{ env:LOCAL_VAR }}".
+  3. Secret (all keys):  set SecretName only — imports every key from the Secret as env vars.
+  4. Secret (one key):   set Name, SecretName, and SecretKey.
+  5. ConfigMap (all):    set ConfigMapName only — imports every key from the ConfigMap as env vars.
+  6. ConfigMap (one key): set Name, ConfigMapName, and ConfigMapKey.
+
+When SecretName or ConfigMapName is provided, the tool constructs the
+appropriate "{{ secret:… }}" or "{{ configMap:… }}" value template automatically.
+The explicit Value field takes precedence if provided alongside source fields.`,
 	Annotations: &mcp.ToolAnnotations{
 		Title:           "Config Environment Variables Add",
 		ReadOnlyHint:    false,
@@ -60,16 +72,41 @@ var configEnvsAddTool = &mcp.Tool{
 }
 
 type ConfigEnvsAddInput struct {
-	Path    string  `json:"path" jsonschema:"required,Path to the function project directory"`
-	Name    *string `json:"name,omitempty" jsonschema:"Name of the environment variable"`
-	Value   *string `json:"value,omitempty" jsonschema:"Value of the environment variable"`
-	Verbose *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
+	Path         string  `json:"path" jsonschema:"required,Path to the function project directory"`
+	Name         *string `json:"name,omitempty" jsonschema:"Name of the environment variable"`
+	Value        *string `json:"value,omitempty" jsonschema:"Literal value for the environment variable"`
+	SecretName   *string `json:"secretName,omitempty" jsonschema:"Name of the Kubernetes Secret to source the value from"`
+	SecretKey    *string `json:"secretKey,omitempty" jsonschema:"Key within the Secret; omit to import all keys as env vars"`
+	ConfigMapName *string `json:"configMapName,omitempty" jsonschema:"Name of the Kubernetes ConfigMap to source the value from"`
+	ConfigMapKey  *string `json:"configMapKey,omitempty" jsonschema:"Key within the ConfigMap; omit to import all keys as env vars"`
+	Verbose      *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
 }
 
 func (i ConfigEnvsAddInput) Args() []string {
 	args := []string{"envs", "add", "--path", i.Path}
 	args = appendStringFlag(args, "--name", i.Name)
-	args = appendStringFlag(args, "--value", i.Value)
+
+	// Explicit Value takes precedence over structured secret/configmap fields.
+	if i.Value != nil {
+		args = appendStringFlag(args, "--value", i.Value)
+	} else if i.SecretName != nil {
+		var v string
+		if i.SecretKey != nil {
+			v = fmt.Sprintf("{{ secret:%s:%s }}", *i.SecretName, *i.SecretKey)
+		} else {
+			v = fmt.Sprintf("{{ secret:%s }}", *i.SecretName)
+		}
+		args = append(args, "--value", v)
+	} else if i.ConfigMapName != nil {
+		var v string
+		if i.ConfigMapKey != nil {
+			v = fmt.Sprintf("{{ configMap:%s:%s }}", *i.ConfigMapName, *i.ConfigMapKey)
+		} else {
+			v = fmt.Sprintf("{{ configMap:%s }}", *i.ConfigMapName)
+		}
+		args = append(args, "--value", v)
+	}
+
 	args = appendBoolFlag(args, "--verbose", i.Verbose)
 	return args
 }

--- a/pkg/mcp/tools_config_envs.go
+++ b/pkg/mcp/tools_config_envs.go
@@ -72,14 +72,14 @@ The explicit Value field takes precedence if provided alongside source fields.`,
 }
 
 type ConfigEnvsAddInput struct {
-	Path         string  `json:"path" jsonschema:"required,Path to the function project directory"`
-	Name         *string `json:"name,omitempty" jsonschema:"Name of the environment variable"`
-	Value        *string `json:"value,omitempty" jsonschema:"Literal value for the environment variable"`
-	SecretName   *string `json:"secretName,omitempty" jsonschema:"Name of the Kubernetes Secret to source the value from"`
-	SecretKey    *string `json:"secretKey,omitempty" jsonschema:"Key within the Secret; omit to import all keys as env vars"`
+	Path          string  `json:"path" jsonschema:"required,Path to the function project directory"`
+	Name          *string `json:"name,omitempty" jsonschema:"Name of the environment variable"`
+	Value         *string `json:"value,omitempty" jsonschema:"Literal value for the environment variable"`
+	SecretName    *string `json:"secretName,omitempty" jsonschema:"Name of the Kubernetes Secret to source the value from"`
+	SecretKey     *string `json:"secretKey,omitempty" jsonschema:"Key within the Secret; omit to import all keys as env vars"`
 	ConfigMapName *string `json:"configMapName,omitempty" jsonschema:"Name of the Kubernetes ConfigMap to source the value from"`
 	ConfigMapKey  *string `json:"configMapKey,omitempty" jsonschema:"Key within the ConfigMap; omit to import all keys as env vars"`
-	Verbose      *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
+	Verbose       *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
 }
 
 func (i ConfigEnvsAddInput) Args() []string {

--- a/pkg/mcp/tools_config_envs.go
+++ b/pkg/mcp/tools_config_envs.go
@@ -3,9 +3,17 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+// validResourceName matches Kubernetes resource names as accepted by the env template syntax.
+// Mirrors the name capture group used in pkg/functions/function.go validation regexes.
+var validResourceName = regexp.MustCompile(`^((?:\w|['-]\w)+)$`)
+
+// validKeyName matches Secret/ConfigMap key names as accepted by the env template syntax.
+var validKeyName = regexp.MustCompile(`^[-._a-zA-Z0-9]+$`)
 
 // config_envs_list
 
@@ -52,7 +60,7 @@ var configEnvsAddTool = &mcp.Tool{
 	Title: "Config Environment Variables Add",
 	Description: `Adds an environment variable to a function's configuration.
 
-Supports four source types:
+Supports six source types:
   1. Literal value:      set Name and Value directly.
   2. Local env var:      set Name and Value to "{{ env:LOCAL_VAR }}".
   3. Secret (all keys):  set SecretName only — imports every key from the Secret as env vars.
@@ -80,6 +88,30 @@ type ConfigEnvsAddInput struct {
 	ConfigMapName *string `json:"configMapName,omitempty" jsonschema:"Name of the Kubernetes ConfigMap to source the value from"`
 	ConfigMapKey  *string `json:"configMapKey,omitempty" jsonschema:"Key within the ConfigMap; omit to import all keys as env vars"`
 	Verbose       *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
+}
+
+// validate returns an error for any illegal input combination or character set
+// violation before args are constructed and forwarded to the CLI.
+func (i ConfigEnvsAddInput) validate() error {
+	if i.SecretKey != nil && i.SecretName == nil {
+		return fmt.Errorf("secretKey requires secretName to be set")
+	}
+	if i.ConfigMapKey != nil && i.ConfigMapName == nil {
+		return fmt.Errorf("configMapKey requires configMapName to be set")
+	}
+	if i.SecretName != nil && !validResourceName.MatchString(*i.SecretName) {
+		return fmt.Errorf("invalid secretName %q: only word characters, hyphens and apostrophes are allowed", *i.SecretName)
+	}
+	if i.SecretKey != nil && !validKeyName.MatchString(*i.SecretKey) {
+		return fmt.Errorf("invalid secretKey %q: only alphanumeric characters, hyphens, dots and underscores are allowed", *i.SecretKey)
+	}
+	if i.ConfigMapName != nil && !validResourceName.MatchString(*i.ConfigMapName) {
+		return fmt.Errorf("invalid configMapName %q: only word characters, hyphens and apostrophes are allowed", *i.ConfigMapName)
+	}
+	if i.ConfigMapKey != nil && !validKeyName.MatchString(*i.ConfigMapKey) {
+		return fmt.Errorf("invalid configMapKey %q: only alphanumeric characters, hyphens, dots and underscores are allowed", *i.ConfigMapKey)
+	}
+	return nil
 }
 
 func (i ConfigEnvsAddInput) Args() []string {
@@ -116,6 +148,9 @@ type ConfigEnvsAddOutput struct {
 }
 
 func (s *Server) configEnvsAddHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigEnvsAddInput) (result *mcp.CallToolResult, output ConfigEnvsAddOutput, err error) {
+	if err = input.validate(); err != nil {
+		return
+	}
 	out, err := s.executor.Execute(ctx, "config", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))

--- a/pkg/mcp/tools_config_envs_test.go
+++ b/pkg/mcp/tools_config_envs_test.go
@@ -274,6 +274,172 @@ func TestTool_ConfigEnvsAdd_ValueTakesPrecedence(t *testing.T) {
 	}
 }
 
+// TestTool_ConfigEnvsAdd_SecretKeyWithoutSecretName ensures a validation error is returned
+// when secretKey is provided without secretName (SEVERE-2).
+func TestTool_ConfigEnvsAdd_SecretKeyWithoutSecretName(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		t.Fatal("executor must not be called when input is invalid")
+		return nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_envs_add",
+		Arguments: map[string]any{
+			"path":      ".",
+			"name":      "MY_VAR",
+			"secretKey": "MY_KEY",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when secretKey is set without secretName")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when input fails validation")
+	}
+}
+
+// TestTool_ConfigEnvsAdd_ConfigMapKeyWithoutConfigMapName ensures a validation error is
+// returned when configMapKey is provided without configMapName (SEVERE-2).
+func TestTool_ConfigEnvsAdd_ConfigMapKeyWithoutConfigMapName(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		t.Fatal("executor must not be called when input is invalid")
+		return nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_envs_add",
+		Arguments: map[string]any{
+			"path":         ".",
+			"name":         "MY_VAR",
+			"configMapKey": "MY_KEY",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when configMapKey is set without configMapName")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when input fails validation")
+	}
+}
+
+// TestTool_ConfigEnvsAdd_InvalidSecretName ensures a validation error is returned when
+// secretName contains characters outside the allowed set (SEVERE-3).
+func TestTool_ConfigEnvsAdd_InvalidSecretName(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		t.Fatal("executor must not be called when input is invalid")
+		return nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_envs_add",
+		Arguments: map[string]any{
+			"path":       ".",
+			"name":       "MY_VAR",
+			"secretName": "evil:inject}}",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when secretName contains invalid characters")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when input fails validation")
+	}
+}
+
+// TestTool_ConfigEnvsAdd_InvalidSecretKey ensures a validation error is returned when
+// secretKey contains characters outside the allowed set (SEVERE-3).
+func TestTool_ConfigEnvsAdd_InvalidSecretKey(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		t.Fatal("executor must not be called when input is invalid")
+		return nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_envs_add",
+		Arguments: map[string]any{
+			"path":       ".",
+			"name":       "MY_VAR",
+			"secretName": "my-secret",
+			"secretKey":  "bad key with spaces",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when secretKey contains invalid characters")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when input fails validation")
+	}
+}
+
+// TestTool_ConfigEnvsAdd_InvalidConfigMapName ensures a validation error is returned when
+// configMapName contains characters outside the allowed set (SEVERE-3).
+func TestTool_ConfigEnvsAdd_InvalidConfigMapName(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		t.Fatal("executor must not be called when input is invalid")
+		return nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_envs_add",
+		Arguments: map[string]any{
+			"path":          ".",
+			"name":          "MY_VAR",
+			"configMapName": "bad}name",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when configMapName contains invalid characters")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when input fails validation")
+	}
+}
+
 // TestTool_ConfigEnvsList ensures the config_envs_list tool lists environment variables.
 func TestTool_ConfigEnvsList(t *testing.T) {
 	executor := mock.NewExecutor()

--- a/pkg/mcp/tools_config_envs_test.go
+++ b/pkg/mcp/tools_config_envs_test.go
@@ -180,8 +180,8 @@ func TestTool_ConfigEnvsAdd_ConfigMapKey(t *testing.T) {
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name: "config_envs_add",
 		Arguments: map[string]any{
-			"path":         ".",
-			"name":         "DATABASE_HOST",
+			"path":          ".",
+			"name":          "DATABASE_HOST",
 			"configMapName": "my-config",
 			"configMapKey":  "DB_HOST",
 		},

--- a/pkg/mcp/tools_config_envs_test.go
+++ b/pkg/mcp/tools_config_envs_test.go
@@ -256,23 +256,13 @@ func TestTool_ConfigEnvsAdd_ConfigMapAllKeys(t *testing.T) {
 	}
 }
 
-// TestTool_ConfigEnvsAdd_ValueTakesPrecedence ensures that when both Value and
-// SecretName are provided, the explicit Value is used.
-func TestTool_ConfigEnvsAdd_ValueTakesPrecedence(t *testing.T) {
+// TestTool_ConfigEnvsAdd_ValueAndSecretMutuallyExclusive ensures a validation
+// error is returned when both Value and SecretName are provided together.
+func TestTool_ConfigEnvsAdd_ValueAndSecretMutuallyExclusive(t *testing.T) {
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
-		if subcommand != "config" {
-			t.Fatalf("expected subcommand 'config', got %q", subcommand)
-		}
-		if len(args) < 2 || args[0] != "envs" || args[1] != "add" {
-			t.Fatalf("expected positional args ['envs','add'], got %v", args[:min(2, len(args))])
-		}
-		argsMap := argsToMap(args[2:])
-		wantValue := "explicit-value"
-		if got, ok := argsMap["--value"]; !ok || got != wantValue {
-			t.Fatalf("expected --value=%q, got %q", wantValue, got)
-		}
-		return []byte("Environment variable added successfully\n"), nil
+		t.Fatal("executor must not be called when input is invalid")
+		return nil, nil
 	}
 
 	client, _, err := newTestPair(t, WithExecutor(executor))
@@ -286,17 +276,17 @@ func TestTool_ConfigEnvsAdd_ValueTakesPrecedence(t *testing.T) {
 			"path":       ".",
 			"name":       "MY_VAR",
 			"value":      "explicit-value",
-			"secretName": "ignored-secret",
+			"secretName": "my-secret",
 		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.IsError {
-		t.Fatalf("unexpected error result: %v", result)
+	if !result.IsError {
+		t.Fatal("expected error result when value and secretName are both provided")
 	}
-	if !executor.ExecuteInvoked {
-		t.Fatal("executor was not invoked")
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when input fails validation")
 	}
 }
 
@@ -460,106 +450,6 @@ func TestTool_ConfigEnvsAdd_ConfigMapKeyWithoutConfigMapName(t *testing.T) {
 	}
 	if !result.IsError {
 		t.Fatal("expected error result when configMapKey is set without configMapName")
-	}
-	if executor.ExecuteInvoked {
-		t.Fatal("executor must not be invoked when input fails validation")
-	}
-}
-
-// TestTool_ConfigEnvsAdd_InvalidSecretName ensures a validation error is returned when
-// secretName contains characters outside the allowed set (SEVERE-3).
-func TestTool_ConfigEnvsAdd_InvalidSecretName(t *testing.T) {
-	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
-		t.Fatal("executor must not be called when input is invalid")
-		return nil, nil
-	}
-
-	client, _, err := newTestPair(t, WithExecutor(executor))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
-		Name: "config_envs_add",
-		Arguments: map[string]any{
-			"path":       ".",
-			"name":       "MY_VAR",
-			"secretName": "evil:inject}}",
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !result.IsError {
-		t.Fatal("expected error result when secretName contains invalid characters")
-	}
-	if executor.ExecuteInvoked {
-		t.Fatal("executor must not be invoked when input fails validation")
-	}
-}
-
-// TestTool_ConfigEnvsAdd_InvalidSecretKey ensures a validation error is returned when
-// secretKey contains characters outside the allowed set (SEVERE-3).
-func TestTool_ConfigEnvsAdd_InvalidSecretKey(t *testing.T) {
-	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
-		t.Fatal("executor must not be called when input is invalid")
-		return nil, nil
-	}
-
-	client, _, err := newTestPair(t, WithExecutor(executor))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
-		Name: "config_envs_add",
-		Arguments: map[string]any{
-			"path":       ".",
-			"name":       "MY_VAR",
-			"secretName": "my-secret",
-			"secretKey":  "bad key with spaces",
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !result.IsError {
-		t.Fatal("expected error result when secretKey contains invalid characters")
-	}
-	if executor.ExecuteInvoked {
-		t.Fatal("executor must not be invoked when input fails validation")
-	}
-}
-
-// TestTool_ConfigEnvsAdd_InvalidConfigMapName ensures a validation error is returned when
-// configMapName contains characters outside the allowed set (SEVERE-3).
-func TestTool_ConfigEnvsAdd_InvalidConfigMapName(t *testing.T) {
-	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
-		t.Fatal("executor must not be called when input is invalid")
-		return nil, nil
-	}
-
-	client, _, err := newTestPair(t, WithExecutor(executor))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
-		Name: "config_envs_add",
-		Arguments: map[string]any{
-			"path":          ".",
-			"name":          "MY_VAR",
-			"configMapName": "bad}name",
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !result.IsError {
-		t.Fatal("expected error result when configMapName contains invalid characters")
 	}
 	if executor.ExecuteInvoked {
 		t.Fatal("executor must not be invoked when input fails validation")

--- a/pkg/mcp/tools_config_envs_test.go
+++ b/pkg/mcp/tools_config_envs_test.go
@@ -72,6 +72,208 @@ func TestTool_ConfigEnvsAdd(t *testing.T) {
 	}
 }
 
+// TestTool_ConfigEnvsAdd_SecretKey ensures secret-key-sourced env vars produce
+// the correct "{{ secret:name:key }}" value template.
+func TestTool_ConfigEnvsAdd_SecretKey(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		if subcommand != "config" {
+			t.Fatalf("expected subcommand 'config', got %q", subcommand)
+		}
+
+		argsMap := argsToMap(args)
+		wantValue := "{{ secret:my-secret:MY_KEY }}"
+		if got, ok := argsMap["--value"]; !ok || got != wantValue {
+			t.Fatalf("expected --value=%q, got %q", wantValue, got)
+		}
+		if got, ok := argsMap["--name"]; !ok || got != "API_KEY" {
+			t.Fatalf("expected --name='API_KEY', got %q", got)
+		}
+		return []byte("Environment variable added successfully\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_envs_add",
+		Arguments: map[string]any{
+			"path":       ".",
+			"name":       "API_KEY",
+			"secretName": "my-secret",
+			"secretKey":  "MY_KEY",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_ConfigEnvsAdd_SecretAllKeys ensures importing all keys from a Secret
+// produces the "{{ secret:name }}" value template without --name.
+func TestTool_ConfigEnvsAdd_SecretAllKeys(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		argsMap := argsToMap(args)
+		wantValue := "{{ secret:my-secret }}"
+		if got, ok := argsMap["--value"]; !ok || got != wantValue {
+			t.Fatalf("expected --value=%q, got %q", wantValue, got)
+		}
+		if _, ok := argsMap["--name"]; ok {
+			t.Fatal("expected no --name flag when importing all secret keys")
+		}
+		return []byte("Environment variable added successfully\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_envs_add",
+		Arguments: map[string]any{
+			"path":       ".",
+			"secretName": "my-secret",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_ConfigEnvsAdd_ConfigMapKey ensures configmap-key-sourced env vars produce
+// the correct "{{ configMap:name:key }}" value template.
+func TestTool_ConfigEnvsAdd_ConfigMapKey(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		argsMap := argsToMap(args)
+		wantValue := "{{ configMap:my-config:DB_HOST }}"
+		if got, ok := argsMap["--value"]; !ok || got != wantValue {
+			t.Fatalf("expected --value=%q, got %q", wantValue, got)
+		}
+		if got, ok := argsMap["--name"]; !ok || got != "DATABASE_HOST" {
+			t.Fatalf("expected --name='DATABASE_HOST', got %q", got)
+		}
+		return []byte("Environment variable added successfully\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_envs_add",
+		Arguments: map[string]any{
+			"path":         ".",
+			"name":         "DATABASE_HOST",
+			"configMapName": "my-config",
+			"configMapKey":  "DB_HOST",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_ConfigEnvsAdd_ConfigMapAllKeys ensures importing all keys from a ConfigMap
+// produces the "{{ configMap:name }}" value template without --name.
+func TestTool_ConfigEnvsAdd_ConfigMapAllKeys(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		argsMap := argsToMap(args)
+		wantValue := "{{ configMap:my-config }}"
+		if got, ok := argsMap["--value"]; !ok || got != wantValue {
+			t.Fatalf("expected --value=%q, got %q", wantValue, got)
+		}
+		if _, ok := argsMap["--name"]; ok {
+			t.Fatal("expected no --name flag when importing all configmap keys")
+		}
+		return []byte("Environment variable added successfully\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_envs_add",
+		Arguments: map[string]any{
+			"path":          ".",
+			"configMapName": "my-config",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_ConfigEnvsAdd_ValueTakesPrecedence ensures that when both Value and
+// SecretName are provided, the explicit Value is used.
+func TestTool_ConfigEnvsAdd_ValueTakesPrecedence(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		argsMap := argsToMap(args)
+		wantValue := "explicit-value"
+		if got, ok := argsMap["--value"]; !ok || got != wantValue {
+			t.Fatalf("expected --value=%q, got %q", wantValue, got)
+		}
+		return []byte("Environment variable added successfully\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_envs_add",
+		Arguments: map[string]any{
+			"path":       ".",
+			"name":       "MY_VAR",
+			"value":      "explicit-value",
+			"secretName": "ignored-secret",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
 // TestTool_ConfigEnvsList ensures the config_envs_list tool lists environment variables.
 func TestTool_ConfigEnvsList(t *testing.T) {
 	executor := mock.NewExecutor()

--- a/pkg/mcp/tools_config_envs_test.go
+++ b/pkg/mcp/tools_config_envs_test.go
@@ -80,8 +80,10 @@ func TestTool_ConfigEnvsAdd_SecretKey(t *testing.T) {
 		if subcommand != "config" {
 			t.Fatalf("expected subcommand 'config', got %q", subcommand)
 		}
-
-		argsMap := argsToMap(args)
+		if len(args) < 2 || args[0] != "envs" || args[1] != "add" {
+			t.Fatalf("expected positional args ['envs','add'], got %v", args[:min(2, len(args))])
+		}
+		argsMap := argsToMap(args[2:])
 		wantValue := "{{ secret:my-secret:MY_KEY }}"
 		if got, ok := argsMap["--value"]; !ok || got != wantValue {
 			t.Fatalf("expected --value=%q, got %q", wantValue, got)
@@ -122,7 +124,13 @@ func TestTool_ConfigEnvsAdd_SecretKey(t *testing.T) {
 func TestTool_ConfigEnvsAdd_SecretAllKeys(t *testing.T) {
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
-		argsMap := argsToMap(args)
+		if subcommand != "config" {
+			t.Fatalf("expected subcommand 'config', got %q", subcommand)
+		}
+		if len(args) < 2 || args[0] != "envs" || args[1] != "add" {
+			t.Fatalf("expected positional args ['envs','add'], got %v", args[:min(2, len(args))])
+		}
+		argsMap := argsToMap(args[2:])
 		wantValue := "{{ secret:my-secret }}"
 		if got, ok := argsMap["--value"]; !ok || got != wantValue {
 			t.Fatalf("expected --value=%q, got %q", wantValue, got)
@@ -161,7 +169,13 @@ func TestTool_ConfigEnvsAdd_SecretAllKeys(t *testing.T) {
 func TestTool_ConfigEnvsAdd_ConfigMapKey(t *testing.T) {
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
-		argsMap := argsToMap(args)
+		if subcommand != "config" {
+			t.Fatalf("expected subcommand 'config', got %q", subcommand)
+		}
+		if len(args) < 2 || args[0] != "envs" || args[1] != "add" {
+			t.Fatalf("expected positional args ['envs','add'], got %v", args[:min(2, len(args))])
+		}
+		argsMap := argsToMap(args[2:])
 		wantValue := "{{ configMap:my-config:DB_HOST }}"
 		if got, ok := argsMap["--value"]; !ok || got != wantValue {
 			t.Fatalf("expected --value=%q, got %q", wantValue, got)
@@ -202,7 +216,13 @@ func TestTool_ConfigEnvsAdd_ConfigMapKey(t *testing.T) {
 func TestTool_ConfigEnvsAdd_ConfigMapAllKeys(t *testing.T) {
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
-		argsMap := argsToMap(args)
+		if subcommand != "config" {
+			t.Fatalf("expected subcommand 'config', got %q", subcommand)
+		}
+		if len(args) < 2 || args[0] != "envs" || args[1] != "add" {
+			t.Fatalf("expected positional args ['envs','add'], got %v", args[:min(2, len(args))])
+		}
+		argsMap := argsToMap(args[2:])
 		wantValue := "{{ configMap:my-config }}"
 		if got, ok := argsMap["--value"]; !ok || got != wantValue {
 			t.Fatalf("expected --value=%q, got %q", wantValue, got)
@@ -241,7 +261,13 @@ func TestTool_ConfigEnvsAdd_ConfigMapAllKeys(t *testing.T) {
 func TestTool_ConfigEnvsAdd_ValueTakesPrecedence(t *testing.T) {
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
-		argsMap := argsToMap(args)
+		if subcommand != "config" {
+			t.Fatalf("expected subcommand 'config', got %q", subcommand)
+		}
+		if len(args) < 2 || args[0] != "envs" || args[1] != "add" {
+			t.Fatalf("expected positional args ['envs','add'], got %v", args[:min(2, len(args))])
+		}
+		argsMap := argsToMap(args[2:])
 		wantValue := "explicit-value"
 		if got, ok := argsMap["--value"]; !ok || got != wantValue {
 			t.Fatalf("expected --value=%q, got %q", wantValue, got)
@@ -271,6 +297,106 @@ func TestTool_ConfigEnvsAdd_ValueTakesPrecedence(t *testing.T) {
 	}
 	if !executor.ExecuteInvoked {
 		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_ConfigEnvsAdd_NameWithSecretAllKeys ensures a validation error is returned
+// when name is provided alongside an all-keys Secret import (no secretKey).
+func TestTool_ConfigEnvsAdd_NameWithSecretAllKeys(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		t.Fatal("executor must not be called when input is invalid")
+		return nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_envs_add",
+		Arguments: map[string]any{
+			"path":       ".",
+			"name":       "MY_VAR",
+			"secretName": "my-secret",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when name is set alongside an all-keys Secret import")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when input fails validation")
+	}
+}
+
+// TestTool_ConfigEnvsAdd_NameWithConfigMapAllKeys ensures a validation error is returned
+// when name is provided alongside an all-keys ConfigMap import (no configMapKey).
+func TestTool_ConfigEnvsAdd_NameWithConfigMapAllKeys(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		t.Fatal("executor must not be called when input is invalid")
+		return nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_envs_add",
+		Arguments: map[string]any{
+			"path":          ".",
+			"name":          "MY_VAR",
+			"configMapName": "my-config",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when name is set alongside an all-keys ConfigMap import")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when input fails validation")
+	}
+}
+
+// TestTool_ConfigEnvsAdd_BothSecretAndConfigMap ensures a validation error is returned
+// when both secretName and configMapName are provided simultaneously.
+func TestTool_ConfigEnvsAdd_BothSecretAndConfigMap(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		t.Fatal("executor must not be called when input is invalid")
+		return nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_envs_add",
+		Arguments: map[string]any{
+			"path":          ".",
+			"name":          "MY_VAR",
+			"secretName":    "my-secret",
+			"configMapName": "my-config",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when both secretName and configMapName are provided")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when input fails validation")
 	}
 }
 


### PR DESCRIPTION
## What

Add secret-backed and ConfigMap-backed environment variable support to the `config_envs_add` MCP tool. Previously, `ConfigEnvsAddInput` only exposed `Name` and `Value` fields, leaving agents unable to configure Kubernetes-sourced env vars through MCP.

## Changes

- **`pkg/mcp/tools_config_envs.go`**: Add four optional fields to `ConfigEnvsAddInput`: `SecretName`, `SecretKey`, `ConfigMapName`, and `ConfigMapKey`. Update `Args()` to construct the appropriate `{{ secret:… }}` / `{{ configMap:… }}` value template automatically. Explicit `Value` takes precedence when provided alongside source fields. Update the tool description to document all sourcing modes.

- **`pkg/mcp/tools_config_envs_test.go`**: Add five new test cases covering single-key secret, all-keys secret, single-key ConfigMap, all-keys ConfigMap, and precedence of explicit `Value` over `SecretName`.

## Sourcing modes

| Mode | Fields required | Generated value |
|---|---|---|
| Literal value | `name`, `value` | value passed through |
| Secret (one key) | `name`, `secretName`, `secretKey` | `{{ secret:name:key }}` |
| Secret (all keys) | `secretName` | `{{ secret:name }}` |
| ConfigMap (one key) | `name`, `configMapName`, `configMapKey` | `{{ configMap:name:key }}` |
| ConfigMap (all keys) | `configMapName` | `{{ configMap:name }}` |

## Testing

All 11 tests in `pkg/mcp` pass locally.