### PR TITLE
fix(mcp): respect cancellation in healthcheck handler

### DIFF
--- a/pkg/mcp/tools_healthcheck.go
+++ b/pkg/mcp/tools_healthcheck.go
@@ -18,6 +18,9 @@ var healthCheckTool = &mcp.Tool{
 }
 
 func (s *Server) healthcheckHandler(ctx context.Context, r *mcp.CallToolRequest, input HealthcheckInput) (result *mcp.CallToolResult, output HealthcheckOutput, err error) {
+	if err = ctx.Err(); err != nil {
+		return
+	}
 	output = HealthcheckOutput{
 		Status:  "ok",
 		Message: "The MCP server is running!",


### PR DESCRIPTION
## Summary

The `healthcheck` tool handler accepted a `context.Context` but never consulted it. The handler now returns early with `ctx.Err()` when the context is already canceled or expired.

## Motivation

Ensures a canceled tool request does not still return a successful health response.

## Changes

- `pkg/mcp/tools_healthcheck.go`: guard at the start of `healthcheckHandler` using `ctx.Err()`.

## Testing

- `go test -race -count=1 ./pkg/mcp/... -run Healthcheck`