### PR TITLE
fix: improve IPv6 support in local Kind cluster setup

### DIFF
--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -239,8 +239,9 @@ networking() {
 
   echo "Installing a configured Contour."
   curl -sSL "https://github.com/knative/net-contour/releases/download/knative-${contour_version}/contour.yaml" \
+    | $YQ '(select(.kind == "Deployment" and .metadata.name == "contour").spec.template.spec.containers[0].args[] | select(. == "--xds-address=0.0.0.0")) = "--xds-address=::"' \
     | $YQ '(select(.kind == "Deployment" and .metadata.name == "contour").spec.template.spec.containers[0].args)
-          += ["--envoy-service-http-address=::", "--envoy-service-https-address=::"]' \
+          += ["--envoy-service-http-address=::", "--envoy-service-https-address=::", "--stats-address=::"]' \
     | $KUBECTL apply -f -
 
   sleep 5

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -599,10 +599,32 @@ localtest.me.            IN      AAAA    ${cluster_node_addr6}\n\
 *.localtest.me.          IN      AAAA    ${cluster_node_addr6}\n"
   fi
 
+  # On IPv6-only clusters, CoreDNS pods can only speak IPv6 but the node's
+  # /etc/resolv.conf may contain only an IPv4 nameserver (e.g. 172.18.0.1 on
+  # Docker). Bridge this gap with socat: proxy DNS from the node's IPv6
+  # address to the IPv4 nameserver. This preserves full container-runtime DNS
+  # resolution (container names, search domains, etc.).
+  local dns_forward="forward . /etc/resolv.conf"
+  local node_resolv
+  node_resolv="$($CONTAINER_ENGINE exec func-control-plane cat /etc/resolv.conf 2>/dev/null || true)"
+  if [[ -n "$cluster_node_addr6" ]] && ! echo "$node_resolv" | grep -qE 'nameserver\s+[0-9a-fA-F]*:'; then
+    local ipv4_ns
+    ipv4_ns="$(echo "$node_resolv" | grep -oP 'nameserver\s+\K[0-9.]+' | head -1)"
+    if [[ -n "$ipv4_ns" ]]; then
+      echo "Node has no IPv6 nameservers — proxying DNS via socat (${cluster_node_addr6} → ${ipv4_ns})"
+      $CONTAINER_ENGINE exec func-control-plane bash -c "
+        apt-get update -qq >/dev/null 2>&1 && apt-get install -y -qq socat >/dev/null 2>&1
+        socat UDP6-LISTEN:53,bind=[${cluster_node_addr6}],fork,reuseaddr UDP4:${ipv4_ns}:53 &
+        socat TCP6-LISTEN:53,bind=[${cluster_node_addr6}],fork,reuseaddr TCP4:${ipv4_ns}:53 &
+      "
+      dns_forward="forward . ${cluster_node_addr6}"
+    fi
+  fi
+
   $KUBECTL patch cm/coredns -n kube-system --patch-file /dev/stdin <<EOF
 {
   "data": {
-    "Corefile": ".:53 {\n    errors\n    health {\n       lameduck 5s\n    }\n    ready\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\n       pods insecure\n       fallthrough in-addr.arpa ip6.arpa\n       ttl 30\n    }\n    file /etc/coredns/example.db localtest.me\n    prometheus :9153\n    forward . /etc/resolv.conf {\n       max_concurrent 1000\n    }\n    cache 30\n    loop\n    reload\n    loadbalance\n}\n",
+    "Corefile": ".:53 {\n    errors\n    health {\n       lameduck 5s\n    }\n    ready\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\n       pods insecure\n       fallthrough in-addr.arpa ip6.arpa\n       ttl 30\n    }\n    file /etc/coredns/example.db localtest.me\n    prometheus :9153\n    ${dns_forward} {\n       max_concurrent 1000\n    }\n    cache 30\n    loop\n    reload\n    loadbalance\n}\n",
     "example.db": "; localtest.me test file\n\
 localtest.me.            IN      SOA     sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600\n\
 $a_recs\

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -604,10 +604,15 @@ localtest.me.            IN      AAAA    ${cluster_node_addr6}\n\
   # Docker). Bridge this gap with socat: proxy DNS from the node's IPv6
   # address to the IPv4 nameserver. This preserves full container-runtime DNS
   # resolution (container names, search domains, etc.).
+  # Note: the node itself may be dual-stack (Docker assigns IPv4 to the
+  # container regardless of Kind's ipFamily), so we check whether CoreDNS
+  # pods have IPv4 to determine if the cluster is truly IPv6-only.
   local dns_forward="forward . /etc/resolv.conf"
   local node_resolv
   node_resolv="$($CONTAINER_ENGINE exec func-control-plane cat /etc/resolv.conf 2>/dev/null || true)"
-  if [[ -n "$cluster_node_addr6" ]] && ! echo "$node_resolv" | grep -qE 'nameserver\s+[0-9a-fA-F]*:'; then
+  local coredns_ip
+  coredns_ip="$($KUBECTL get pods -n kube-system -l k8s-app=kube-dns -o jsonpath='{.items[0].status.podIP}' 2>/dev/null || true)"
+  if [[ "$coredns_ip" == *":"* ]] && [[ -n "$cluster_node_addr6" ]] && ! echo "$node_resolv" | grep -qE 'nameserver\s+[0-9a-fA-F]*:'; then
     local ipv4_ns
     ipv4_ns="$(echo "$node_resolv" | grep -oP 'nameserver\s+\K[0-9.]+' | head -1)"
     if [[ -n "$ipv4_ns" ]]; then


### PR DESCRIPTION

## Summary

Fixes two IPv6-related issues in `hack/cluster.sh` that break the local Kind development cluster on IPv6-only and dual-stack Docker networks:

- **Contour IPv6 bindings:** Contour defaults its xDS server, Envoy listeners, and stats endpoint to `0.0.0.0` (IPv4-only). On IPv6-only clusters the control plane cannot reach Envoy and ingress traffic is blocked. The Contour deployment is now patched at install time to rebind `--xds-address` and `--stats-address` to `::` alongside the existing HTTP/HTTPS address overrides.
Note: `::` listens on both IPv4 and IPv6 on Linux by default. However if machines completely disables IPv6  or deliberately sets `net.ipv6.bindv6only = 1`  the it might not listen on IPv4, but people doing that had it coming anyway.

- **CoreDNS DNS forwarding via socat:** Docker's embedded DNS proxy only listens on IPv4 (`moby/moby#41651`), and Kind replaces the node's nameserver with the IPv4 bridge gateway (e.g. `172.18.0.1`). On IPv6-only clusters CoreDNS pods cannot reach this address, breaking all DNS resolution. A socat UDP/TCP proxy is now installed on the Kind node when IPv4-only nameservers are detected, forwarding DNS from the node's IPv6 address to the IPv4 nameserver. The CoreDNS Corefile is patched to use this proxy instead of `/etc/resolv.conf`. See also https://github.com/kubernetes-sigs/kind/issues/4152

## Test plan

- [ ] Run `hack/cluster.sh` on a Docker host with an IPv6-only Kind cluster and verify DNS resolution works inside pods
- [ ] Run `hack/cluster.sh` on a dual-stack Kind cluster and verify both IPv4 and IPv6 DNS resolution work
- [ ] Run `hack/cluster.sh` on a standard IPv4-only Kind cluster and verify no regressions (socat proxy should be skipped, Contour bindings are additive)
- [ ] Verify Contour/Envoy ingress serves traffic on IPv6-only clusters
