### PR TITLE
fix(mcp): correct Server.readonly field comment

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -22,7 +22,7 @@ const (
 type Server struct {
 	OnInit    func(context.Context) // Invoked when the server is initialized
 	prefix    string                // Command prefix ("func" or "kn func")
-	readonly  bool                  // enables deploy and delete
+	readonly  bool                  // disables deploy and delete when true
 	executor  executor
 	transport mcp.Transport // Transport to use (defaults to StdioTransport)
 	impl      *mcp.Server   // implements the protocol


### PR DESCRIPTION
## Summary

Corrects the `Server.readonly` struct field comment in `pkg/mcp/mcp.go`. The field is used to block deploy and delete when true; the previous comment described the opposite behavior.

## Motivation

Misleading comments confuse contributors and anyone tracing read-only MCP behavior.

## Changes

- `pkg/mcp/mcp.go`: update `readonly` comment to state that deploy and delete are disabled when `readonly` is true.