### PR TITLE
fix(mcp): block build --push in read-only MCP mode

### DIFF
--- a/pkg/mcp/tools_build.go
+++ b/pkg/mcp/tools_build.go
@@ -20,6 +20,10 @@ var buildTool = &mcp.Tool{
 }
 
 func (s *Server) buildHandler(ctx context.Context, r *mcp.CallToolRequest, input BuildInput) (result *mcp.CallToolResult, output BuildOutput, err error) {
+	if s.readonly && input.Push != nil && *input.Push {
+		err = fmt.Errorf("the server is in read-only mode; set FUNC_ENABLE_MCP_WRITE=true to push images")
+		return
+	}
 	out, err := s.executor.Execute(ctx, "build", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))


### PR DESCRIPTION
## Summary

When the MCP server runs in read-only mode (default unless `FUNC_ENABLE_MCP_WRITE` enables writes), `deploy` and `delete` are already rejected. `build` with `push: true` could still push images to a registry. This change rejects that path with a clear error.

## Motivation

Read-only mode is meant to avoid mutating external state. Pushing a built image to a registry is such a mutation and should align with the same policy as deploy/delete.

## Changes

- `pkg/mcp/tools_build.go`: in `buildHandler`, return an error when `s.readonly` is true and the tool input requests push (`Push != nil && *input.Push`).

## Testing

- `go test ./pkg/mcp/...` or `make test`