### PR TITLE
cmd/mcp: pass WithReadonly at construction to fix instructions desync

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -112,7 +112,9 @@ func runMCPStart(cmd *cobra.Command, args []string, newClient ClientFactory) err
 
 	// Instantiate
 	client, done := newClient(ClientConfig{},
-		fn.WithMCPServer(mcp.New(mcp.WithPrefix(cmdPrefix))))
+		fn.WithMCPServer(mcp.New(
+			mcp.WithPrefix(cmdPrefix),
+			mcp.WithReadonly(!writeEnabled))))
 	defer done()
 
 	// Start


### PR DESCRIPTION
The MCP server instructions were computed at `New()` time before `Start()` set the readonly flag. This meant the readonly warning was never included in instructions sent to MCP clients, even when the server was running in readonly mode.

Pass `WithReadonly(!writeEnabled)` at construction time so the instructions correctly reflect the runtime readonly state.

# Changes

- Pass `mcp.WithReadonly(!writeEnabled)` to `mcp.New()` in `cmd/mcp.go`

Fixes #3703

**Release Note**

```release-note

```

**Docs**

```docs

```