### PR TITLE
mcp: fix appendBoolFlag to handle explicit false values

### DIFF
--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -221,3 +221,63 @@ func TestWithPrefix_Validation(t *testing.T) {
 		})
 	}
 }
+
+// TestAppendBoolFlag verifies that appendBoolFlag handles nil, true, and false correctly.
+func TestAppendBoolFlag(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	cases := []struct {
+		name  string
+		value *bool
+		want  []string
+	}{
+		{"nil omits flag", nil, []string{}},
+		{"true appends flag", &trueVal, []string{"--push"}},
+		{"false appends flag=false", &falseVal, []string{"--push=false"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := appendBoolFlag(nil, "--push", tc.value)
+			if len(got) != len(tc.want) {
+				t.Fatalf("appendBoolFlag(nil, --push, %v) = %v, want %v", tc.value, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("result[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestAppendStringFlag verifies that appendStringFlag handles nil, empty, and non-empty values.
+func TestAppendStringFlag(t *testing.T) {
+	empty := ""
+	val := "prod"
+
+	cases := []struct {
+		name  string
+		value *string
+		want  []string
+	}{
+		{"nil omits flag", nil, []string{}},
+		{"empty omits flag", &empty, []string{}},
+		{"non-empty appends flag and value", &val, []string{"--namespace", "prod"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := appendStringFlag(nil, "--namespace", tc.value)
+			if len(got) != len(tc.want) {
+				t.Fatalf("appendStringFlag(nil, --namespace, %v) = %v, want %v", tc.value, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("result[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -26,11 +26,15 @@ func appendStringFlag(args []string, flag string, value *string) []string {
 	return args
 }
 
-// appendBoolFlag adds a boolean flag to args only if the value is non-nil and true.
-// This ensures we only pass flags that were explicitly provided by the user.
+// appendBoolFlag adds a boolean flag to args only if the value is non-nil.
+// When true, appends the flag (e.g. --push). When false, appends
+// flag=false (e.g. --push=false) to allow explicit disabling.
 func appendBoolFlag(args []string, flag string, value *bool) []string {
-	if value != nil && *value {
-		return append(args, flag)
+	if value != nil {
+		if *value {
+			return append(args, flag)
+		}
+		return append(args, flag+"=false")
 	}
 	return args
 }


### PR DESCRIPTION
`appendBoolFlag` silently dropped the flag when `value` was non-nil but `false`. This meant MCP clients could not explicitly disable boolean flags like `--push` that may be enabled via `func.yaml` defaults.

When `value` is non-nil and `false`, append `flag=false` (e.g. `--push=false`) to allow explicit disabling.

# Changes

- When `*value == false`, append `flag=false` instead of dropping the flag

Fixes #3705 

**Release Note**

```release-note

```

**Docs**

```docs

```
