### PR TITLE
e2e: use broker ingress instead of in-cluster dialer

### DIFF
--- a/e2e/e2e_metadata_test.go
+++ b/e2e/e2e_metadata_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	fn "knative.dev/func/pkg/functions"
-	fnhttp "knative.dev/func/pkg/http"
 )
 
 // ---------------------------------------------------------------------------
@@ -611,13 +610,8 @@ func TestMetadata_Subscriptions(t *testing.T) {
 	// a reply CloudEvent just to satisfy waitForCloudevent.
 	waitForTriggerKnative(t, Namespace, subscriberName)
 
-	transport := fnhttp.NewRoundTripper()
-	defer transport.Close()
-	client := http.Client{
-		Transport: transport,
-		Timeout:   30 * time.Second,
-	}
-	url := fmt.Sprintf("http://broker-ingress.knative-eventing.svc/%s/%s", Namespace, brokerName)
+	client := http.Client{Timeout: 30 * time.Second}
+	url := fmt.Sprintf("http://%s/%s/%s", BrokerHost, Namespace, brokerName)
 	req, _ := http.NewRequestWithContext(t.Context(), "POST", url, strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("ce-specversion", "1.0")
@@ -699,13 +693,8 @@ func TestMetadata_Subscriptions_Raw(t *testing.T) {
 	// Wait for trigger to be created and ready
 	waitForTriggerRaw(t, Namespace, subscriberName)
 
-	transport := fnhttp.NewRoundTripper()
-	defer transport.Close()
-	client := http.Client{
-		Transport: transport,
-		Timeout:   30 * time.Second,
-	}
-	url := fmt.Sprintf("http://broker-ingress.knative-eventing.svc/%s/%s", Namespace, brokerName)
+	client := http.Client{Timeout: 30 * time.Second}
+	url := fmt.Sprintf("http://%s/%s/%s", BrokerHost, Namespace, brokerName)
 	req, _ := http.NewRequestWithContext(t.Context(), "POST", url, strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("ce-specversion", "1.0")

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -74,6 +74,11 @@ const (
 	// overridden using FUNC_E2E_NAMESPACE environment variable.
 	DefaultNamespace = "default"
 
+	// DefaultBrokerHost is the hostname of the Knative broker ingress.
+	// Defaults to "broker.localtest.me" but can be overridden using
+	// FUNC_E2E_BROKER_HOST environment variable.
+	DefaultBrokerHost = "broker.localtest.me"
+
 	// DefaultDomain for E2E tests. Defaults to "localtest.me" but can be
 	// overridden using FUNC_E2E_DOMAIN environment variable. This domain
 	// must be properly configured in the cluster's DNS and Knative serving.
@@ -157,6 +162,10 @@ var (
 
 	// MatrixTemplates specifies the templates to check during matrix tests.
 	MatrixTemplates = []string{"http", "cloudevents"}
+
+	// BrokerHost is the hostname of the Knative broker ingress.
+	// Defaults to "broker.localtest.me". Can be set with FUNC_E2E_BROKER_HOST.
+	BrokerHost string
 
 	// Namespace is the Kubernetes namespace where functions will be deployed
 	// during tests. Defaults to "default". When using a custom namespace,
@@ -255,6 +264,7 @@ func init() {
 	fmt.Fprintf(os.Stderr, "  FUNC_E2E_CLEAN=%v\n", os.Getenv("FUNC_E2E_CLEAN"))
 	fmt.Fprintf(os.Stderr, "  FUNC_E2E_CLEAN_IMAGES=%v\n", os.Getenv("FUNC_E2E_CLEAN_IMAGES"))
 	fmt.Fprintf(os.Stderr, "  FUNC_E2E_DOCKER_HOST=%v\n", os.Getenv("FUNC_E2E_DOCKER_HOST"))
+	fmt.Fprintf(os.Stderr, "  FUNC_E2E_BROKER_HOST=%v\n", os.Getenv("FUNC_E2E_BROKER_HOST"))
 	fmt.Fprintf(os.Stderr, "  FUNC_E2E_DOMAIN=%v\n", os.Getenv("FUNC_E2E_DOMAIN"))
 	fmt.Fprintf(os.Stderr, "  FUNC_E2E_GOCOVERDIR=%v\n", os.Getenv("FUNC_E2E_GOCOVERDIR"))
 	fmt.Fprintf(os.Stderr, "  FUNC_E2E_HOME=%v\n", os.Getenv("FUNC_E2E_HOME"))
@@ -283,6 +293,7 @@ func init() {
 
 	fmt.Fprintln(os.Stderr, "Final Config:")
 	fmt.Fprintf(os.Stderr, "  Bin=%v\n", Bin)
+	fmt.Fprintf(os.Stderr, "  BrokerHost=%v\n", BrokerHost)
 	fmt.Fprintf(os.Stderr, "  Clean=%v\n", Clean)
 	fmt.Fprintf(os.Stderr, "  CleanImages=%v\n", CleanImages)
 	fmt.Fprintf(os.Stderr, "  DockerHost=%v\n", DockerHost)
@@ -323,6 +334,9 @@ func readEnvs() {
 	// Bin - path to binary which will be used when running the tests.
 	Bin = getEnvPath("FUNC_E2E_BIN", "E2E_FUNC_BIN", DefaultBin)
 	// Final =          current ENV, deprecated ENV, default
+
+	// BrokerHost - the hostname of the Knative broker ingress
+	BrokerHost = getEnv("FUNC_E2E_BROKER_HOST", "", DefaultBrokerHost)
 
 	// Clean up deployed functions before starting next test
 	Clean = getEnvBool("FUNC_E2E_CLEAN", "", DefaultClean)

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -293,7 +293,8 @@ eventing() {
   sleep 5
   $KUBECTL wait pod --for=condition=Ready -l '!job-name' -n knative-eventing --timeout=5m
 
-  echo "Exposing broker at broker.localtest.me"
+  local -r broker_host="${FUNC_E2E_BROKER_HOST:-broker.localtest.me}"
+  echo "Exposing broker at ${broker_host}"
   $KUBECTL apply -f - <<EOF
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -303,7 +304,7 @@ metadata:
 spec:
   ingressClassName: contour-external
   rules:
-    - host: broker.localtest.me
+    - host: ${broker_host}
       http:
         paths:
           - backend:


### PR DESCRIPTION
<!-- PR Title: e2e: use broker ingress instead of in-cluster dialer -->

# Changes

- :broom: Replace `fnhttp.NewRoundTripper()` (in-cluster socat tunnel) with a plain `http.Client` in subscription e2e tests, reaching the broker via its Kubernetes Ingress at `broker.localtest.me`
- :broom: Add configurable `FUNC_E2E_BROKER_HOST` env var to `hack/cluster.sh` and e2e test config, following the existing `FUNC_INT_PAC_HOST` pattern
- :wastebasket: Remove unused `fnhttp` import from `e2e/e2e_metadata_test.go`

/kind cleanup

Relates to #3697

**Release Note**

```release-note

```

**Docs**

```docs

```
