### PR TITLE
mcp: add missing help resource for delete command

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -125,6 +125,7 @@ func New(options ...Option) *Server {
 	i.AddResource(newHelpResource(s, "Build Help", "help for 'build'", "build"))
 	i.AddResource(newHelpResource(s, "Deploy Help", "help for 'deploy'", "deploy"))
 	i.AddResource(newHelpResource(s, "List Help", "help for 'list'", "list"))
+	i.AddResource(newHelpResource(s, "Delete Help", "help for delete", "delete"))
 
 	i.AddResource(newHelpResource(s, "Volumes Help", "general help for volumes", "config", "volumes"))
 	i.AddResource(newHelpResource(s, "Volumes Add Help", "help for 'config volumes add'", "config", "volumes", "add"))

--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -121,6 +121,11 @@ func TestResource_Help(t *testing.T) {
 			wantArgs: []string{"list", "--help"},
 		},
 		{
+			name:     "delete help",
+			uri:      "func://help/delete",
+			wantArgs: []string{"delete", "--help"},
+		},
+		{
 			name:     "config volumes help",
 			uri:      "func://help/config/volumes",
 			wantArgs: []string{"config", "volumes", "--help"},


### PR DESCRIPTION
# Changes

Hi! I'm new to the repo and was just exploring the codebase. While mapping out the tool-to-resource architecture in `pkg/mcp` to understand how things work, I noticed a small gap.

Every registered tool in `mcp.go` has a corresponding `func://help/<command>` resource for flag discovery (build, deploy, list, etc.). But the `delete` tool was missing its help resource. It looks like it slipped through the cracks during a previous MCP refactor.

This PR adds it:
- Registers `func://help/delete` using the existing `newHelpResource` factory pattern.
- Adds the test case to the `TestResource_Help` suite in `resources_test.go`.

(Side note: the `delete` tool has a destructive annotation and a readonly guard, so making its parameters discoverable via `--help`, I think it feels important for agent interactions.)

Ran the `mcp` package tests locally and everything passes fine. 

/kind cleanup

There is no open issue for this, just something I found while exploring the code. Let me know if there are any changes to make, thanks. 


