### PR TITLE
docs(cmd): fix stale runMCPServer reference in mcp start comment

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -91,7 +91,7 @@ DESCRIPTION
 	}
 	// no flags at this time; future enhancements may be to allow configuring
 	// HTTP Stream vs stdio, single vs multiuser modes, etc.  For now
-	// we just use a simple gathering of options in runMCPServer.
+	// we just use a simple gathering of options in runMCPStart.
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

Updates an inline comment in `cmd/mcp.go` that referred to a non-existent `runMCPServer` helper. The actual entry point is `runMCPStart`.

## Motivation

Stale names in comments mislead readers when tracing how `mcp start` is wired.

## Changes

- `cmd/mcp.go`: comment under `NewMCPStartCmd` now references `runMCPStart`.

## Testing

- Not required for comment-only change; optional: `make check` / `go test ./cmd/...`