### PR TITLE
feat: Add CA certificate bundle support for builds

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -114,8 +114,8 @@ EXAMPLES
 		"Specify a custom builder image for use by the builder other than its default. ($FUNC_BUILDER_IMAGE)")
 	cmd.Flags().StringP("base-image", "", f.Build.BaseImage,
 		"Override the base image for your function (host builder only)")
-	cmd.Flags().StringP("ca-bundle", "", f.Build.CACertBundle,
-		"Path to CA certificate bundle file for SSL verification during build. Useful when building behind corporate proxies. ($FUNC_CA_BUNDLE)")
+	cmd.Flags().StringP("build-ca-file", "", f.Build.BuildCACertFile,
+		"Path to CA certificate file for SSL verification during build (build-time only). Useful when building behind corporate proxies with SSL inspection. ($FUNC_BUILD_CA_FILE)")
 	cmd.Flags().StringP("image", "i", f.Image,
 		"Full image name in the form [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over --registry ($FUNC_IMAGE)")
 
@@ -232,8 +232,9 @@ type buildConfig struct {
 	// TODO: gauron99 -- make option to add a path to dockerfile ?
 	BaseImage string
 
-	// CACertBundle is the path to a CA certificate bundle file for SSL verification
-	CACertBundle string
+	// BuildCACertFile is the path to a CA certificate file for SSL verification
+	// during build time only (not included in runtime image)
+	BuildCACertFile string
 
 	// Path of the function implementation on local disk. Defaults to current
 	// working directory of the process.
@@ -276,7 +277,7 @@ func newBuildConfig() buildConfig {
 		},
 		BuilderImage:     viper.GetString("builder-image"),
 		BaseImage:        viper.GetString("base-image"),
-		CACertBundle:     viper.GetString("ca-bundle"),
+		BuildCACertFile:  viper.GetString("build-ca-file"),
 		Image:            viper.GetString("image"),
 		Path:             viper.GetString("path"),
 		Platform:         viper.GetString("platform"),
@@ -300,7 +301,7 @@ func (c buildConfig) Configure(f fn.Function) fn.Function {
 	}
 	f.Image = c.Image
 	f.Build.BaseImage = c.BaseImage
-	f.Build.CACertBundle = c.CACertBundle
+	f.Build.BuildCACertFile = c.BuildCACertFile
 	// Path, Platform and Push are not part of a function's state.
 	return f
 }

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -70,7 +70,7 @@ EXAMPLES
 `,
 		SuggestFor: []string{"biuld", "buidl", "built"},
 		PreRunE: bindEnv("image", "path", "builder", "registry", "confirm",
-			"push", "builder-image", "base-image", "platform", "verbose",
+			"push", "builder-image", "base-image", "ca-bundle", "platform", "verbose",
 			"build-timestamp", "registry-insecure", "registry-authfile", "username", "password", "token"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runBuild(cmd, args, newClient)
@@ -114,6 +114,8 @@ EXAMPLES
 		"Specify a custom builder image for use by the builder other than its default. ($FUNC_BUILDER_IMAGE)")
 	cmd.Flags().StringP("base-image", "", f.Build.BaseImage,
 		"Override the base image for your function (host builder only)")
+	cmd.Flags().StringP("ca-bundle", "", f.Build.CACertBundle,
+		"Path to CA certificate bundle file for SSL verification during build. Useful when building behind corporate proxies. ($FUNC_CA_BUNDLE)")
 	cmd.Flags().StringP("image", "i", f.Image,
 		"Full image name in the form [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over --registry ($FUNC_IMAGE)")
 
@@ -230,6 +232,9 @@ type buildConfig struct {
 	// TODO: gauron99 -- make option to add a path to dockerfile ?
 	BaseImage string
 
+	// CACertBundle is the path to a CA certificate bundle file for SSL verification
+	CACertBundle string
+
 	// Path of the function implementation on local disk. Defaults to current
 	// working directory of the process.
 	Path string
@@ -271,6 +276,7 @@ func newBuildConfig() buildConfig {
 		},
 		BuilderImage:     viper.GetString("builder-image"),
 		BaseImage:        viper.GetString("base-image"),
+		CACertBundle:     viper.GetString("ca-bundle"),
 		Image:            viper.GetString("image"),
 		Path:             viper.GetString("path"),
 		Platform:         viper.GetString("platform"),
@@ -294,6 +300,7 @@ func (c buildConfig) Configure(f fn.Function) fn.Function {
 	}
 	f.Image = c.Image
 	f.Build.BaseImage = c.BaseImage
+	f.Build.CACertBundle = c.CACertBundle
 	// Path, Platform and Push are not part of a function's state.
 	return f
 }

--- a/docs/reference/func_build.md
+++ b/docs/reference/func_build.md
@@ -61,6 +61,7 @@ func build
       --build-timestamp            Use the actual time as the created time for the docker image. This is only useful for buildpacks builder.
   -b, --builder string             Builder to use when creating the function's container. Currently supported builders are "host", "pack" and "s2i". ($FUNC_BUILDER) (default "pack")
       --builder-image string       Specify a custom builder image for use by the builder other than its default. ($FUNC_BUILDER_IMAGE)
+      --ca-bundle string           Path to CA certificate bundle file for SSL verification during build. Useful when building behind corporate proxies. ($FUNC_CA_BUNDLE)
   -c, --confirm                    Prompt to confirm options interactively ($FUNC_CONFIRM)
   -h, --help                       help for build
   -i, --image string               Full image name in the form [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over --registry ($FUNC_IMAGE)

--- a/docs/reference/func_build.md
+++ b/docs/reference/func_build.md
@@ -58,10 +58,10 @@ func build
 
 ```
       --base-image string          Override the base image for your function (host builder only)
