### PR TITLE
mcp: fix appendBoolFlag to handle explicit false values

### DIFF
--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -26,13 +26,16 @@ func appendStringFlag(args []string, flag string, value *string) []string {
 	return args
 }
 
-// appendBoolFlag adds a boolean flag to args only if the value is non-nil and true.
-// This ensures we only pass flags that were explicitly provided by the user.
+// appendBoolFlag adds a boolean flag to args only if the value is non-nil.
+// true appends "--flag", false appends "--flag=false", nil omits the flag entirely.
 func appendBoolFlag(args []string, flag string, value *bool) []string {
-	if value != nil && *value {
+	if value == nil {
+		return args
+	}
+	if *value {
 		return append(args, flag)
 	}
-	return args
+	return append(args, flag+"=false")
 }
 
 // ptr returns a pointer to the given value.

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -17,11 +17,17 @@ func validateArgLength(t *testing.T, args []string, stringFlagsCount, boolFlagsC
 }
 
 // argsToMap converts a command-line arguments slice into a map for order-independent validation.
-// String flags are stored as "--flag" -> "value", boolean flags as "--flag" -> "".
+// String flags are stored as "--flag" -> "value", boolean flags as "--flag" -> "",
+// and --flag=value forms as "--flag" -> "value".
 func argsToMap(args []string) map[string]string {
 	argsMap := make(map[string]string)
 	for i := 0; i < len(args); {
-		if i+1 < len(args) && !strings.HasPrefix(args[i+1], "--") {
+		if strings.Contains(args[i], "=") {
+			// --flag=value form
+			parts := strings.SplitN(args[i], "=", 2)
+			argsMap[parts[0]] = parts[1]
+			i++
+		} else if i+1 < len(args) && !strings.HasPrefix(args[i+1], "--") {
 			// String flag: --flag value
 			argsMap[args[i]] = args[i+1]
 			i += 2
@@ -76,4 +82,28 @@ func buildInputArgs(stringFlags map[string]struct {
 		inputArgs[key] = true
 	}
 	return inputArgs
+}
+
+// TestAppendBoolFlag verifies nil/true/false semantics of appendBoolFlag.
+func TestAppendBoolFlag(t *testing.T) {
+	t.Run("nil omits flag", func(t *testing.T) {
+		args := appendBoolFlag([]string{}, "--verbose", nil)
+		if len(args) != 0 {
+			t.Fatalf("expected empty args for nil, got %v", args)
+		}
+	})
+	t.Run("true appends flag", func(t *testing.T) {
+		v := true
+		args := appendBoolFlag([]string{}, "--verbose", &v)
+		if len(args) != 1 || args[0] != "--verbose" {
+			t.Fatalf("expected [--verbose], got %v", args)
+		}
+	})
+	t.Run("false appends flag=false", func(t *testing.T) {
+		v := false
+		args := appendBoolFlag([]string{}, "--verbose", &v)
+		if len(args) != 1 || args[0] != "--verbose=false" {
+			t.Fatalf("expected [--verbose=false], got %v", args)
+		}
+	})
 }


### PR DESCRIPTION
## Changes

Fixes a correctness bug in `appendBoolFlag`: explicit `false` values were silently dropped, making it impossible for agents to explicitly disable bool flags like `--insecure` or `--verbose`.

**Before:** only appended the flag when value was `true`. Explicit `false` was ignored.

**After (tri-state semantics):**
- `nil` — omit flag entirely (not provided by agent)
- `true` — `--flag`
- `false` — `--flag=false`

Also fixes `argsToMap` in tools_test.go to correctly parse `--flag=value` format. Previously `--verbose=false` was treated as a boolean flag with empty value instead of a string flag with value `false`.

**Tests added:**
- `TestAppendBoolFlag` with subtests for nil/true/false cases

All existing tests pass.

/kind bug

Fixes #3705

```release-note
Fix MCP appendBoolFlag: explicit false values now correctly passed as --flag=false instead of being silently dropped
```