### PR TITLE
fix(cmd): return error when config add flags are partially provided

### DIFF
--- a/cmd/config_envs.go
+++ b/cmd/config_envs.go
@@ -120,6 +120,9 @@ set environment variable from a secret
 			}
 
 			if np != nil || vp != nil {
+				if np != nil && vp == nil {
+					return fmt.Errorf("--value is required when --name is provided")
+				}
 				if np != nil {
 					if err := utils.ValidateEnvVarName(*np); err != nil {
 						return err

--- a/cmd/config_labels.go
+++ b/cmd/config_labels.go
@@ -92,6 +92,13 @@ the local machine.
 				return loaderSaver.Save(function)
 			}
 
+			if np != nil {
+				return fmt.Errorf("--value is required when --name is provided")
+			}
+			if vp != nil {
+				return fmt.Errorf("--name is required when --value is provided")
+			}
+
 			return runAddLabelsPrompt(cmd.Context(), function, loaderSaver)
 		},
 	}

--- a/cmd/config_labels.go
+++ b/cmd/config_labels.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -93,10 +94,10 @@ the local machine.
 			}
 
 			if np != nil {
-				return fmt.Errorf("--value is required when --name is provided")
+				return errors.New("--value is required when --name is provided")
 			}
 			if vp != nil {
-				return fmt.Errorf("--name is required when --value is provided")
+				return errors.New("--name is required when --value is provided")
 			}
 
 			return runAddLabelsPrompt(cmd.Context(), function, loaderSaver)

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -113,6 +113,82 @@ func TestListEnvAdd(t *testing.T) {
 	}
 }
 
+// TestEnvsAddNameWithoutValue ensures that providing --name without --value returns an error
+// rather than silently writing a broken fn.Env{Name: &key, Value: nil} to func.yaml.
+func TestEnvsAddNameWithoutValue(t *testing.T) {
+	mock := common.NewMockLoaderSaver()
+	mock.LoadFn = func(path string) (fn.Function, error) {
+		return fn.Function{}, nil
+	}
+	mock.SaveFn = func(f fn.Function) error {
+		t.Error("Save must not be called when validation fails")
+		return nil
+	}
+
+	cmd := setupConfigEnvCmd(mock, "add", "--name=API_KEY")
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --name is provided without --value, got nil")
+	}
+}
+
+func setupConfigLabelsCmd(mock common.FunctionLoaderSaver, args ...string) *cobra.Command {
+	cmd := fnCmd.NewConfigCmd(
+		mock,
+		ci.NewBufferWriter(),
+		common.CurrentBranchStub("", nil),
+		common.WorkDirStub("", nil),
+		fnCmd.NewClient,
+	)
+	cmd.SetArgs(append([]string{"labels"}, args...))
+	return cmd
+}
+
+// TestLabelsAddNameWithoutValue ensures that providing --name without --value returns an error.
+func TestLabelsAddNameWithoutValue(t *testing.T) {
+	mock := common.NewMockLoaderSaver()
+	mock.LoadFn = func(path string) (fn.Function, error) {
+		return fn.Function{}, nil
+	}
+	mock.SaveFn = func(f fn.Function) error {
+		t.Error("Save must not be called when validation fails")
+		return nil
+	}
+
+	cmd := setupConfigLabelsCmd(mock, "add", "--name=env")
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --name is provided without --value, got nil")
+	}
+}
+
+// TestLabelsAddValueWithoutName ensures that providing --value without --name returns an error.
+func TestLabelsAddValueWithoutName(t *testing.T) {
+	mock := common.NewMockLoaderSaver()
+	mock.LoadFn = func(path string) (fn.Function, error) {
+		return fn.Function{}, nil
+	}
+	mock.SaveFn = func(f fn.Function) error {
+		t.Error("Save must not be called when validation fails")
+		return nil
+	}
+
+	cmd := setupConfigLabelsCmd(mock, "add", "--value=prod")
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --value is provided without --name, got nil")
+	}
+}
+
 func envsEqual(a, b []fn.Env) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## Problem

`config envs add --name=KEY` (without `--value`) silently writes
`fn.Env{Name: &"KEY", Value: nil}` to `func.yaml`. This entry is invisible
in `config envs list`, renders as `KEY=` (empty string) at deploy time, and
fails `ValidateEnvs` at build time with "env entry #N is missing value
field". The OR condition in the non-interactive guard allowed the partial
set to bypass the interactive prompt and go straight to Save.

`config labels add --name=Foo` (without `--value`) silently drops the flag
and launches the interactive prompt with no explanation, because the AND
condition means the non-interactive block is never entered.

## Changes

**`cmd/config_envs.go`**
- Added guard: if `--name` is provided but `--value` is not, return
  `--value is required when --name is provided` before calling Save.
- Bulk-import usage (`--value='{{ secret:S }}'` without `--name`) is
  unaffected — the guard only triggers when name is set and value is nil.

**`cmd/config_labels.go`**
- Added guards before the interactive fallback: if only `--name` or only
  `--value` is provided, return a clear error rather than silently entering
  interactive mode.

## Tests

Added to `cmd/config_test.go`:
- `TestEnvsAddNameWithoutValue` — verifies error is returned and Save is
  not called.
- `TestLabelsAddNameWithoutValue` — verifies error when `--name` is given
  without `--value`.
- `TestLabelsAddValueWithoutName` — verifies error when `--value` is given
  without `--name`.