### PR TITLE
mcp: expose server version in healthcheck output

### DIFF
--- a/pkg/mcp/tools_healthcheck.go
+++ b/pkg/mcp/tools_healthcheck.go
@@ -21,6 +21,7 @@ func (s *Server) healthcheckHandler(ctx context.Context, r *mcp.CallToolRequest,
 	output = HealthcheckOutput{
 		Status:  "ok",
 		Message: "The MCP server is running!",
+		Version: version,
 	}
 	return
 }
@@ -33,4 +34,5 @@ type HealthcheckInput struct{}
 type HealthcheckOutput struct {
 	Status  string `json:"status" jsonschema:"Status of the server (ok)"`
 	Message string `json:"message" jsonschema:"Healthcheck message"`
+	Version string `json:"version" jsonschema:"Version of the MCP server"`
 }

--- a/pkg/mcp/tools_healthcheck_test.go
+++ b/pkg/mcp/tools_healthcheck_test.go
@@ -63,4 +63,8 @@ func TestTool_Healthcheck(t *testing.T) {
 	if !strings.Contains(output.Message, "running") {
 		t.Errorf("expected message to contain 'running', got %q", output.Message)
 	}
+
+	if output.Version == "" {
+		t.Error("expected non-empty version")
+	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Was going through the `mcp` package exploring the codebase, and I noticed the `healthcheck` tool only returns `{ "status": "ok", "message": "..." }`. 

Agents currently have no way to know which version of `knative-func` is running the server. Maybe an outdated binary could run against a new cluster and behave differently, so an agent needs to have the version number to debug that.

`mcp.go` already defines a package-level `version` constant (used during handshake). This PR just takes that existing constant into the `HealthcheckOutput` so agents have immediate version context during healthchecks.

This PR:
- Adds a `Version` field to `HealthcheckOutput` and populates it.
- Adds the corresponding non-empty assertion to `TestTool_Healthcheck`.

/kind enhancement

There is no open issue for this; I found it during a codebase review. But I recently made another PR #3724.

I ran the test suite and everything runs ok for me locally. Let me know if any changes are required. 

**Release Note**

```release-note

