### PR TITLE
mcp: add missing test coverage for Remove help resources

### DIFF
--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -150,6 +150,21 @@ func TestResource_Help(t *testing.T) {
 			uri:      "func://help/config/envs/add",
 			wantArgs: []string{"config", "envs", "add", "--help"},
 		},
+		{
+			name:     "config volumes remove help",
+			uri:      "func://help/config/volumes/remove",
+			wantArgs: []string{"config", "volumes", "remove", "--help"},
+		},
+		{
+			name:     "config labels remove help",
+			uri:      "func://help/config/labels/remove",
+			wantArgs: []string{"config", "labels", "remove", "--help"},
+		},
+		{
+			name:     "config envs remove help",
+			uri:      "func://help/config/envs/remove",
+			wantArgs: []string{"config", "envs", "remove", "--help"},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Changes

The Remove help resources for `config volumes`, `config labels`, and `config envs` were registered correctly in `mcp.go` but had no test coverage. Regressions in the command paths could go undetected.

Adds three test cases to `TestResource_Help` verifying the correct URIs and command args:
- `func://help/config/volumes/remove` maps to `config volumes remove --help`
- `func://help/config/labels/remove` maps to `config labels remove --help`
- `func://help/config/envs/remove` maps to `config envs remove --help`

/kind bug

Fixes #3711

```release-note
Add missing test coverage for MCP Remove help resources (config volumes/labels/envs)
```