### PR TITLE
fix: use net.Dial in socat for dual-stack support (Happy Eyeballs)

### DIFF
--- a/cmd/func-util/socat.go
+++ b/cmd/func-util/socat.go
@@ -65,15 +65,9 @@ func createConnection(address string, stdio connection) (connection, error) {
 	switch typ {
 	case "tcp", "tcp4", "tcp6":
 		_, _ = fmt.Fprintln(os.Stderr, "opening connection")
-		var laddr net.TCPAddr
-		raddr, err := net.ResolveTCPAddr(typ, addr)
-		if err != nil {
-			return nil, fmt.Errorf("name does not resolve: %w", err)
-		}
-
-		conn, err := net.DialTCP(typ, &laddr, raddr)
+		conn, err := net.Dial(typ, addr)
 		if err == nil {
-			_, _ = fmt.Fprintf(os.Stderr, "successfully connected to %v\n", raddr)
+			_, _ = fmt.Fprintf(os.Stderr, "successfully connected to %v\n", conn.RemoteAddr())
 		}
 		return conn, err
 	case "open":

--- a/cmd/func-util/socat_test.go
+++ b/cmd/func-util/socat_test.go
@@ -72,7 +72,7 @@ func TestRootCmd(t *testing.T) {
 			args: args{
 				args:          []string{"-", "TCP:does.not.exist:10000"},
 				inputString:   "tcp-echo",
-				errOutMatcher: contains("not resolve"),
+				errOutMatcher: contains("no such host"),
 				wantErr:       true,
 			},
 		},


### PR DESCRIPTION
# Changes

ResolveTCPAddr + DialTCP resolves the hostname to a single address and dials it directly.  When DNS returns both A and AAAA records (dual-stack Docker network), the IPv4 address is typically returned first.  On IPv6-only pods this fails with "network is unreachable" because the pod has no IPv4 connectivity.

Switch to net.Dial which implements Happy Eyeballs (RFC 6555): it resolves all addresses, tries them concurrently with IPv6 preferred, and uses whichever connects first.  The tcp4/tcp6 explicit cases are also handled correctly by net.Dial.

/kind bug

```release-note
fix: in cluster dialer (socat) uses Happy Eyeballs
```