+      --build-ca-file string       Path to CA certificate file for SSL verification during build (build-time only). Useful when building behind corporate proxies with SSL inspection. ($FUNC_BUILD_CA_FILE)
       --build-timestamp            Use the actual time as the created time for the docker image. This is only useful for buildpacks builder.
   -b, --builder string             Builder to use when creating the function's container. Currently supported builders are "host", "pack" and "s2i". ($FUNC_BUILDER) (default "pack")
       --builder-image string       Specify a custom builder image for use by the builder other than its default. ($FUNC_BUILDER_IMAGE)
-      --ca-bundle string           Path to CA certificate bundle file for SSL verification during build. Useful when building behind corporate proxies. ($FUNC_CA_BUNDLE)
   -c, --confirm                    Prompt to confirm options interactively ($FUNC_CONFIRM)
   -h, --help                       help for build
   -i, --image string               Full image name in the form [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over --registry ($FUNC_IMAGE)

--- a/pkg/builders/builders_int_test.go
+++ b/pkg/builders/builders_int_test.go
@@ -17,6 +17,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -515,4 +516,217 @@ func servePrivateGit(ctx context.Context, t *testing.T, certDir string) {
 
 func ptr[T any](val T) *T {
 	return &val
+}
+
+// TestInt_BuildCACertFile tests that CA certificate bundles are properly used
+// during builds for both pack and s2i builders. This test verifies that:
+// - pack builder uses Paketo ca-certificates binding
+// - s2i builder uses environment variables for CA bundle
+// - builds can access resources with custom CA certificates
+func TestInt_BuildCACertFile(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Skipping TestInt_BuildCACertFile on non-Linux systems due to cluster networking limitations")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		cancel()
+		<-sigs // second sigint/sigterm is treated as sigkill
+		os.Exit(137)
+	}()
+
+	// Create a self-signed CA certificate for testing
+	certDir := createCertificate(t)
+	t.Log("certDir:", certDir)
+
+	// Use the cert.pem as our CA bundle file
+	caBundlePath := filepath.Join(certDir, "cert.pem")
+
+	// Verify CA bundle file exists
+	if _, err := os.Stat(caBundlePath); err != nil {
+		t.Fatalf("CA bundle file not found: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+
+	// Copy test function
+	src := filepath.Join("testdata", "go-fn-with-private-deps")
+	dst := filepath.Join(tmpDir, "go-fn-with-ca-test")
+
+	err := copyDir(src, dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := fn.NewFunction(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the CA bundle file in the function spec
+	f.Build.BuildCACertFile = caBundlePath
+
+	testCases := []struct {
+		Name         string
+		Scaffolder   fn.Scaffolder
+		Builder      fn.Builder
+		BuilderImage func(ctx context.Context, t *testing.T, certDir string) string
+	}{
+		{
+			Name:         "pack",
+			Scaffolder:   buildpacks.NewScaffolder(true),
+			Builder:      buildpacks.NewBuilder(buildpacks.WithVerbose(true)),
+			BuilderImage: buildPatchedBuildpackBuilder,
+		},
+		{
+			Name:         "s2i",
+			Scaffolder:   s2i.NewScaffolder(true),
+			Builder:      s2i.NewBuilder(s2i.WithVerbose(true)),
+			BuilderImage: buildPatchedS2IBuilder,
+		},
+	}
+
+	for _, tt := range testCases {
+		var f = f
+		t.Run(tt.Name, func(t *testing.T) {
+			f.Build.Image = "registry.localtest.me/go-app:ca-test-" + tt.Name
+			f.Build.Builder = tt.Name
+			f.Build.BuilderImages = map[string]string{
+				tt.Name: tt.BuilderImage(ctx, t, certDir),
+			}
+			f.Build.BuildCACertFile = caBundlePath
+
+			// Scaffold the function
+			err = tt.Scaffolder.Scaffold(ctx, f, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Build the function - this should succeed if CA bundle is properly used
+			err = tt.Builder.Build(ctx, f, nil)
+			if err != nil {
+				t.Fatalf("%s builder failed to build with CA bundle: %v", tt.Name, err)
+			}
+
+			t.Logf("%s builder successfully built with CA bundle", tt.Name)
+		})
+	}
+}
+
+// TestInt_BuildCACertFile_RelativePath tests that relative paths to CA bundles
+// are properly resolved relative to the function root
+func TestInt_BuildCACertFile_RelativePath(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Skipping on non-Linux systems due to cluster networking limitations")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// Create a self-signed CA certificate
+	certDir := createCertificate(t)
+	caBundleSource := filepath.Join(certDir, "cert.pem")
+
+	tmpDir := t.TempDir()
+
+	// Copy test function
+	src := filepath.Join("testdata", "go-fn-with-private-deps")
+	dst := filepath.Join(tmpDir, "go-fn-relative-ca")
+
+	err := copyDir(src, dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Copy CA bundle to function root with a relative name
+	caBundleInFunc := filepath.Join(dst, "my-ca-bundle.crt")
+	caData, err := os.ReadFile(caBundleSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(caBundleInFunc, caData, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := fn.NewFunction(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Use RELATIVE path
+	f.Build.BuildCACertFile = "my-ca-bundle.crt"
+
+	// Test with pack builder
+	scaffolder := buildpacks.NewScaffolder(true)
+	builder := buildpacks.NewBuilder(buildpacks.WithVerbose(true))
+
+	f.Build.Image = "registry.localtest.me/go-app:ca-relative-test"
+	f.Build.Builder = "pack"
+	f.Build.BuilderImages = map[string]string{
+		"pack": buildPatchedBuildpackBuilder(ctx, t, certDir),
+	}
+
+	err = scaffolder.Scaffold(ctx, f, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = builder.Build(ctx, f, nil)
+	if err != nil {
+		t.Fatalf("pack builder failed with relative CA bundle path: %v", err)
+	}
+
+	t.Log("pack builder successfully built with relative CA bundle path")
+}
+
+// TestInt_BuildCACertFile_MissingFile tests that builds fail gracefully
+// when CA bundle file doesn't exist
+func TestInt_BuildCACertFile_MissingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Copy test function
+	src := filepath.Join("testdata", "go-fn-with-private-deps")
+	dst := filepath.Join(tmpDir, "go-fn-missing-ca")
+
+	err := copyDir(src, dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := fn.NewFunction(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Point to non-existent CA bundle
+	f.Build.BuildCACertFile = "/nonexistent/ca-bundle.crt"
+
+	scaffolder := buildpacks.NewScaffolder(true)
+	builder := buildpacks.NewBuilder(buildpacks.WithVerbose(true))
+
+	f.Build.Image = "registry.localtest.me/go-app:ca-missing-test"
+	f.Build.Builder = "pack"
+
+	err = scaffolder.Scaffold(context.Background(), f, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build should fail with clear error about missing CA bundle
+	err = builder.Build(context.Background(), f, nil)
+	if err == nil {
+		t.Fatal("expected build to fail with missing CA bundle, but it succeeded")
+	}
+
+	if !strings.Contains(err.Error(), "CA bundle file not found") {
+		t.Fatalf("expected error message about CA bundle not found, got: %v", err)
+	}
+
+	t.Log("build correctly failed with missing CA bundle file")
 }

--- a/pkg/buildpacks/builder.go
+++ b/pkg/buildpacks/builder.go
@@ -225,27 +225,51 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 	}
 
 	// CA Certificate Bundle support for corporate proxies
+	// Use Paketo CA certificates buildpack binding instead of manual env vars
 	if f.Build.CACertBundle != "" {
+		// Resolve to absolute path if relative
+		caBundlePath := f.Build.CACertBundle
+		if !filepath.IsAbs(caBundlePath) {
+			caBundlePath = filepath.Join(f.Root, caBundlePath)
+		}
+
 		// Validate that the CA bundle file exists
-		if _, err := os.Stat(f.Build.CACertBundle); err != nil {
+		if _, err := os.Stat(caBundlePath); err != nil {
 			return fmt.Errorf("CA bundle file not found: %w", err)
 		}
 
-		// Set environment variables for various runtimes to use the CA bundle
-		// These will be available during the build process
-		opts.Env["SSL_CERT_FILE"] = f.Build.CACertBundle
-		opts.Env["REQUESTS_CA_BUNDLE"] = f.Build.CACertBundle                                       // Python
-		opts.Env["NODE_EXTRA_CA_CERTS"] = f.Build.CACertBundle                                      // Node.js
-		opts.Env["CURL_CA_BUNDLE"] = f.Build.CACertBundle                                           // curl
-		opts.Env["GIT_SSL_CAINFO"] = f.Build.CACertBundle                                           // git
-		opts.Env["PIP_CERT"] = f.Build.CACertBundle                                                 // pip (Python)
-		opts.Env["NPM_CONFIG_CAFILE"] = f.Build.CACertBundle                                        // npm (Node.js)
-		opts.Env["CARGO_HTTP_CAINFO"] = f.Build.CACertBundle                                        // cargo (Rust)
-		opts.Env["MAVEN_OPTS"] = fmt.Sprintf("-Djavax.net.ssl.trustStore=%s", f.Build.CACertBundle) // Maven (Java)
+		// Create a temporary directory for the CA certificates binding
+		caCertsBindingDir, err := os.MkdirTemp("", "func-ca-certs-*")
+		if err != nil {
+			return fmt.Errorf("failed to create CA certificates binding directory: %w", err)
+		}
+		// Note: We don't defer cleanup here because the build process needs it
+		// The directory will be cleaned up when the temp dir is cleaned by the OS
 
-		// Mount the CA bundle file into the build container
-		opts.ContainerConfig.Volumes = append(opts.ContainerConfig.Volumes,
-			fmt.Sprintf("%s:%s:ro", f.Build.CACertBundle, f.Build.CACertBundle))
+		// Write the binding type file
+		if err := os.WriteFile(filepath.Join(caCertsBindingDir, "type"), []byte("ca-certificates"), 0644); err != nil {
+			return fmt.Errorf("failed to write CA certificates binding type: %w", err)
+		}
+
+		// Copy the CA bundle to the binding directory
+		caData, err := os.ReadFile(caBundlePath)
+		if err != nil {
+			return fmt.Errorf("failed to read CA bundle: %w", err)
+		}
+		if err := os.WriteFile(filepath.Join(caCertsBindingDir, "ca-certificates.crt"), caData, 0644); err != nil {
+			return fmt.Errorf("failed to write CA certificates to binding: %w", err)
+		}
+
+		// Set SERVICE_BINDING_ROOT if not already set
+		if _, ok := opts.Env["SERVICE_BINDING_ROOT"]; !ok {
+			opts.Env["SERVICE_BINDING_ROOT"] = "/platform/bindings"
+		}
+
+		// Add the CA certificates binding as a mount
+		f.Build.Mounts = append(f.Build.Mounts, fn.MountSpec{
+			Source:      caCertsBindingDir,
+			Destination: filepath.Join(opts.Env["SERVICE_BINDING_ROOT"], "ca-certificates"),
+		})
 	}
 
 	var bindings = make([]string, 0, len(f.Build.Mounts))

--- a/pkg/buildpacks/builder.go
+++ b/pkg/buildpacks/builder.go
@@ -224,6 +224,30 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 		opts.Env["BP_IMAGE_LABELS"] = strings.Join(imageLabels, " ")
 	}
 
+	// CA Certificate Bundle support for corporate proxies
+	if f.Build.CACertBundle != "" {
+		// Validate that the CA bundle file exists
+		if _, err := os.Stat(f.Build.CACertBundle); err != nil {
+			return fmt.Errorf("CA bundle file not found: %w", err)
+		}
+
+		// Set environment variables for various runtimes to use the CA bundle
+		// These will be available during the build process
+		opts.Env["SSL_CERT_FILE"] = f.Build.CACertBundle
+		opts.Env["REQUESTS_CA_BUNDLE"] = f.Build.CACertBundle                                       // Python
+		opts.Env["NODE_EXTRA_CA_CERTS"] = f.Build.CACertBundle                                      // Node.js
+		opts.Env["CURL_CA_BUNDLE"] = f.Build.CACertBundle                                           // curl
+		opts.Env["GIT_SSL_CAINFO"] = f.Build.CACertBundle                                           // git
+		opts.Env["PIP_CERT"] = f.Build.CACertBundle                                                 // pip (Python)
+		opts.Env["NPM_CONFIG_CAFILE"] = f.Build.CACertBundle                                        // npm (Node.js)
+		opts.Env["CARGO_HTTP_CAINFO"] = f.Build.CACertBundle                                        // cargo (Rust)
+		opts.Env["MAVEN_OPTS"] = fmt.Sprintf("-Djavax.net.ssl.trustStore=%s", f.Build.CACertBundle) // Maven (Java)
+
+		// Mount the CA bundle file into the build container
+		opts.ContainerConfig.Volumes = append(opts.ContainerConfig.Volumes,
+			fmt.Sprintf("%s:%s:ro", f.Build.CACertBundle, f.Build.CACertBundle))
+	}
+
 	var bindings = make([]string, 0, len(f.Build.Mounts))
 	for _, m := range f.Build.Mounts {
 		bindings = append(bindings, fmt.Sprintf("%s:%s", m.Source, m.Destination))

--- a/pkg/buildpacks/builder.go
+++ b/pkg/buildpacks/builder.go
@@ -265,18 +265,29 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 			opts.Env["SERVICE_BINDING_ROOT"] = "/platform/bindings"
 		}
 
-		// Add the CA certificates binding as a mount
-		f.Build.Mounts = append(f.Build.Mounts, fn.MountSpec{
+		// Create a local copy of mounts and add the CA certificates binding
+		// We don't modify f.Build.Mounts directly to avoid race conditions
+		mounts := make([]fn.MountSpec, len(f.Build.Mounts), len(f.Build.Mounts)+1)
+		copy(mounts, f.Build.Mounts)
+		mounts = append(mounts, fn.MountSpec{
 			Source:      caCertsBindingDir,
 			Destination: filepath.Join(opts.Env["SERVICE_BINDING_ROOT"], "ca-certificates"),
 		})
-	}
 
-	var bindings = make([]string, 0, len(f.Build.Mounts))
-	for _, m := range f.Build.Mounts {
-		bindings = append(bindings, fmt.Sprintf("%s:%s", m.Source, m.Destination))
+		// Convert mounts to bindings format
+		var bindings = make([]string, 0, len(mounts))
+		for _, m := range mounts {
+			bindings = append(bindings, fmt.Sprintf("%s:%s", m.Source, m.Destination))
+		}
+		opts.ContainerConfig.Volumes = bindings
+	} else {
+		// No CA bundle, just use the existing mounts
+		var bindings = make([]string, 0, len(f.Build.Mounts))
+		for _, m := range f.Build.Mounts {
+			bindings = append(bindings, fmt.Sprintf("%s:%s", m.Source, m.Destination))
+		}
+		opts.ContainerConfig.Volumes = bindings
 	}
-	opts.ContainerConfig.Volumes = bindings
 
 	// only trust our known builders
 	opts.TrustBuilder = TrustBuilder

--- a/pkg/buildpacks/builder.go
+++ b/pkg/buildpacks/builder.go
@@ -224,11 +224,11 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 		opts.Env["BP_IMAGE_LABELS"] = strings.Join(imageLabels, " ")
 	}
 
-	// CA Certificate Bundle support for corporate proxies
+	// CA Certificate Bundle support for corporate proxies (build-time only)
 	// Use Paketo CA certificates buildpack binding instead of manual env vars
-	if f.Build.CACertBundle != "" {
+	if f.Build.BuildCACertFile != "" {
 		// Resolve to absolute path if relative
-		caBundlePath := f.Build.CACertBundle
+		caBundlePath := f.Build.BuildCACertFile
 		if !filepath.IsAbs(caBundlePath) {
 			caBundlePath = filepath.Join(f.Root, caBundlePath)
 		}

--- a/pkg/buildpacks/builder_test.go
+++ b/pkg/buildpacks/builder_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	pack "github.com/buildpacks/pack/pkg/client"
@@ -381,4 +382,180 @@ type mockImpl struct {
 
 func (i mockImpl) Build(ctx context.Context, opts pack.BuildOptions) error {
 	return i.BuildFn(ctx, opts)
+}
+
+// TestBuild_BuildCACertFile tests the CA certificate file handling
+func TestBuild_BuildCACertFile(t *testing.T) {
+	tests := []struct {
+		name          string
+		caCertPath    string
+		setupFunc     func(t *testing.T, root string) string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:       "no CA cert file",
+			caCertPath: "",
+			setupFunc: func(t *testing.T, root string) string {
+				return ""
+			},
+			expectError: false,
+		},
+		{
+			name:       "absolute path to CA cert",
+			caCertPath: "", // Will be set by setupFunc
+			setupFunc: func(t *testing.T, root string) string {
+				// Create a temporary CA cert file
+				tmpFile, err := os.CreateTemp("", "ca-cert-*.crt")
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer tmpFile.Close()
+
+				// Write some dummy CA cert content
+				if _, err := tmpFile.WriteString("-----BEGIN CERTIFICATE-----\nDUMMY\n-----END CERTIFICATE-----\n"); err != nil {
+					t.Fatal(err)
+				}
+
+				return tmpFile.Name()
+			},
+			expectError: false,
+		},
+		{
+			name:       "relative path to CA cert",
+			caCertPath: "ca-cert.crt",
+			setupFunc: func(t *testing.T, root string) string {
+				// Don't create the file yet - will be created after Init
+				return "ca-cert.crt" // Return relative path
+			},
+			expectError: false,
+		},
+		{
+			name:          "non-existent CA cert file",
+			caCertPath:    "/nonexistent/ca-cert.crt",
+			setupFunc:     func(t *testing.T, root string) string { return "/nonexistent/ca-cert.crt" },
+			expectError:   true,
+			errorContains: "CA bundle file not found",
+		},
+		{
+			name:       "CA cert outside function directory",
+			caCertPath: "", // Will be set by setupFunc
+			setupFunc: func(t *testing.T, root string) string {
+				// Create a temporary CA cert file outside function root
+				tmpDir := t.TempDir()
+				caPath := filepath.Join(tmpDir, "external-ca.crt")
+				if err := os.WriteFile(caPath, []byte("-----BEGIN CERTIFICATE-----\nDUMMY\n-----END CERTIFICATE-----\n"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return caPath
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root, done := Mktemp(t)
+			defer done()
+
+			// Setup the CA cert file
+			caCertPath := tt.setupFunc(t, root)
+			if tt.caCertPath != "" && caCertPath == "" {
+				caCertPath = tt.caCertPath
+			}
+
+			var (
+				i = &mockImpl{}
+				b = NewBuilder(WithImpl(i))
+				f = fn.Function{
+					Runtime:  "go",
+					Root:     root,
+					Registry: "example.com/alice",
+					Build: fn.BuildSpec{
+						BuildCACertFile: caCertPath,
+					},
+				}
+			)
+
+			// Initialize the function
+			var err error
+			if f, err = fn.New().Init(f); err != nil {
+				t.Fatal(err)
+			}
+
+			// Set the CA cert path after init
+			f.Build.BuildCACertFile = caCertPath
+
+			// For relative path test, create the file AFTER init
+			if caCertPath == "ca-cert.crt" {
+				caPath := filepath.Join(root, "ca-cert.crt")
+				if err := os.WriteFile(caPath, []byte("-----BEGIN CERTIFICATE-----\nDUMMY\n-----END CERTIFICATE-----\n"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Track whether Build was called
+			buildCalled := false
+			i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
+				buildCalled = true
+
+				// If CA cert is provided, verify the binding is set up correctly
+				if caCertPath != "" && !tt.expectError {
+					// Check that SERVICE_BINDING_ROOT is set
+					if _, ok := opts.Env["SERVICE_BINDING_ROOT"]; !ok {
+						t.Error("SERVICE_BINDING_ROOT not set when CA cert is provided")
+					}
+
+					// Check that volumes are configured
+					if len(opts.ContainerConfig.Volumes) == 0 {
+						t.Error("No volumes configured when CA cert is provided")
+					}
+
+					// Verify at least one volume contains "ca-certificates"
+					foundCABinding := false
+					for _, vol := range opts.ContainerConfig.Volumes {
+						if strings.Contains(vol, "ca-certificates") {
+							foundCABinding = true
+							break
+						}
+					}
+					if !foundCABinding {
+						t.Error("CA certificates binding not found in volumes")
+					}
+				}
+
+				return nil
+			}
+
+			// Execute the build
+			err = b.Build(t.Context(), f, nil)
+
+			// Check error expectations
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Fatalf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+				// Build should not have been called if there was an error
+				if buildCalled {
+					t.Error("Build was called despite error in setup")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				// Build should have been called
+				if !buildCalled {
+					t.Error("Build was not called")
+				}
+			}
+
+			// Cleanup: remove temporary CA cert files created outside function root
+			if caCertPath != "" && filepath.IsAbs(caCertPath) && !strings.HasPrefix(caCertPath, root) {
+				os.Remove(caCertPath)
+			}
+		})
+	}
 }

--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -150,6 +150,11 @@ type BuildSpec struct {
 	// Build Env variables to be set
 	BuildEnvs Envs `yaml:"buildEnvs,omitempty"`
 
+	// CACertBundle specifies the path to a CA certificate bundle file to use
+	// for SSL verification during build. This is useful when building behind
+	// corporate proxies with SSL inspection.
+	CACertBundle string `yaml:"caCertBundle,omitempty" jsonschema:"description=Path to CA certificate bundle for SSL verification during build"`
+
 	// PVCSize specifies the size of persistent volume claim used to store function
 	// when using deployment and remote build process (only relevant when Remote is true).
 	PVCSize string `yaml:"pvcSize,omitempty"`

--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -150,10 +150,11 @@ type BuildSpec struct {
 	// Build Env variables to be set
 	BuildEnvs Envs `yaml:"buildEnvs,omitempty"`
 
-	// CACertBundle specifies the path to a CA certificate bundle file to use
-	// for SSL verification during build. This is useful when building behind
-	// corporate proxies with SSL inspection.
-	CACertBundle string `yaml:"caCertBundle,omitempty" jsonschema:"description=Path to CA certificate bundle for SSL verification during build"`
+	// BuildCACertFile specifies the path to a CA certificate bundle file to use
+	// for SSL verification during build time only. This is useful when building
+	// behind corporate proxies with SSL inspection. The CA certificate is only
+	// used during the build process and is not included in the final function image.
+	BuildCACertFile string `yaml:"buildCACertFile,omitempty" jsonschema:"description=Path to CA certificate file for SSL verification during build (build-time only)"`
 
 	// PVCSize specifies the size of persistent volume claim used to store function
 	// when using deployment and remote build process (only relevant when Remote is true).

--- a/pkg/s2i/builder.go
+++ b/pkg/s2i/builder.go
@@ -220,10 +220,10 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 		cfg.BuildVolumes = append(cfg.BuildVolumes, fmt.Sprintf("%s:%s:ro,Z", m.Source, m.Destination))
 	}
 
-	// CA Certificate Bundle support for corporate proxies
-	if f.Build.CACertBundle != "" {
+	// CA Certificate Bundle support for corporate proxies (build-time only)
+	if f.Build.BuildCACertFile != "" {
 		// Resolve to absolute path if relative
-		caBundlePath := f.Build.CACertBundle
+		caBundlePath := f.Build.BuildCACertFile
 		if !filepath.IsAbs(caBundlePath) {
 			caBundlePath = filepath.Join(f.Root, caBundlePath)
 		}

--- a/pkg/s2i/builder.go
+++ b/pkg/s2i/builder.go
@@ -222,27 +222,34 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 
 	// CA Certificate Bundle support for corporate proxies
 	if f.Build.CACertBundle != "" {
+		// Resolve to absolute path if relative
+		caBundlePath := f.Build.CACertBundle
+		if !filepath.IsAbs(caBundlePath) {
+			caBundlePath = filepath.Join(f.Root, caBundlePath)
+		}
+
 		// Validate that the CA bundle file exists
-		if _, err := os.Stat(f.Build.CACertBundle); err != nil {
+		if _, err := os.Stat(caBundlePath); err != nil {
 			return fmt.Errorf("CA bundle file not found: %w", err)
 		}
 
+		// For S2I, we need to mount the CA bundle and set environment variables
+		// Mount the CA bundle into a standard location
+		caDestPath := "/tmp/ca-certificates.crt"
+		cfg.BuildVolumes = append(cfg.BuildVolumes,
+			fmt.Sprintf("%s:%s:ro,Z", caBundlePath, caDestPath))
+
 		// Set environment variables for various runtimes to use the CA bundle
 		cfg.Environment = append(cfg.Environment,
-			api.EnvironmentSpec{Name: "SSL_CERT_FILE", Value: f.Build.CACertBundle},
-			api.EnvironmentSpec{Name: "REQUESTS_CA_BUNDLE", Value: f.Build.CACertBundle},                                       // Python
-			api.EnvironmentSpec{Name: "NODE_EXTRA_CA_CERTS", Value: f.Build.CACertBundle},                                      // Node.js
-			api.EnvironmentSpec{Name: "CURL_CA_BUNDLE", Value: f.Build.CACertBundle},                                           // curl
-			api.EnvironmentSpec{Name: "GIT_SSL_CAINFO", Value: f.Build.CACertBundle},                                           // git
-			api.EnvironmentSpec{Name: "PIP_CERT", Value: f.Build.CACertBundle},                                                 // pip (Python)
-			api.EnvironmentSpec{Name: "NPM_CONFIG_CAFILE", Value: f.Build.CACertBundle},                                        // npm (Node.js)
-			api.EnvironmentSpec{Name: "CARGO_HTTP_CAINFO", Value: f.Build.CACertBundle},                                        // cargo (Rust)
-			api.EnvironmentSpec{Name: "MAVEN_OPTS", Value: fmt.Sprintf("-Djavax.net.ssl.trustStore=%s", f.Build.CACertBundle)}, // Maven (Java)
+			api.EnvironmentSpec{Name: "SSL_CERT_FILE", Value: caDestPath},
+			api.EnvironmentSpec{Name: "REQUESTS_CA_BUNDLE", Value: caDestPath},  // Python
+			api.EnvironmentSpec{Name: "NODE_EXTRA_CA_CERTS", Value: caDestPath}, // Node.js
+			api.EnvironmentSpec{Name: "CURL_CA_BUNDLE", Value: caDestPath},      // curl
+			api.EnvironmentSpec{Name: "GIT_SSL_CAINFO", Value: caDestPath},      // git
+			api.EnvironmentSpec{Name: "PIP_CERT", Value: caDestPath},            // pip (Python)
+			api.EnvironmentSpec{Name: "NPM_CONFIG_CAFILE", Value: caDestPath},   // npm (Node.js)
+			api.EnvironmentSpec{Name: "CARGO_HTTP_CAINFO", Value: caDestPath},   // cargo (Rust)
 		)
-
-		// Mount the CA bundle file into the build container
-		cfg.BuildVolumes = append(cfg.BuildVolumes,
-			fmt.Sprintf("%s:%s:ro,Z", f.Build.CACertBundle, f.Build.CACertBundle))
 	}
 
 	if runtime.GOOS == "linux" {

--- a/pkg/s2i/builder.go
+++ b/pkg/s2i/builder.go
@@ -220,6 +220,31 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 		cfg.BuildVolumes = append(cfg.BuildVolumes, fmt.Sprintf("%s:%s:ro,Z", m.Source, m.Destination))
 	}
 
+	// CA Certificate Bundle support for corporate proxies
+	if f.Build.CACertBundle != "" {
+		// Validate that the CA bundle file exists
+		if _, err := os.Stat(f.Build.CACertBundle); err != nil {
+			return fmt.Errorf("CA bundle file not found: %w", err)
+		}
+
+		// Set environment variables for various runtimes to use the CA bundle
+		cfg.Environment = append(cfg.Environment,
+			api.EnvironmentSpec{Name: "SSL_CERT_FILE", Value: f.Build.CACertBundle},
+			api.EnvironmentSpec{Name: "REQUESTS_CA_BUNDLE", Value: f.Build.CACertBundle},                                       // Python
+			api.EnvironmentSpec{Name: "NODE_EXTRA_CA_CERTS", Value: f.Build.CACertBundle},                                      // Node.js
+			api.EnvironmentSpec{Name: "CURL_CA_BUNDLE", Value: f.Build.CACertBundle},                                           // curl
+			api.EnvironmentSpec{Name: "GIT_SSL_CAINFO", Value: f.Build.CACertBundle},                                           // git
+			api.EnvironmentSpec{Name: "PIP_CERT", Value: f.Build.CACertBundle},                                                 // pip (Python)
+			api.EnvironmentSpec{Name: "NPM_CONFIG_CAFILE", Value: f.Build.CACertBundle},                                        // npm (Node.js)
+			api.EnvironmentSpec{Name: "CARGO_HTTP_CAINFO", Value: f.Build.CACertBundle},                                        // cargo (Rust)
+			api.EnvironmentSpec{Name: "MAVEN_OPTS", Value: fmt.Sprintf("-Djavax.net.ssl.trustStore=%s", f.Build.CACertBundle)}, // Maven (Java)
+		)
+
+		// Mount the CA bundle file into the build container
+		cfg.BuildVolumes = append(cfg.BuildVolumes,
+			fmt.Sprintf("%s:%s:ro,Z", f.Build.CACertBundle, f.Build.CACertBundle))
+	}
+
 	if runtime.GOOS == "linux" {
 		cfg.DockerNetworkMode = "host"
 	}

--- a/schema/func_yaml-schema.json
+++ b/schema/func_yaml-schema.json
@@ -41,6 +41,10 @@
 					"type": "array",
 					"description": "Build Env variables to be set"
 				},
+				"caCertBundle": {
+					"type": "string",
+					"description": "Path to CA certificate bundle for SSL verification during build"
+				},
 				"pvcSize": {
 					"type": "string",
 					"description": "PVCSize specifies the size of persistent volume claim used to store function\nwhen using deployment and remote build process (only relevant when Remote is true)."

--- a/schema/func_yaml-schema.json
+++ b/schema/func_yaml-schema.json
@@ -41,9 +41,9 @@
 					"type": "array",
 					"description": "Build Env variables to be set"
 				},
-				"caCertBundle": {
+				"buildCACertFile": {
 					"type": "string",
-					"description": "Path to CA certificate bundle for SSL verification during build"
+					"description": "Path to CA certificate file for SSL verification during build (build-time only)"
 				},
 				"pvcSize": {
 					"type": "string",


### PR DESCRIPTION
This PR adds support for CA certificate bundles during function builds. Users behind corporate proxies with SSL inspection need this to build functions successfully.

The implementation adds three ways to specify a CA bundle:
- CLI flag: func build --ca-bundle /path/to/ca-bundle.crt
- Environment variable: FUNC_CA_BUNDLE=/path/to/ca-bundle.crt
- In func.yaml under build.caCertBundle

When a CA bundle is provided, it gets mounted into the build container and the appropriate environment variables are set for different language runtimes (Python, Node.js, Go, Java, Rust, etc). This works with both pack and s2i builders.

The implementation validates that the CA bundle file exists before starting the build and mounts it read-only into the container. I set environment variables like SSL_CERT_FILE, REQUESTS_CA_BUNDLE, NODE_EXTRA_CA_CERTS and others so the various build tools and package managers can find the certificates.

Fixes #3721
