### PR TITLE
fix(mcp): defer impl construction so Start's writeEnabled controls readonly

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -73,7 +73,21 @@ func New(options ...Option) *Server {
 	for _, o := range options {
 		o(s)
 	}
+	return s
+}
 
+// Start the MCP server using the configured transport.
+// The underlying mcp.Server is built here so that the Instructions string
+// reflects readonly as resolved from writeEnabled, not whatever was set at New.
+func (s *Server) Start(ctx context.Context, writeEnabled bool) error {
+	s.readonly = !writeEnabled
+	s.impl = s.buildImpl()
+	return s.impl.Run(ctx, s.transport)
+}
+
+// buildImpl constructs the underlying *mcp.Server. Called from Start so that
+// readonly resolution from writeEnabled is observable in Instructions.
+func (s *Server) buildImpl() *mcp.Server {
 	i := mcp.NewServer(
 		&mcp.Implementation{
 			Name:    name,
@@ -138,15 +152,7 @@ func New(options ...Option) *Server {
 	i.AddResource(newHelpResource(s, "Envs Add Help", "help for 'config envs add'", "config", "envs", "add"))
 	i.AddResource(newHelpResource(s, "Envs Remove Help", "help for 'config envs remove'", "config", "envs", "remove"))
 
-	s.impl = i
-
-	return s
-}
-
-// Start the MCP server using the configured transport
-func (s *Server) Start(ctx context.Context, writeEnabled bool) error {
-	s.readonly = !writeEnabled
-	return s.impl.Run(ctx, s.transport)
+	return i
 }
 
 // For now the executor is a simple run of the command "func" or "kn func"

--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -61,6 +61,40 @@ func TestInstructions(t *testing.T) {
 	}
 }
 
+// TestInstructionsStartArgDrivesReadonly covers the cmd/mcp.go flow: New is
+// called without WithReadonly, then Start receives writeEnabled. The
+// resulting Instructions must reflect Start's argument.
+func TestInstructionsStartArgDrivesReadonly(t *testing.T) {
+	testCases := []struct {
+		name         string
+		writeEnabled bool
+		wantWarning  bool
+	}{
+		{name: "readonly", writeEnabled: false, wantWarning: true},
+		{name: "write", writeEnabled: true, wantWarning: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, _, err := newTestPairCore(t, !tc.writeEnabled)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			result := client.InitializeResult()
+			if result == nil {
+				t.Fatal("InitializeResult is nil")
+			}
+
+			hasReadonlyWarning := strings.Contains(result.Instructions, "# ⚠️  Read-Only Mode Warning")
+			if hasReadonlyWarning != tc.wantWarning {
+				t.Errorf("writeEnabled=%v: got readonly warning=%v, want %v",
+					tc.writeEnabled, hasReadonlyWarning, tc.wantWarning)
+			}
+		})
+	}
+}
+
 // newTestPairCore is the core logic for creating a ClientSession and Server connected over an in-memory transport.
 func newTestPairCore(t *testing.T, readonly bool, options ...Option) (session *mcp.ClientSession, server *Server, err error) {
 	t.Helper()


### PR DESCRIPTION
## Problem

`mcp.New` eagerly constructs the underlying `*mcp.Server` with
`Instructions: instructions(s.readonly)`. At that point `s.readonly`
is whatever `WithReadonly` set it to (default `false`). `Start` later
reassigns `s.readonly = !writeEnabled`, but the `Instructions` string
is already baked into the impl.

`cmd/mcp.go` calls `mcp.New(mcp.WithPrefix(cmdPrefix))` with no
`WithReadonly`, then `client.StartMCPServer(cmd.Context(), writeEnabled)`.
`writeEnabled` defaults to `false` and only flips when `FUNC_ENABLE_MCP_WRITE=1`
is set. The default `func mcp` invocation therefore runs in readonly mode
but ships the non-readonly system prompt. `instructions_warning.md` is
silently dropped and the agent assumes it can deploy and delete.

`TestInstructions` did not catch this because `newTestPairWithReadonly`
threads `WithReadonly` into `New`, which already produces the correct
baked `Instructions` for that call path.

## Fix

Move the `mcp.NewServer` call and the `AddTool` / `AddResource`
registration out of `New` into a `buildImpl` method. `Start` invokes
it after `s.readonly = !writeEnabled`, so the resolved value is the
one baked into `Instructions`. `New`'s public surface and Options
behavior are unchanged.

## Tests

`TestInstructionsStartArgDrivesReadonly` mirrors the `cmd/mcp.go` flow:
`mcp.New` is called without `WithReadonly`, then `Start` receives a
concrete `writeEnabled`. The two subtests (`readonly` / `write`)
assert that the readonly warning appears or is absent based on the
`Start` argument, not on what `New` saw at construction time.

`make check` and `make test` clean.

/kind bug

```release-note
fix: default `func mcp` invocation now ships the readonly system prompt instead of the write-mode one
```