### PR TITLE
fix(mcp): validate prefix in WithPrefix to reject shell metacharacters

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"strings"
 
@@ -34,9 +35,20 @@ type executor interface {
 
 type Option func(*Server)
 
-// WithPrefix sets the command prefix (e.g., "func" or "kn func")
+// disallowedPrefixChars contains shell metacharacters that must not appear
+// in the command prefix to prevent command injection.
+const disallowedPrefixChars = "&|;`$(){}[]!><\"'\\\n\r"
+
+// WithPrefix sets the command prefix (e.g., "func" or "kn func").
+// The prefix is validated to reject shell metacharacters.
 func WithPrefix(prefix string) Option {
 	return func(s *Server) {
+		if strings.ContainsAny(prefix, disallowedPrefixChars) {
+			panic(fmt.Sprintf("mcp: prefix %q contains disallowed shell metacharacters", prefix))
+		}
+		if strings.TrimSpace(prefix) == "" {
+			panic("mcp: prefix must not be empty or whitespace-only")
+		}
 		s.prefix = prefix
 	}
 }

--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -180,3 +180,44 @@ func TestBuildArgs(t *testing.T) {
 		})
 	}
 }
+
+// TestWithPrefix_Validation ensures that WithPrefix rejects shell
+// metacharacters and empty/whitespace-only prefixes.
+func TestWithPrefix_Validation(t *testing.T) {
+	// Valid prefixes should not panic.
+	validCases := []string{"func", "kn func", "/usr/local/bin/func"}
+	for _, prefix := range validCases {
+		t.Run("valid_"+prefix, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("WithPrefix(%q) panicked unexpectedly: %v", prefix, r)
+				}
+			}()
+			New(WithPrefix(prefix))
+		})
+	}
+
+	// Invalid prefixes containing shell metacharacters should panic.
+	invalidCases := []struct {
+		name   string
+		prefix string
+	}{
+		{"semicolon", "func; rm -rf /"},
+		{"pipe", "func | cat"},
+		{"ampersand", "func & bg"},
+		{"backtick", "func `whoami`"},
+		{"dollar_paren", "func $(whoami)"},
+		{"empty", ""},
+		{"whitespace_only", "   "},
+	}
+	for _, tc := range invalidCases {
+		t.Run("invalid_"+tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Fatalf("WithPrefix(%q) should have panicked but did not", tc.prefix)
+				}
+			}()
+			New(WithPrefix(tc.prefix))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3757

The `buildArgs` function passes the prefix directly to `exec.CommandContext` via `strings.Fields` splitting. The `WithPrefix()` option does not validate the prefix string, so a caller could provide a value containing shell metacharacters or a path to an arbitrary binary.

While `exec.CommandContext` does not invoke a shell (limiting the blast radius), the lack of any validation means arbitrary binary paths can be injected as the first field of the prefix.

## Changes

- **`pkg/mcp/mcp.go`**: Add `disallowedPrefixChars` constant and validation in `WithPrefix()` that panics on shell metacharacters or empty/whitespace-only prefixes.
- **`pkg/mcp/mcp_test.go`**: Add `TestWithPrefix_Validation` covering valid prefixes (`func`, `kn func`, absolute paths) and invalid prefixes (semicolons, pipes, backticks, empty strings).

## Testing

```
go test ./pkg/mcp/... -count=1    # PASS
```
