### PR TITLE
mcp: reject relative paths in tool handlers

### DIFF
--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -39,4 +40,13 @@ func appendBoolFlag(args []string, flag string, value *bool) []string {
 // Useful for setting optional annotation fields.
 func ptr[T any](v T) *T {
 	return &v
+}
+
+// validatePath rejects relative paths. Since cmd.Dir is not set in the executor,
+// relative paths resolve against the MCP server's CWD, not the user's project root.
+func validatePath(path string) error {
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("path must be absolute, got %q", path)
+	}
+	return nil
 }

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -46,7 +46,7 @@ func ptr[T any](v T) *T {
 // relative paths resolve against the MCP server's CWD, not the user's project root.
 func validatePath(path string) error {
 	if !filepath.IsAbs(path) {
-		return fmt.Errorf("path must be absolute, got %q", path)
+		return fmt.Errorf("path must be absolute (the MCP server's working directory is not the user's project root), got %q", path)
 	}
 	return nil
 }

--- a/pkg/mcp/tools_build.go
+++ b/pkg/mcp/tools_build.go
@@ -20,6 +20,9 @@ var buildTool = &mcp.Tool{
 }
 
 func (s *Server) buildHandler(ctx context.Context, r *mcp.CallToolRequest, input BuildInput) (result *mcp.CallToolResult, output BuildOutput, err error) {
+	if err = validatePath(input.Path); err != nil {
+		return
+	}
 	out, err := s.executor.Execute(ctx, "build", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))

--- a/pkg/mcp/tools_build_test.go
+++ b/pkg/mcp/tools_build_test.go
@@ -11,12 +11,13 @@ import (
 // TestTool_Build_Args ensures the build tool executes with all arguments passed correctly.
 func TestTool_Build_Args(t *testing.T) {
 	// Test data - defined once and used for both input and validation
+	path := t.TempDir()
 	stringFlags := map[string]struct {
 		jsonKey string
 		flag    string
 		value   string
 	}{
-		"path":         {"path", "--path", "."},
+		"path":         {"path", "--path", path},
 		"builder":      {"builder", "--builder", "pack"},
 		"registry":     {"registry", "--registry", "ghcr.io/user"},
 		"builderImage": {"builderImage", "--builder-image", "custom-builder:latest"},

--- a/pkg/mcp/tools_config_envs.go
+++ b/pkg/mcp/tools_config_envs.go
@@ -36,6 +36,9 @@ type ConfigEnvsListOutput struct {
 }
 
 func (s *Server) configEnvsListHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigEnvsListInput) (result *mcp.CallToolResult, output ConfigEnvsListOutput, err error) {
+	if err = validatePath(input.Path); err != nil {
+		return
+	}
 	out, err := s.executor.Execute(ctx, "config", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))
@@ -142,6 +145,9 @@ type ConfigEnvsAddOutput struct {
 }
 
 func (s *Server) configEnvsAddHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigEnvsAddInput) (result *mcp.CallToolResult, output ConfigEnvsAddOutput, err error) {
+	if err = validatePath(input.Path); err != nil {
+		return
+	}
 	if err = input.validate(); err != nil {
 		return
 	}
@@ -186,6 +192,9 @@ type ConfigEnvsRemoveOutput struct {
 }
 
 func (s *Server) configEnvsRemoveHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigEnvsRemoveInput) (result *mcp.CallToolResult, output ConfigEnvsRemoveOutput, err error) {
+	if err = validatePath(input.Path); err != nil {
+		return
+	}
 	out, err := s.executor.Execute(ctx, "config", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))

--- a/pkg/mcp/tools_config_envs_test.go
+++ b/pkg/mcp/tools_config_envs_test.go
@@ -11,12 +11,13 @@ import (
 
 // TestTool_ConfigEnvsAdd ensures the config_envs_add tool executes with all arguments.
 func TestTool_ConfigEnvsAdd(t *testing.T) {
+	path := t.TempDir()
 	stringFlags := map[string]struct {
 		jsonKey string
 		flag    string
 		value   string
 	}{
-		"path":  {"path", "--path", "."},
+		"path":  {"path", "--path", path},
 		"name":  {"name", "--name", "API_KEY"},
 		"value": {"value", "--value", "secret123"},
 	}
@@ -458,13 +459,14 @@ func TestTool_ConfigEnvsAdd_ConfigMapKeyWithoutConfigMapName(t *testing.T) {
 
 // TestTool_ConfigEnvsList ensures the config_envs_list tool lists environment variables.
 func TestTool_ConfigEnvsList(t *testing.T) {
+	path := t.TempDir()
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
 		if subcommand != "config" {
 			t.Fatalf("expected subcommand 'config', got %q", subcommand)
 		}
 
-		// "envs" + "--path" + "." = 3 args
+		// "envs" + "--path" + path = 3 args
 		if len(args) != 3 {
 			t.Fatalf("expected 3 args, got %d: %v", len(args), args)
 		}
@@ -473,8 +475,8 @@ func TestTool_ConfigEnvsList(t *testing.T) {
 		}
 
 		argsMap := argsToMap(args[1:])
-		if val, ok := argsMap["--path"]; !ok || val != "." {
-			t.Fatalf("expected --path='.', got %q", val)
+		if val, ok := argsMap["--path"]; !ok || val != path {
+			t.Fatalf("expected --path=%q, got %q", path, val)
 		}
 
 		return []byte("DATABASE_URL=postgres://localhost\nAPI_KEY=secret\n"), nil
@@ -487,7 +489,7 @@ func TestTool_ConfigEnvsList(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_envs_list",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": path},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -502,12 +504,13 @@ func TestTool_ConfigEnvsList(t *testing.T) {
 
 // TestTool_ConfigEnvsRemove ensures the config_envs_remove tool removes an environment variable.
 func TestTool_ConfigEnvsRemove(t *testing.T) {
+	path := t.TempDir()
 	stringFlags := map[string]struct {
 		jsonKey string
 		flag    string
 		value   string
 	}{
-		"path": {"path", "--path", "."},
+		"path": {"path", "--path", path},
 		"name": {"name", "--name", "API_KEY"},
 	}
 
@@ -570,7 +573,7 @@ func TestTool_ConfigEnvsList_Error(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_envs_list",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": t.TempDir()},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -594,7 +597,7 @@ func TestTool_ConfigEnvsAdd_Error(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_envs_add",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": t.TempDir()},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -618,7 +621,7 @@ func TestTool_ConfigEnvsRemove_Error(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_envs_remove",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": t.TempDir()},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/mcp/tools_config_envs_test.go
+++ b/pkg/mcp/tools_config_envs_test.go
@@ -76,6 +76,7 @@ func TestTool_ConfigEnvsAdd(t *testing.T) {
 // TestTool_ConfigEnvsAdd_SecretKey ensures secret-key-sourced env vars produce
 // the correct "{{ secret:name:key }}" value template.
 func TestTool_ConfigEnvsAdd_SecretKey(t *testing.T) {
+	path := t.TempDir()
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
 		if subcommand != "config" {
@@ -103,7 +104,7 @@ func TestTool_ConfigEnvsAdd_SecretKey(t *testing.T) {
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name: "config_envs_add",
 		Arguments: map[string]any{
-			"path":       ".",
+			"path":       path,
 			"name":       "API_KEY",
 			"secretName": "my-secret",
 			"secretKey":  "MY_KEY",
@@ -123,6 +124,7 @@ func TestTool_ConfigEnvsAdd_SecretKey(t *testing.T) {
 // TestTool_ConfigEnvsAdd_SecretAllKeys ensures importing all keys from a Secret
 // produces the "{{ secret:name }}" value template without --name.
 func TestTool_ConfigEnvsAdd_SecretAllKeys(t *testing.T) {
+	path := t.TempDir()
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
 		if subcommand != "config" {
@@ -150,7 +152,7 @@ func TestTool_ConfigEnvsAdd_SecretAllKeys(t *testing.T) {
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name: "config_envs_add",
 		Arguments: map[string]any{
-			"path":       ".",
+			"path":       path,
 			"secretName": "my-secret",
 		},
 	})
@@ -168,6 +170,7 @@ func TestTool_ConfigEnvsAdd_SecretAllKeys(t *testing.T) {
 // TestTool_ConfigEnvsAdd_ConfigMapKey ensures configmap-key-sourced env vars produce
 // the correct "{{ configMap:name:key }}" value template.
 func TestTool_ConfigEnvsAdd_ConfigMapKey(t *testing.T) {
+	path := t.TempDir()
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
 		if subcommand != "config" {
@@ -195,7 +198,7 @@ func TestTool_ConfigEnvsAdd_ConfigMapKey(t *testing.T) {
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name: "config_envs_add",
 		Arguments: map[string]any{
-			"path":          ".",
+			"path":          path,
 			"name":          "DATABASE_HOST",
 			"configMapName": "my-config",
 			"configMapKey":  "DB_HOST",
@@ -215,6 +218,7 @@ func TestTool_ConfigEnvsAdd_ConfigMapKey(t *testing.T) {
 // TestTool_ConfigEnvsAdd_ConfigMapAllKeys ensures importing all keys from a ConfigMap
 // produces the "{{ configMap:name }}" value template without --name.
 func TestTool_ConfigEnvsAdd_ConfigMapAllKeys(t *testing.T) {
+	path := t.TempDir()
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
 		if subcommand != "config" {
@@ -242,7 +246,7 @@ func TestTool_ConfigEnvsAdd_ConfigMapAllKeys(t *testing.T) {
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name: "config_envs_add",
 		Arguments: map[string]any{
-			"path":          ".",
+			"path":          path,
 			"configMapName": "my-config",
 		},
 	})
@@ -274,7 +278,7 @@ func TestTool_ConfigEnvsAdd_ValueAndSecretMutuallyExclusive(t *testing.T) {
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name: "config_envs_add",
 		Arguments: map[string]any{
-			"path":       ".",
+			"path":       t.TempDir(),
 			"name":       "MY_VAR",
 			"value":      "explicit-value",
 			"secretName": "my-secret",
@@ -308,7 +312,7 @@ func TestTool_ConfigEnvsAdd_NameWithSecretAllKeys(t *testing.T) {
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name: "config_envs_add",
 		Arguments: map[string]any{
-			"path":       ".",
+			"path":       t.TempDir(),
 			"name":       "MY_VAR",
 			"secretName": "my-secret",
 		},
@@ -341,7 +345,7 @@ func TestTool_ConfigEnvsAdd_NameWithConfigMapAllKeys(t *testing.T) {
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name: "config_envs_add",
 		Arguments: map[string]any{
-			"path":          ".",
+			"path":          t.TempDir(),
 			"name":          "MY_VAR",
 			"configMapName": "my-config",
 		},
@@ -374,7 +378,7 @@ func TestTool_ConfigEnvsAdd_BothSecretAndConfigMap(t *testing.T) {
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name: "config_envs_add",
 		Arguments: map[string]any{
-			"path":          ".",
+			"path":          t.TempDir(),
 			"name":          "MY_VAR",
 			"secretName":    "my-secret",
 			"configMapName": "my-config",
@@ -408,7 +412,7 @@ func TestTool_ConfigEnvsAdd_SecretKeyWithoutSecretName(t *testing.T) {
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name: "config_envs_add",
 		Arguments: map[string]any{
-			"path":      ".",
+			"path":      t.TempDir(),
 			"name":      "MY_VAR",
 			"secretKey": "MY_KEY",
 		},
@@ -441,7 +445,7 @@ func TestTool_ConfigEnvsAdd_ConfigMapKeyWithoutConfigMapName(t *testing.T) {
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name: "config_envs_add",
 		Arguments: map[string]any{
-			"path":         ".",
+			"path":         t.TempDir(),
 			"name":         "MY_VAR",
 			"configMapKey": "MY_KEY",
 		},

--- a/pkg/mcp/tools_config_labels.go
+++ b/pkg/mcp/tools_config_labels.go
@@ -36,6 +36,9 @@ type ConfigLabelsListOutput struct {
 }
 
 func (s *Server) configLabelsListHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigLabelsListInput) (result *mcp.CallToolResult, output ConfigLabelsListOutput, err error) {
+	if err = validatePath(input.Path); err != nil {
+		return
+	}
 	out, err := s.executor.Execute(ctx, "config", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))
@@ -79,6 +82,9 @@ type ConfigLabelsAddOutput struct {
 }
 
 func (s *Server) configLabelsAddHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigLabelsAddInput) (result *mcp.CallToolResult, output ConfigLabelsAddOutput, err error) {
+	if err = validatePath(input.Path); err != nil {
+		return
+	}
 	out, err := s.executor.Execute(ctx, "config", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))
@@ -120,6 +126,9 @@ type ConfigLabelsRemoveOutput struct {
 }
 
 func (s *Server) configLabelsRemoveHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigLabelsRemoveInput) (result *mcp.CallToolResult, output ConfigLabelsRemoveOutput, err error) {
+	if err = validatePath(input.Path); err != nil {
+		return
+	}
 	out, err := s.executor.Execute(ctx, "config", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))

--- a/pkg/mcp/tools_config_labels_test.go
+++ b/pkg/mcp/tools_config_labels_test.go
@@ -11,12 +11,13 @@ import (
 
 // TestTool_ConfigLabelsAdd ensures the config_labels_add tool executes with all arguments.
 func TestTool_ConfigLabelsAdd(t *testing.T) {
+	path := t.TempDir()
 	stringFlags := map[string]struct {
 		jsonKey string
 		flag    string
 		value   string
 	}{
-		"path":  {"path", "--path", "."},
+		"path":  {"path", "--path", path},
 		"name":  {"name", "--name", "environment"},
 		"value": {"value", "--value", "prod"},
 	}
@@ -73,13 +74,14 @@ func TestTool_ConfigLabelsAdd(t *testing.T) {
 
 // TestTool_ConfigLabelsList ensures the config_labels_list tool lists labels.
 func TestTool_ConfigLabelsList(t *testing.T) {
+	path := t.TempDir()
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
 		if subcommand != "config" {
 			t.Fatalf("expected subcommand 'config', got %q", subcommand)
 		}
 
-		// "labels" + "--path" + "." = 3 args
+		// "labels" + "--path" + path = 3 args
 		if len(args) != 3 {
 			t.Fatalf("expected 3 args, got %d: %v", len(args), args)
 		}
@@ -88,8 +90,8 @@ func TestTool_ConfigLabelsList(t *testing.T) {
 		}
 
 		argsMap := argsToMap(args[1:])
-		if val, ok := argsMap["--path"]; !ok || val != "." {
-			t.Fatalf("expected --path='.', got %q", val)
+		if val, ok := argsMap["--path"]; !ok || val != path {
+			t.Fatalf("expected --path=%q, got %q", path, val)
 		}
 
 		return []byte("app=my-function\nenvironment=prod\n"), nil
@@ -102,7 +104,7 @@ func TestTool_ConfigLabelsList(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_labels_list",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": path},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -117,12 +119,13 @@ func TestTool_ConfigLabelsList(t *testing.T) {
 
 // TestTool_ConfigLabelsRemove ensures the config_labels_remove tool removes a label.
 func TestTool_ConfigLabelsRemove(t *testing.T) {
+	path := t.TempDir()
 	stringFlags := map[string]struct {
 		jsonKey string
 		flag    string
 		value   string
 	}{
-		"path": {"path", "--path", "."},
+		"path": {"path", "--path", path},
 		"name": {"name", "--name", "environment"},
 	}
 
@@ -185,7 +188,7 @@ func TestTool_ConfigLabelsList_Error(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_labels_list",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": t.TempDir()},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -209,7 +212,7 @@ func TestTool_ConfigLabelsAdd_Error(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_labels_add",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": t.TempDir()},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -233,7 +236,7 @@ func TestTool_ConfigLabelsRemove_Error(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_labels_remove",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": t.TempDir()},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/mcp/tools_config_volumes.go
+++ b/pkg/mcp/tools_config_volumes.go
@@ -36,6 +36,9 @@ type ConfigVolumesListOutput struct {
 }
 
 func (s *Server) configVolumesListHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigVolumesListInput) (result *mcp.CallToolResult, output ConfigVolumesListOutput, err error) {
+	if err = validatePath(input.Path); err != nil {
+		return
+	}
 	out, err := s.executor.Execute(ctx, "config", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))
@@ -87,6 +90,9 @@ type ConfigVolumesAddOutput struct {
 }
 
 func (s *Server) configVolumesAddHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigVolumesAddInput) (result *mcp.CallToolResult, output ConfigVolumesAddOutput, err error) {
+	if err = validatePath(input.Path); err != nil {
+		return
+	}
 	out, err := s.executor.Execute(ctx, "config", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))
@@ -128,6 +134,9 @@ type ConfigVolumesRemoveOutput struct {
 }
 
 func (s *Server) configVolumesRemoveHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigVolumesRemoveInput) (result *mcp.CallToolResult, output ConfigVolumesRemoveOutput, err error) {
+	if err = validatePath(input.Path); err != nil {
+		return
+	}
 	out, err := s.executor.Execute(ctx, "config", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))

--- a/pkg/mcp/tools_config_volumes_test.go
+++ b/pkg/mcp/tools_config_volumes_test.go
@@ -11,12 +11,13 @@ import (
 
 // TestTool_ConfigVolumesAdd ensures the config_volumes_add tool executes with all arguments.
 func TestTool_ConfigVolumesAdd(t *testing.T) {
+	path := t.TempDir()
 	stringFlags := map[string]struct {
 		jsonKey string
 		flag    string
 		value   string
 	}{
-		"path":      {"path", "--path", "."},
+		"path":      {"path", "--path", path},
 		"type":      {"type", "--type", "secret"},
 		"mountPath": {"mountPath", "--mount-path", "/workspace/secret"},
 		"source":    {"source", "--source", "my-secret"},
@@ -77,13 +78,14 @@ func TestTool_ConfigVolumesAdd(t *testing.T) {
 
 // TestTool_ConfigVolumesList ensures the config_volumes_list tool lists volumes.
 func TestTool_ConfigVolumesList(t *testing.T) {
+	path := t.TempDir()
 	executor := mock.NewExecutor()
 	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
 		if subcommand != "config" {
 			t.Fatalf("expected subcommand 'config', got %q", subcommand)
 		}
 
-		// "volumes" + "--path" + "." = 3 args
+		// "volumes" + "--path" + path = 3 args
 		if len(args) != 3 {
 			t.Fatalf("expected 3 args, got %d: %v", len(args), args)
 		}
@@ -92,8 +94,8 @@ func TestTool_ConfigVolumesList(t *testing.T) {
 		}
 
 		argsMap := argsToMap(args[1:])
-		if val, ok := argsMap["--path"]; !ok || val != "." {
-			t.Fatalf("expected --path='.', got %q", val)
+		if val, ok := argsMap["--path"]; !ok || val != path {
+			t.Fatalf("expected --path=%q, got %q", path, val)
 		}
 
 		return []byte("secret:my-secret:/workspace/secret\n"), nil
@@ -106,7 +108,7 @@ func TestTool_ConfigVolumesList(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_volumes_list",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": path},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -121,12 +123,13 @@ func TestTool_ConfigVolumesList(t *testing.T) {
 
 // TestTool_ConfigVolumesRemove ensures the config_volumes_remove tool removes a volume.
 func TestTool_ConfigVolumesRemove(t *testing.T) {
+	path := t.TempDir()
 	stringFlags := map[string]struct {
 		jsonKey string
 		flag    string
 		value   string
 	}{
-		"path":      {"path", "--path", "."},
+		"path":      {"path", "--path", path},
 		"mountPath": {"mountPath", "--mount-path", "/workspace/secret"},
 	}
 
@@ -189,7 +192,7 @@ func TestTool_ConfigVolumesList_Error(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_volumes_list",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": t.TempDir()},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -213,7 +216,7 @@ func TestTool_ConfigVolumesAdd_Error(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_volumes_add",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": t.TempDir()},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -237,7 +240,7 @@ func TestTool_ConfigVolumesRemove_Error(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_volumes_remove",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": t.TempDir()},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/mcp/tools_create.go
+++ b/pkg/mcp/tools_create.go
@@ -20,6 +20,9 @@ var createTool = &mcp.Tool{
 }
 
 func (s *Server) createHandler(ctx context.Context, r *mcp.CallToolRequest, input CreateInput) (result *mcp.CallToolResult, output CreateOutput, err error) {
+	if err = validatePath(input.Path); err != nil {
+		return
+	}
 	out, err := s.executor.Execute(ctx, "create", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))

--- a/pkg/mcp/tools_create_test.go
+++ b/pkg/mcp/tools_create_test.go
@@ -14,12 +14,13 @@ import (
 func TestTool_Create_Args(t *testing.T) {
 	// Test data - defined once and used for both input and validation
 	// Note: language (-l) is required and handled separately
+	path := t.TempDir()
 	stringFlags := map[string]struct {
 		jsonKey string
 		flag    string
 		value   string
 	}{
-		"path":       {"path", "--path", "."},
+		"path":       {"path", "--path", path},
 		"template":   {"template", "--template", "cloudevents"},
 		"repository": {"repository", "--repository", "https://example.com/repo"},
 	}
@@ -82,9 +83,6 @@ func TestTool_Create_Args(t *testing.T) {
 	}
 }
 
-// TestCreate_PathValidation is removed - path validation no longer exists
-// Create now operates in current working directory
-
 // TestCreate_BinaryFailure ensures errors from the func binary are returned as MCP errors
 func TestTool_Create_BinaryFailure(t *testing.T) {
 	executor := mock.NewExecutor()
@@ -103,7 +101,7 @@ func TestTool_Create_BinaryFailure(t *testing.T) {
 		Name: "create",
 		Arguments: map[string]any{
 			"language": "go",
-			"path":     ".",
+			"path":     t.TempDir(),
 		},
 	})
 	if err != nil {

--- a/pkg/mcp/tools_delete.go
+++ b/pkg/mcp/tools_delete.go
@@ -30,6 +30,11 @@ func (s *Server) deleteHandler(ctx context.Context, r *mcp.CallToolRequest, inpu
 		err = fmt.Errorf("exactly one of 'path' or 'name' must be provided")
 		return
 	}
+	if input.Path != nil {
+		if err = validatePath(*input.Path); err != nil {
+			return
+		}
+	}
 
 	// Execute
 	out, err := s.executor.Execute(ctx, "delete", input.Args()...)

--- a/pkg/mcp/tools_deploy.go
+++ b/pkg/mcp/tools_deploy.go
@@ -24,6 +24,9 @@ func (s *Server) deployHandler(ctx context.Context, r *mcp.CallToolRequest, inpu
 		err = fmt.Errorf("the server is currently in readonly mode.  Please set FUNC_ENABLE_MCP_WRITE and restart the client")
 		return
 	}
+	if err = validatePath(input.Path); err != nil {
+		return
+	}
 	out, err := s.executor.Execute(ctx, "deploy", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))

--- a/pkg/mcp/tools_deploy_test.go
+++ b/pkg/mcp/tools_deploy_test.go
@@ -11,12 +11,13 @@ import (
 // TestTool_Deploy_Args ensures the deploy tool executes with all arguments passed correctly.
 func TestTool_Deploy_Args(t *testing.T) {
 	// Test data - defined once and used for both input and validation
+	path := t.TempDir()
 	stringFlags := map[string]struct {
 		jsonKey string
 		flag    string
 		value   string
 	}{
-		"path":               {"path", "--path", "."},
+		"path":               {"path", "--path", path},
 		"builder":            {"builder", "--builder", "pack"},
 		"registry":           {"registry", "--registry", "ghcr.io/user"},
 		"image":              {"image", "--image", "ghcr.io/user/my-func:latest"},

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -62,6 +62,19 @@ func validateBoolFlags(t *testing.T, args []string, boolFlags map[string]string)
 	}
 }
 
+// TestValidatePath ensures validatePath accepts absolute paths and rejects relative ones.
+func TestValidatePath(t *testing.T) {
+	if err := validatePath("/absolute/path"); err != nil {
+		t.Fatalf("expected no error for absolute path, got: %v", err)
+	}
+	if err := validatePath("relative/path"); err == nil {
+		t.Fatal("expected error for relative path, got nil")
+	}
+	if err := validatePath("."); err == nil {
+		t.Fatal("expected error for '.', got nil")
+	}
+}
+
 // buildInputArgs constructs the input arguments map for CallTool from test data.
 func buildInputArgs(stringFlags map[string]struct {
 	jsonKey string

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"strings"
 	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // validateArgLength validates that the args slice has the expected length based on
@@ -62,9 +64,50 @@ func validateBoolFlags(t *testing.T, args []string, boolFlags map[string]string)
 	}
 }
 
+// TestTool_RejectsRelativePath verifies that every tool handler wired to validatePath
+// returns an error result when given a relative path, not just the helper itself.
+func TestTool_RejectsRelativePath(t *testing.T) {
+	cases := []struct {
+		tool string
+		args map[string]any
+	}{
+		{"build", map[string]any{"path": "."}},
+		{"create", map[string]any{"path": ".", "language": "go"}},
+		{"deploy", map[string]any{"path": "."}},
+		{"delete", map[string]any{"path": "."}},
+		{"config_envs_list", map[string]any{"path": "."}},
+		{"config_envs_add", map[string]any{"path": "."}},
+		{"config_envs_remove", map[string]any{"path": "."}},
+		{"config_labels_list", map[string]any{"path": "."}},
+		{"config_labels_add", map[string]any{"path": "."}},
+		{"config_labels_remove", map[string]any{"path": "."}},
+		{"config_volumes_list", map[string]any{"path": "."}},
+		{"config_volumes_add", map[string]any{"path": "."}},
+		{"config_volumes_remove", map[string]any{"path": "."}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tool, func(t *testing.T) {
+			client, _, err := newTestPair(t)
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+				Name:      tc.tool,
+				Arguments: tc.args,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !result.IsError {
+				t.Fatalf("tool %q: expected error result for relative path, got success", tc.tool)
+			}
+		})
+	}
+}
+
 // TestValidatePath ensures validatePath accepts absolute paths and rejects relative ones.
 func TestValidatePath(t *testing.T) {
-	if err := validatePath("/absolute/path"); err != nil {
+	if err := validatePath(t.TempDir()); err != nil {
 		t.Fatalf("expected no error for absolute path, got: %v", err)
 	}
 	if err := validatePath("relative/path"); err == nil {


### PR DESCRIPTION
## Description
Adds `validatePath()` to the MCP server that rejects non-absolute path arguments before shelling out to the func CLI. Since `cmd.Dir` is never set in the executor, relative paths silently resolved against the MCP server's working directory instead of the user's project turning a wrong directory failure into a silent misbehavior. This change turns that into an actionable error, matching the guidance already documented in instructions.md.All existing tests updated to use `t.TempDir()` and a `TestValidatePath` unit test added.