### PR TITLE
git/github: default GitHub webhooks to TLS verification

### DIFF
--- a/pkg/git/github/github.go
+++ b/pkg/git/github/github.go
@@ -26,7 +26,7 @@ func (c Client) CreateWebHook(ctx context.Context, repoOwner, repoName, payloadU
 		Config: &github.HookConfig{
 			URL:         github.Ptr(payloadURL),
 			ContentType: github.Ptr("json"),
-			InsecureSSL: github.Ptr("1"), // TODO fix insecure (default should be 0)
+			InsecureSSL: github.Ptr("0"),
 			Secret:      github.Ptr(webhookSecret),
 		},
 	}


### PR DESCRIPTION
- Default GitHub repository webhooks created by `pkg/git/github` to `insecure_ssl: "0"` so GitHub verifies TLS when delivering to HTTPS payload URLs.
- Remove the prior insecure default (`"1"`) and the associated TODO in `CreateWebHook`.
<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:
/kind <kind>
Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance
-->
/kind bug
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or Relates to #<issue number>.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3713 
<!-- Please include the 'why' behind your changes if no issue exists -->
GitHub’s webhook `insecure_ssl` setting was hard-coded to `"1"`, which disables TLS certificate verification for HTTPS webhook targets. The secure default is `"0"` for normal HTTPS endpoints. Users whose controller URL uses a certificate that GitHub does not trust (for example self-signed TLS in lab environments) may need a follow-up opt-in if hook creation or deliveries fail.

@davidhadas @lkingland  can you please review this. Thanks for your time.