### PR TITLE
fix(mcp): use 'config' prefix for remove help resources

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -122,15 +122,15 @@ func New(options ...Option) *Server {
 
 	i.AddResource(newHelpResource(s, "Volumes Help", "general help for volumes", "config", "volumes"))
 	i.AddResource(newHelpResource(s, "Volumes Add Help", "help for 'config volumes add'", "config", "volumes", "add"))
-	i.AddResource(newHelpResource(s, "Volumes Remove Help", "help for 'config volumes remove'", "list", "volumes", "remove"))
+	i.AddResource(newHelpResource(s, "Volumes Remove Help", "help for 'config volumes remove'", "config", "volumes", "remove"))
 
 	i.AddResource(newHelpResource(s, "Labels Help", "general help for labels", "config", "labels"))
 	i.AddResource(newHelpResource(s, "Labels Add Help", "help for 'config labels add'", "config", "labels", "add"))
-	i.AddResource(newHelpResource(s, "Labels Remove Help", "help for 'config labels remove'", "list", "labels", "remove"))
+	i.AddResource(newHelpResource(s, "Labels Remove Help", "help for 'config labels remove'", "config", "labels", "remove"))
 
 	i.AddResource(newHelpResource(s, "Envs Help", "general help for environment variables", "config", "envs"))
 	i.AddResource(newHelpResource(s, "Envs Add Help", "help for 'config envs add'", "config", "envs", "add"))
-	i.AddResource(newHelpResource(s, "Envs Remove Help", "help for 'config envs remove'", "list", "envs", "remove"))
+	i.AddResource(newHelpResource(s, "Envs Remove Help", "help for 'config envs remove'", "config", "envs", "remove"))
 
 	s.impl = i
 


### PR DESCRIPTION
# PR Description

## I. Describe what this PR does

- Fixes `Volumes/Labels/Envs Remove Help` MCP resources invoking `func list <x> remove --help` instead of `func config <x> remove --help`.
- Corrects generated resource URIs from `func://help/list/<x>/remove` to `func://help/config/<x>/remove`, matching each resource's description.


## Fix

* #3711


## VI. Checklist

- [x] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [x] All checks passed in make test