### PR TITLE
fix: use non-root group for dialer and volume-uploader pods

### DIFF
--- a/pkg/k8s/security_context.go
+++ b/pkg/k8s/security_context.go
@@ -11,11 +11,6 @@ import (
 // SeccompProfile is set at both pod and container level (see defaultSecurityContext)
 // as defence-in-depth: pod-level covers all containers by default, container-level
 // ensures compliance even if a pod-level context is ever overridden downstream.
-//
-// RunAsGroup: 0 (root group) is retained on non-OpenShift to preserve compatibility
-// with Tekton buildpack tasks that mount volumes with group ownership 0.
-// This does not violate the restricted profile (which checks UID, not GID) but is
-// tracked for remediation in https://github.com/knative/func/issues/3517.
 func defaultPodSecurityContext() *corev1.PodSecurityContext {
 	runAsNonRoot := true
 	seccompProfile := &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}
@@ -31,8 +26,8 @@ func defaultPodSecurityContext() *corev1.PodSecurityContext {
 	}
 
 	runAsUser := int64(1001)
-	runAsGroup := int64(0) // Match Tekton buildpack task group; see doc comment above.
-	fsGroup := int64(1002) // Keep FSGroup for volume ownership
+	runAsGroup := int64(1001) // Use non-root group for better security
+	fsGroup := int64(1002)    // Keep FSGroup for volume ownership
 	return &corev1.PodSecurityContext{
 		RunAsNonRoot:   &runAsNonRoot,
 		SeccompProfile: seccompProfile,


### PR DESCRIPTION

This PR completes the fix for issue #3517 by changing `RunAsGroup` from 0 (root group) to 1001 (non-root group) for dialer and volume-uploader pods.

## Background

PR #3614 partially fixed #3517 by adding all required fields for the Kubernetes restricted pod security profile. However, it left `RunAsGroup: 0` with a comment saying it was needed for Tekton buildpack compatibility and tracked for future remediation.

After testing, using `RunAsGroup: 1001` works fine with Tekton tasks, so we can complete the fix now.

## Changes

- Changed `RunAsGroup` from `0` to `1001` in `defaultPodSecurityContext()`
- Removed the comment about tracking this in #3517
- Updated comment to reflect the change

## Why This Matters

While `RunAsGroup: 0` doesn't violate the Kubernetes restricted pod security profile (which only checks UID, not GID), using a non-root group is a security best practice. This change improves the security posture of dialer and volume-uploader pods.

## Testing

- All existing tests pass including `TestRestrictedProfileCompliance`
- Linting passes (`make check`)
- The change affects both dialer pods (used for SSH connections) and volume-uploader pods (used for on-cluster builds)

## Related

- Fixes #3517
- Builds on PR #3614