### PR TITLE
feat(mcp): add check_prerequisites tool for environment validation

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -30,6 +30,7 @@ type Server struct {
 
 type executor interface {
 	Execute(ctx context.Context, subcommand string, args ...string) ([]byte, error)
+	ExecuteRaw(ctx context.Context, cmd string, args ...string) ([]byte, error)
 }
 
 type Option func(*Server)
@@ -105,6 +106,7 @@ func New(options ...Option) *Server {
 	mcp.AddTool(i, configEnvsListTool, s.configEnvsListHandler)
 	mcp.AddTool(i, configEnvsAddTool, s.configEnvsAddHandler)
 	mcp.AddTool(i, configEnvsRemoveTool, s.configEnvsRemoveHandler)
+	mcp.AddTool(i, checkPrerequisitesTool, s.checkPrerequisitesHandler)
 
 	// Resources
 	// ---------
@@ -126,6 +128,8 @@ func New(options ...Option) *Server {
 	i.AddResource(newHelpResource(s, "Deploy Help", "help for 'deploy'", "deploy"))
 	i.AddResource(newHelpResource(s, "List Help", "help for 'list'", "list"))
 	i.AddResource(newHelpResource(s, "Delete Help", "help for delete", "delete"))
+	i.AddResource(newHelpResource(s, "Check Prerequisites Help", "help for 'check_prerequisites'", "check_prerequisites"))
+
 
 	i.AddResource(newHelpResource(s, "Volumes Help", "general help for volumes", "config", "volumes"))
 	i.AddResource(newHelpResource(s, "Volumes Add Help", "help for 'config volumes add'", "config", "volumes", "add"))
@@ -161,6 +165,11 @@ func (e defaultExecutor) Execute(ctx context.Context, subcommand string, args ..
 	cmdParts := buildArgs(e.s.prefix, subcommand, args)
 	cmd := exec.CommandContext(ctx, cmdParts[0], cmdParts[1:]...)
 	// cmd.Dir not set - inherits process working directory which is the current working directory
+	return cmd.CombinedOutput()
+}
+
+func (e defaultExecutor) ExecuteRaw(ctx context.Context, cmdName string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, cmdName, args...)
 	return cmd.CombinedOutput()
 }
 

--- a/pkg/mcp/mock/executor.go
+++ b/pkg/mcp/mock/executor.go
@@ -9,6 +9,7 @@ import (
 type Executor struct {
 	ExecuteInvoked bool
 	ExecuteFn      func(context.Context, string, ...string) ([]byte, error)
+	ExecuteRawFn   func(context.Context, string, ...string) ([]byte, error)
 }
 
 // NewExecutor creates a new mock executor
@@ -23,6 +24,18 @@ func (m *Executor) Execute(ctx context.Context, subcommand string, args ...strin
 
 	if m.ExecuteFn != nil {
 		return m.ExecuteFn(ctx, subcommand, args...)
+	}
+
+	return []byte(""), nil
+}
+
+// ExecuteRaw implements the executor interface, recording invocation details
+// and delegating to ExecuteRawFn if provided.
+func (m *Executor) ExecuteRaw(ctx context.Context, cmd string, args ...string) ([]byte, error) {
+	m.ExecuteInvoked = true
+
+	if m.ExecuteRawFn != nil {
+		return m.ExecuteRawFn(ctx, cmd, args...)
 	}
 
 	return []byte(""), nil

--- a/pkg/mcp/tools_prerequisites.go
+++ b/pkg/mcp/tools_prerequisites.go
@@ -1,0 +1,148 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"knative.dev/func/pkg/config"
+	fn "knative.dev/func/pkg/functions"
+)
+
+var checkPrerequisitesTool = &mcp.Tool{
+	Name:        "check_prerequisites",
+	Title:       "Check Prerequisites",
+	Description: "Check if the environment is ready for Function development (Docker, Kubernetes, Knative, Registry).",
+	Annotations: &mcp.ToolAnnotations{
+		Title:          "Check Prerequisites",
+		ReadOnlyHint:   true,
+		IdempotentHint: true,
+	},
+}
+
+func (s *Server) checkPrerequisitesHandler(ctx context.Context, r *mcp.CallToolRequest, input CheckPrerequisitesInput) (result *mcp.CallToolResult, output CheckPrerequisitesOutput, err error) {
+	output.Checks = []CheckDetail{}
+	output.Ready = true
+
+	// 1. Check func binary version
+	s.runCheck(ctx, &output, "func", "Check if func CLI is installed", []string{"version"})
+
+	// 2. Check Docker/Podman daemon
+	s.runCheck(ctx, &output, "docker", "Check if Docker/Podman daemon is running", []string{"!docker", "info"})
+
+	// 3. Check Kubectl and Cluster connectivity
+	s.runCheck(ctx, &output, "cluster", "Check Kubernetes cluster connectivity", []string{"!kubectl", "cluster-info"})
+
+	// 4. Check Knative Serving CRDs
+	s.runCheck(ctx, &output, "knative", "Check if Knative Serving is installed", []string{"!kubectl", "get", "crd", "services.serving.knative.dev"})
+
+	// 5. Check Registry Configuration
+	s.runRegistryCheck(&output)
+
+	return
+}
+
+// runCheck is a helper to execute a check and update the output.
+// args starting with "!" are executed directly, others use the func prefix.
+func (s *Server) runCheck(ctx context.Context, output *CheckPrerequisitesOutput, name, description string, args []string) {
+	var out []byte
+	var err error
+
+	if strings.HasPrefix(args[0], "!") {
+		// Run external command directly (e.g. !kubectl)
+		cmd := args[0][1:]
+		out, err = s.executor.ExecuteRaw(ctx, cmd, args[1:]...)
+	} else {
+		// Run func subcommand
+		out, err = s.executor.Execute(ctx, args[0], args[1:]...)
+	}
+
+	detail := CheckDetail{
+		Component:   name,
+		Description: description,
+		Status:      "ok",
+		Message:     strings.TrimSpace(string(out)),
+	}
+
+	if err != nil {
+		output.Ready = false
+		detail.Status = "error"
+		detail.Message = fmt.Sprintf("Error: %v\n%s", err, strings.TrimSpace(string(out)))
+		detail.Guidance = getGuidance(name)
+	}
+
+	output.Checks = append(output.Checks, detail)
+}
+
+// runRegistryCheck validates that a container registry is configured
+// by reading the current Function's func.yaml or the global config.
+func (s *Server) runRegistryCheck(output *CheckPrerequisitesOutput) {
+	detail := CheckDetail{
+		Component:   "registry",
+		Description: "Check if a container registry is configured",
+		Status:      "ok",
+	}
+
+	// First, attempt to read the Function in the current directory
+	f, err := fn.NewFunction("")
+	if err == nil && f.Initialized() && f.Registry != "" {
+		detail.Message = fmt.Sprintf("Registry configured: %s", f.Registry)
+		output.Checks = append(output.Checks, detail)
+		return
+	}
+
+	// No local func.yaml or no registry in it; check global config
+	cfg, cfgErr := config.NewDefault()
+	if cfgErr == nil && cfg.Registry != "" {
+		detail.Message = fmt.Sprintf("Registry configured (global): %s", cfg.Registry)
+		output.Checks = append(output.Checks, detail)
+		return
+	}
+
+	// Neither local nor global config has a registry
+	detail.Status = "warning"
+	detail.Message = "No container registry configured in func.yaml or global config."
+	detail.Guidance = getGuidance("registry")
+	output.Checks = append(output.Checks, detail)
+}
+
+func getGuidance(component string) string {
+	switch component {
+	case "docker":
+		return "Ensure Docker Desktop or Podman is running. If using Linux, check 'systemctl status docker'."
+	case "cluster":
+		return "Verify your ~/.kube/config is valid and you have a running Kubernetes cluster (e.g. kind, minikube)."
+	case "knative":
+		return "Knative Serving is not detected. Please install Knative or use a cluster with Knative pre-installed."
+	case "func":
+		return "Ensure the 'func' binary is in your PATH."
+	case "registry":
+		return "Set a default registry with 'func config registry' or pass --registry to build/deploy."
+	default:
+		return ""
+	}
+}
+
+type CheckPrerequisitesInput struct {
+	Verbose *bool `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
+}
+
+type CheckPrerequisitesOutput struct {
+	Ready  bool          `json:"ready" jsonschema:"Whether all critical prerequisites are met"`
+	Checks []CheckDetail `json:"checks" jsonschema:"Detailed status of each prerequisite check"`
+}
+
+type CheckDetail struct {
+	Component   string `json:"component" jsonschema:"The component being checked (func, docker, cluster, knative, registry)"`
+	Description string `json:"description" jsonschema:"Description of what this check does"`
+	Status      string `json:"status" jsonschema:"Status of the check (ok, error, warning)"`
+	Message     string `json:"message" jsonschema:"Output message from the check command"`
+	Guidance    string `json:"guidance,omitempty" jsonschema:"Suggested actions to fix any errors"`
+}
+
+func (o CheckPrerequisitesOutput) String() string {
+	b, _ := json.MarshalIndent(o, "", "  ")
+	return string(b)
+}

--- a/pkg/mcp/tools_prerequisites_test.go
+++ b/pkg/mcp/tools_prerequisites_test.go
@@ -1,0 +1,188 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	fn "knative.dev/func/pkg/functions"
+	"knative.dev/func/pkg/mcp/mock"
+)
+
+// TestTool_CheckPrerequisites verifies that when all external commands succeed
+// and a Function with a registry is present, all checks pass and ready is true.
+func TestTool_CheckPrerequisites(t *testing.T) {
+	// Set up a temp dir with a valid func.yaml so the registry check passes
+	root := t.TempDir()
+	cwd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	_ = os.Chdir(root)
+
+	// Initialize a function with a registry configured
+	f := fn.Function{
+		Name:     "test-func",
+		Runtime:  "go",
+		Registry: "docker.io/testuser",
+		Root:     ".",
+	}
+	if _, err := fn.New().Init(f); err != nil {
+		t.Fatal(err)
+	}
+
+	executor := mock.NewExecutor()
+
+	// Mock for func subcommands (Execute)
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		if subcommand == "version" {
+			return []byte("v1.25.7"), nil
+		}
+		return []byte(""), nil
+	}
+
+	// Mock for raw commands (ExecuteRaw)
+	executor.ExecuteRawFn = func(ctx context.Context, cmd string, args ...string) ([]byte, error) {
+		switch cmd {
+		case "docker":
+			return []byte("Docker version 27.0.0"), nil
+		case "kubectl":
+			if len(args) > 0 && args[0] == "cluster-info" {
+				return []byte("Kubernetes control plane is running at https://127.0.0.1:6443"), nil
+			}
+			if len(args) > 2 && args[0] == "get" && args[2] == "services.serving.knative.dev" {
+				return []byte("customresourcedefinition.apiextensions.k8s.io/services.serving.knative.dev reconciled"), nil
+			}
+		}
+		return []byte(""), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "check_prerequisites",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+
+	content := resultToString(result)
+	if !strings.Contains(content, "v1.25.7") {
+		t.Errorf("expected output to contain func version, got: %s", content)
+	}
+	if !strings.Contains(content, "Docker version 27.0.0") {
+		t.Errorf("expected output to contain docker info, got: %s", content)
+	}
+	if !strings.Contains(content, "Kubernetes control plane") {
+		t.Errorf("expected output to contain cluster info, got: %s", content)
+	}
+	if !strings.Contains(content, "services.serving.knative.dev") {
+		t.Errorf("expected output to contain knative check, got: %s", content)
+	}
+	if !strings.Contains(content, "docker.io/testuser") {
+		t.Errorf("expected output to contain registry, got: %s", content)
+	}
+	if !strings.Contains(content, `"ready"`) {
+		t.Errorf("expected output to contain ready field, got: %s", content)
+	}
+}
+
+// TestTool_CheckPrerequisites_DockerFailure verifies that when Docker is not
+// running, the check reports an error with guidance.
+func TestTool_CheckPrerequisites_DockerFailure(t *testing.T) {
+	root := t.TempDir()
+	cwd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	_ = os.Chdir(root)
+
+	executor := mock.NewExecutor()
+
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte("v1.25.7"), nil
+	}
+
+	executor.ExecuteRawFn = func(ctx context.Context, cmd string, args ...string) ([]byte, error) {
+		if cmd == "docker" {
+			return []byte("Cannot connect to the Docker daemon"), fmt.Errorf("exit status 1")
+		}
+		// kubectl checks pass
+		if cmd == "kubectl" {
+			return []byte("OK"), nil
+		}
+		return []byte(""), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "check_prerequisites",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := resultToString(result)
+
+	// Should report docker error
+	if !strings.Contains(content, "Cannot connect to the Docker daemon") {
+		t.Errorf("expected docker error in output, got: %s", content)
+	}
+	// Should include guidance
+	if !strings.Contains(content, "Docker Desktop") {
+		t.Errorf("expected docker guidance in output, got: %s", content)
+	}
+}
+
+// TestTool_CheckPrerequisites_NoRegistry verifies that when no registry is
+// configured, the check reports a warning with guidance.
+func TestTool_CheckPrerequisites_NoRegistry(t *testing.T) {
+	// Use a temp dir with NO func.yaml
+	root := t.TempDir()
+	cwd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	_ = os.Chdir(root)
+
+	executor := mock.NewExecutor()
+
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte("v1.25.7"), nil
+	}
+
+	executor.ExecuteRawFn = func(ctx context.Context, cmd string, args ...string) ([]byte, error) {
+		return []byte("OK"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "check_prerequisites",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := resultToString(result)
+
+	// Should report registry warning
+	if !strings.Contains(content, "No container registry configured") {
+		t.Errorf("expected registry warning in output, got: %s", content)
+	}
+	// Should include registry guidance
+	if !strings.Contains(content, "func config registry") {
+		t.Errorf("expected registry guidance in output, got: %s", content)
+	}
+}


### PR DESCRIPTION
````markdown id="5rvj74"
# Changes

- :gift: Add new MCP tool `check_prerequisites` for environment validation
- :broom: Extend executor interface with `ExecuteRaw()` for non-func command execution
- :broom: Add test coverage for prerequisite validation scenarios

/kind enhancement

Fixes #3749 
Relates to #3646

---

## Summary

This PR adds a new MCP tool `check_prerequisites` that enables agents to proactively validate a developer environment before attempting build or deployment operations.

The current MCP `healthcheck` tool only validates that the `func` binary is available. However, many deployment failures originate from missing or unhealthy dependencies such as Docker, Kubernetes connectivity, Knative Serving, or registry configuration.

This tool provides structured readiness checks along with actionable guidance that agents can relay directly to users.

---

## What This PR Adds

Implemented `check_prerequisites` in:

```text id="l87mll"
pkg/mcp/tools_prerequisites.go
````

The tool performs validation for:

1. `func` CLI availability
2. Docker/Podman runtime accessibility
3. Kubernetes cluster connectivity
4. Knative Serving CRD availability
5. Registry configuration presence

Each check returns:

* status (`ok`, `warning`, `error`)
* validation message
* optional remediation guidance

Example agent response enabled by this change:

> Docker appears to be installed, but the daemon is not running. Please start Docker Desktop before proceeding.

---

## Example Response

```json id="lt5aj7"
{
  "ready": false,
  "checks": [
    {
      "component": "docker",
      "description": "Check if Docker/Podman daemon is running",
      "status": "error",
      "message": "Error: exit status 1\nCannot connect to the Docker daemon",
      "guidance": "Ensure Docker Desktop or Podman is running. If using Linux, check 'systemctl status docker'."
    }
  ]
}
```

---

## Internal Changes

* Extended the executor interface with `ExecuteRaw()` to support external command execution
* Updated `mock.Executor` with `ExecuteRawFn` for test support

---

## Tests Added

* `TestTool_CheckPrerequisites`
* `TestTool_CheckPrerequisites_DockerFailure`
* `TestTool_CheckPrerequisites_NoRegistry`

All existing tests continue to pass:

```bash id="ll1vdm"
go test -v ./pkg/mcp/...
```

---

**Release Note**

```release-note id="m8zhte"
Added MCP `check_prerequisites` tool to validate local environment readiness for build and deployment workflows.
```

