### PR TITLE
cmd/mcp_test: use t.Setenv to prevent env var leak across tests

### DIFF
--- a/cmd/mcp_test.go
+++ b/cmd/mcp_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	fn "knative.dev/func/pkg/functions"
@@ -51,7 +50,7 @@ func TestMCP_StartWriteable(t *testing.T) {
 	}
 
 	// Ensure it is set to true on proper truthy value
-	_ = os.Setenv("FUNC_ENABLE_MCP_WRITE", "true")
+	t.Setenv("FUNC_ENABLE_MCP_WRITE", "true")
 	server = mock.NewMCPServer()
 	server.StartFn = func(_ context.Context, writeEnabled bool) error {
 		if !writeEnabled {


### PR DESCRIPTION
TestMCP_StartWriteable sets FUNC_ENABLE_MCP_WRITE via os.Setenv but never cleans it up. Since Go runs all tests in a package within the same process, this leaked env var persists for subsequent tests.

Replace os.Setenv with t.Setenv, which automatically restores the original value when the test finishes. Remove the now-unused os import.

# Changes

- Replace `os.Setenv` with `t.Setenv` in `TestMCP_StartWriteable` to auto-restore the env var after the test
- Remove unused `"os"` import from `cmd/mcp_test.go`

Fixes #3686

**Release Note**

```release-note
NONE
