### PR TITLE
e2e subscription tests using in-cluster recorder

### DIFF
--- a/e2e/e2e_metadata_test.go
+++ b/e2e/e2e_metadata_test.go
@@ -571,15 +571,19 @@ func TestMetadata_Subscriptions(t *testing.T) {
 
 	uniqueEventID := fmt.Sprintf("e2e-test-%d", time.Now().UnixNano())
 
-	subscriberName := "func-e2e-test-subscriber-knative"
-	eventReceived := waitForEvent(t, subscriberName, uniqueEventID)
+	rec := deployRecorder(t, "func-e2e-test-recorder-knative")
 
+	subscriberName := "func-e2e-test-subscriber-knative"
 	subscriberRoot := fromCleanEnv(t, subscriberName)
 	if err := newCmd(t, "init", "-l=go", "-t=cloudevents").Run(); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(subscriberRoot, "function.go"),
-		[]byte(subscriberCode()), 0644); err != nil {
+		[]byte(subscriberSource), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := newCmd(t, "config", "envs", "add",
+		"--name=RECORDER_URL", "--value="+rec.internalURL).Run(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -602,10 +606,9 @@ func TestMetadata_Subscriptions(t *testing.T) {
 	}
 	defer clean(t, subscriberName, Namespace)
 
-	subscriberURL := ksvcUrl(subscriberName)
-	if !waitFor(t, subscriberURL, withTemplate("cloudevents")) {
-		t.Fatal("subscriber not ready")
-	}
+	// Trigger readiness implies the subscriber is ready — no separate
+	// probe on subscriberURL, which would require the function to return
+	// a reply CloudEvent just to satisfy waitForCloudevent.
 	waitForTriggerKnative(t, Namespace, subscriberName)
 
 	transport := fnhttp.NewRoundTripper()
@@ -633,12 +636,12 @@ func TestMetadata_Subscriptions(t *testing.T) {
 	}
 	t.Logf("Broker accepted event %s", uniqueEventID)
 
-	select {
-	case receivedID := <-eventReceived:
-		t.Logf("Event flow verified (received: %s)", receivedID)
-	case <-time.After(60 * time.Second):
-		t.Fatal("Timeout: No callback from subscriber")
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+	if !rec.awaitReceived(ctx, t, uniqueEventID) {
+		t.Fatal("Timeout: recorder did not observe event from subscriber")
 	}
+	t.Logf("Event flow verified (id=%s)", uniqueEventID)
 }
 
 func TestMetadata_Subscriptions_Raw(t *testing.T) {
@@ -648,15 +651,23 @@ func TestMetadata_Subscriptions_Raw(t *testing.T) {
 
 	uniqueEventID := fmt.Sprintf("e2e-test-%d", time.Now().UnixNano())
 
-	subscriberName := "func-e2e-test-subscriber-raw"
-	eventReceived := waitForEvent(t, subscriberName, uniqueEventID)
+	// The recorder is deployed via Knative (public URL) regardless of the
+	// subscriber's deployer — the test runner reaches the recorder over its
+	// external URL while the raw-deployed subscriber reaches it over its
+	// cluster-internal URL.
+	rec := deployRecorder(t, "func-e2e-test-recorder-raw")
 
+	subscriberName := "func-e2e-test-subscriber-raw"
 	subscriberRoot := fromCleanEnv(t, subscriberName)
 	if err := newCmd(t, "init", "-l=go", "-t=cloudevents").Run(); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(subscriberRoot, "function.go"),
-		[]byte(subscriberCode()), 0644); err != nil {
+		[]byte(subscriberSource), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := newCmd(t, "config", "envs", "add",
+		"--name=RECORDER_URL", "--value="+rec.internalURL).Run(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -680,9 +691,8 @@ func TestMetadata_Subscriptions_Raw(t *testing.T) {
 	}
 	defer clean(t, subscriberName, Namespace)
 
-	// Note: Raw deployer creates cluster-internal services without external routes,
-	// so we can't use waitFor with domain-based URLs. Instead, we verify the
-	// deployment is ready and then test event delivery directly.
+	// Raw deployer creates cluster-internal services without external
+	// routes; wait on the Deployment instead of the ksvc URL.
 	t.Log("Waiting for deployment to be ready...")
 	waitForDeployment(t, Namespace, subscriberName)
 
@@ -714,70 +724,12 @@ func TestMetadata_Subscriptions_Raw(t *testing.T) {
 	}
 	t.Logf("Broker accepted event %s", uniqueEventID)
 
-	select {
-	case receivedID := <-eventReceived:
-		t.Logf("Event flow verified (received: %s)", receivedID)
-	case <-time.After(60 * time.Second):
-		t.Fatal("Timeout: No callback from subscriber")
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+	if !rec.awaitReceived(ctx, t, uniqueEventID) {
+		t.Fatal("Timeout: recorder did not observe event from subscriber")
 	}
-}
-
-func waitForEvent(t *testing.T, functionName, eventId string) <-chan string {
-	t.Helper()
-
-	eventReceived := make(chan string, 1)
-
-	ctx, cancel := context.WithCancel(t.Context())
-	t.Cleanup(cancel)
-
-	go func() {
-		pattern := `EVENT_RECEIVED: id=` + eventId
-		for {
-			if ctx.Err() != nil {
-				return
-			}
-			cmd := exec.CommandContext(ctx, "kubectl", "logs",
-				"-l", "function.knative.dev/name="+functionName,
-				"-n", Namespace, "--all-containers=true")
-			cmd.Env = append(os.Environ(), "KUBECONFIG="+Kubeconfig)
-			out, _ := cmd.Output()
-			if strings.Contains(string(out), pattern) {
-				eventReceived <- "OK"
-				cancel()
-				return
-			}
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(2 * time.Second):
-			}
-		}
-	}()
-
-	return eventReceived
-}
-
-// CloudEvents handler that logs events
-func subscriberCode() string {
-	return `package function
-
-import (
-	"fmt"
-	"github.com/cloudevents/sdk-go/v2/event"
-)
-
-type Function struct{}
-func New() *Function { return &Function{} }
-func (f *Function) Handle(e event.Event) (*event.Event, error) {
-	fmt.Printf("EVENT_RECEIVED: id=%s type=%s source=%s\n", e.ID(), e.Type(), e.Source())
-	r := event.New()
-	r.SetID("response-" + e.ID())
-	r.SetSource("subscriber")
-	r.SetType("test.response")
-	r.SetData("application/json", map[string]string{"status": "received"})
-	return &r, nil
-}
-`
+	t.Logf("Event flow verified (id=%s)", uniqueEventID)
 }
 
 // createBrokerWithCheck creates a Knative Broker

--- a/e2e/e2e_recorder_test.go
+++ b/e2e/e2e_recorder_test.go
@@ -1,0 +1,177 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// The recorder is a tiny HTTP Function deployed into the cluster that
+// serves as an observation point for E2E tests exercising event delivery.
+// Subscribers under test POST to /record?id=X on event receipt; the test
+// runner polls /received?id=X for an HTTP 200. This is a dogfooded
+// replacement for scraping subscriber stdout via kubectl logs: the
+// system-under-test is what's being used to validate itself.
+
+// recorderSource is a minimal in-memory event recorder served as a
+// function. One-replica assumption is acceptable because each test
+// deploys its own recorder and drives low request volume.
+const recorderSource = `package function
+
+import (
+	"net/http"
+	"sync"
+)
+
+type Function struct {
+	mu       sync.Mutex
+	received map[string]bool
+}
+
+func New() *Function {
+	return &Function{received: make(map[string]bool)}
+}
+
+func (f *Function) Handle(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	switch r.URL.Path {
+	case "/record":
+		if id == "" {
+			http.Error(w, "missing id", http.StatusBadRequest)
+			return
+		}
+		f.mu.Lock()
+		f.received[id] = true
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	case "/received":
+		if id == "" {
+			http.Error(w, "missing id", http.StatusBadRequest)
+			return
+		}
+		f.mu.Lock()
+		ok := f.received[id]
+		f.mu.Unlock()
+		if ok {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("OK"))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	default:
+		// Readiness / health probe. waitFor polls the root and expects OK.
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	}
+}
+`
+
+// subscriberSource is the target of a test Subscription — a CloudEvents
+// handler that forwards each event's id to the recorder at
+// $RECORDER_URL/record?id=<id> so the test runner can observe delivery.
+//
+// Returning nil yields an empty response body; Knative broker-filter
+// rejects a dispatch with "received a non-empty response not recognized
+// as CloudEvent" if the subscriber writes anything else.
+const subscriberSource = `package function
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+)
+
+type Function struct {
+	recorderURL string
+}
+
+func New() *Function {
+	return &Function{recorderURL: os.Getenv("RECORDER_URL")}
+}
+
+func (f *Function) Handle(e event.Event) error {
+	if id := e.ID(); id != "" && f.recorderURL != "" {
+		if resp, err := http.Post(f.recorderURL+"/record?id="+id, "text/plain", nil); err == nil {
+			resp.Body.Close()
+		}
+	}
+	return nil
+}
+`
+
+// recorder is a handle to a deployed recorder function.
+type recorder struct {
+	name        string
+	externalURL string // reachable from the test runner
+	internalURL string // reachable from in-cluster workloads; pass as RECORDER_URL
+}
+
+// deployRecorder stands up a recorder function via the Knative deployer
+// (so it gets a public URL) and blocks until it's ready. t.Cleanup is
+// registered to delete the function at test end.
+func deployRecorder(t *testing.T, name string) *recorder {
+	t.Helper()
+
+	root := fromCleanEnv(t, name)
+	if err := newCmd(t, "init", "-l=go", "-t=http").Run(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "function.go"),
+		[]byte(recorderSource), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := newCmd(t, "deploy").Run(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { clean(t, name, Namespace) })
+
+	external := ksvcUrl(name)
+	if !waitFor(t, external) {
+		t.Fatal("recorder did not become ready")
+	}
+
+	return &recorder{
+		name:        name,
+		externalURL: external,
+		// Knative exposes ksvcs via a standard Kubernetes DNS name in the
+		// same namespace. The subscriber uses this to reach the recorder
+		// without going back out through the external ingress.
+		internalURL: fmt.Sprintf("http://%s.%s.svc.cluster.local", name, Namespace),
+	}
+}
+
+// awaitReceived polls the recorder's external URL until it reports that
+// the given event id has been recorded, or the context is canceled.
+// Returns true on observed receipt.
+func (r *recorder) awaitReceived(ctx context.Context, t *testing.T, id string) bool {
+	t.Helper()
+	url := r.externalURL + "/received?id=" + id
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+		if err != nil {
+			t.Fatalf("building recorder request: %v", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			code := resp.StatusCode
+			resp.Body.Close()
+			if code == http.StatusOK {
+				return true
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+		}
+	}
+}


### PR DESCRIPTION
Scraping stdout to verify test cases is not ideal.  This replaces it with a function which records events and can report an event was received, completing the validation using pure functions.

A reusable recorder Function deployed into the cluster alongside the subscriber under test records subscribtion events for later validation by the test.

  recorder:
    POST /record?id=X    adds X to an in-memory set
    GET  /received?id=X  200 if X in set, 404 otherwise
    default path         200 OK (readiness probe)

  subscriber:
    receives events from the broker (Ce-Id header present),
    POSTs the id to RECORDER_URL/record, returns 204 empty

