### PR TITLE
mcp: change DeleteInput.All from *string to *bool

### DIFF
--- a/pkg/mcp/tools_delete.go
+++ b/pkg/mcp/tools_delete.go
@@ -49,7 +49,7 @@ type DeleteInput struct {
 	Path      *string `json:"path,omitempty" jsonschema:"Path to the function project directory (mutually exclusive with name)"`
 	Name      *string `json:"name,omitempty" jsonschema:"Name of the function to delete (mutually exclusive with path)"`
 	Namespace *string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace to delete from (default: current or active namespace)"`
-	All       *string `json:"all,omitempty" jsonschema:"Delete all related resources like Pipelines, Secrets (true/false)"`
+	All       *bool   `json:"all,omitempty" jsonschema:"Delete all related resources like Pipelines, Secrets"`
 	Verbose   *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
 }
 
@@ -64,7 +64,7 @@ func (i DeleteInput) Args() []string {
 	}
 
 	args = appendStringFlag(args, "--namespace", i.Namespace)
-	args = appendStringFlag(args, "--all", i.All)
+	args = appendBoolFlag(args, "--all", i.All)
 	args = appendBoolFlag(args, "--verbose", i.Verbose)
 	return args
 }

--- a/pkg/mcp/tools_delete_test.go
+++ b/pkg/mcp/tools_delete_test.go
@@ -17,11 +17,11 @@ func TestTool_Delete_Args(t *testing.T) {
 		value   string
 	}{
 		"namespace": {"namespace", "--namespace", "prod"},
-		"all":       {"all", "--all", "true"},
 	}
 
 	boolFlags := map[string]string{
 		"verbose": "--verbose",
+		"all":     "--all",
 	}
 
 	// Required fields and positional arguments


### PR DESCRIPTION
The `All` field in `DeleteInput` was typed as `*string` but the underlying `func delete --all` CLI flag is boolean. This caused the JSON schema to present a string field to MCP clients instead of a boolean, and passed the flag as `--all true` (two separate args) instead of `--all`.

Change `All` to `*bool` and use `appendBoolFlag` instead of `appendStringFlag`.

# Changes

- Change `DeleteInput.All` from `*string` to `*bool`
- Switch from `appendStringFlag` to `appendBoolFlag` for the `--all` flag

Fixes #3706

**Release Note**

```release-note

```

**Docs**

```docs

```