### PR TITLE
mcp: set HasPrompts to false since no prompts are registered

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -81,7 +81,7 @@ func New(options ...Option) *Server {
 			Version: version},
 		&mcp.ServerOptions{
 			Instructions:       instructions(s.readonly),
-			HasPrompts:         true,
+			HasPrompts:         false,
 			HasResources:       true,
 			HasTools:           true,
 			InitializedHandler: func(ctx context.Context, _ *mcp.InitializedRequest) { s.OnInit(ctx) },


### PR DESCRIPTION
The MCP server declares `HasPrompts: true` in its capabilities but no prompts are registered. Per the MCP specification, clients may call `prompts/list` when this capability is advertised and expect results.

Set `HasPrompts` to `false` to accurately reflect the server capabilities.

# Changes

- Set `HasPrompts` to `false` in MCP server options since no prompts are registered

Fixes #3689

**Release Note**

```release-note
NONE
