### PR TITLE
mcp: add func-workflow prompt for guided Function lifecycle

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -152,6 +152,10 @@ func New(options ...Option) *Server {
 	i.AddResource(newHelpResource(s, "Envs Add Help", "help for 'config envs add'", "config", "envs", "add"))
 	i.AddResource(newHelpResource(s, "Envs Remove Help", "help for 'config envs remove'", "config", "envs", "remove"))
 
+	// Prompts
+	// -------
+	i.AddPrompt(funcWorkflowPrompt, funcWorkflowHandler)
+
 	s.impl = i
 
 	return s

--- a/pkg/mcp/prompts.go
+++ b/pkg/mcp/prompts.go
@@ -1,0 +1,53 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+var funcWorkflowPrompt = &mcp.Prompt{
+	Name:        "func-workflow",
+	Title:       "Function Lifecycle Workflow",
+	Description: "Guides through the full Function lifecycle: create, build, and deploy.",
+	Arguments: []*mcp.PromptArgument{
+		{
+			Name:        "language",
+			Description: "Programming language for the Function (e.g. go, python, node).",
+		},
+	},
+}
+
+func funcWorkflowHandler(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	lang := req.Params.Arguments["language"]
+	return &mcp.GetPromptResult{
+		Description: "Step-by-step guide for the Function lifecycle.",
+		Messages: []*mcp.PromptMessage{
+			{
+				Role:    "user",
+				Content: &mcp.TextContent{Text: funcWorkflowText(lang)},
+			},
+		},
+	}, nil
+}
+
+func funcWorkflowText(language string) string {
+	langLine := ""
+	if language != "" {
+		langLine = fmt.Sprintf("\nUse language: %s\n", language)
+	}
+	return fmt.Sprintf(`Guide me through the full Function lifecycle.%s
+Step 1 - Create:
+  Use the "create" tool to scaffold a new Function.
+  Check "func://languages" for available languages and "func://templates" for templates.
+
+Step 2 - Build:
+  Use the "build" tool to compile the Function into a container image.
+
+Step 3 - Deploy:
+  Use the "deploy" tool to deploy the Function to the cluster.
+  On first deploy, a container registry is required (e.g. docker.io/user).
+
+Use "func://function" to check current Function state at any point.`, langLine)
+}

--- a/pkg/mcp/prompts_test.go
+++ b/pkg/mcp/prompts_test.go
@@ -1,0 +1,92 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestPrompt_Listed(t *testing.T) {
+	client, _, err := newTestPair(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.ListPrompts(t.Context(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var found bool
+	for _, p := range result.Prompts {
+		if p.Name == "func-workflow" {
+			found = true
+			if p.Description == "" {
+				t.Error("expected non-empty description")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatal("func-workflow prompt not found in listing")
+	}
+}
+
+func TestPrompt_Get(t *testing.T) {
+	client, _, err := newTestPair(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.GetPrompt(t.Context(), &mcp.GetPromptParams{
+		Name: "func-workflow",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+	msg := result.Messages[0]
+	if msg.Role != "user" {
+		t.Fatalf("expected role 'user', got %q", msg.Role)
+	}
+	tc, ok := msg.Content.(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", msg.Content)
+	}
+	if !strings.Contains(tc.Text, "create") {
+		t.Error("expected prompt text to mention create")
+	}
+	if !strings.Contains(tc.Text, "deploy") {
+		t.Error("expected prompt text to mention deploy")
+	}
+}
+
+func TestPrompt_GetWithLanguage(t *testing.T) {
+	client, _, err := newTestPair(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.GetPrompt(t.Context(), &mcp.GetPromptParams{
+		Name:      "func-workflow",
+		Arguments: map[string]string{"language": "go"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+	tc, ok := result.Messages[0].Content.(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Messages[0].Content)
+	}
+	if !strings.Contains(tc.Text, "go") {
+		t.Error("expected prompt text to contain the language 'go'")
+	}
+}


### PR DESCRIPTION
## Changes

Adds a `func-workflow` MCP prompt that guides agents through the full Function lifecycle: create, build, and deploy.

**Why Option 2 (add a real prompt) over Option 1 (set HasPrompts: false):**
Setting the flag to false would be a minimal fix but leaves the capability unused. A guided workflow prompt is directly useful to agents and aligns with the MCP server's purpose of enabling end-to-end agentic usage of Functions.

**Prompt behavior:**
- Name: `func-workflow`
- Optional `language` argument to tailor guidance (e.g. go, python, node)
- Returns step-by-step instructions referencing the real MCP tools (create, build, deploy) and resources (func://languages, func://templates, func://function)
- `HasPrompts: true` remains correct now that a prompt is registered

**Tests added (3):**
- `TestPrompt_Listed` — prompt appears in ListPrompts response
- `TestPrompt_Get` — prompt returns valid message with create/deploy content
- `TestPrompt_GetWithLanguage` — language argument is reflected in output

/kind enhancement

Fixes #3734

```release-note
Add MCP `func-workflow` prompt for guided Function lifecycle (create, build, deploy)
```