### PR TITLE
fix(k8s): thread caller ctx into DialContext exec goroutine

### DIFF
--- a/pkg/k8s/dialer.go
+++ b/pkg/k8s/dialer.go
@@ -81,7 +81,7 @@ func (c *contextDialer) DialContext(ctx context.Context, network string, addr st
 		stderrBuff := bytes.NewBuffer(nil)
 		ctrStderr := io.MultiWriter(stderrBuff, detectConnSuccess(connectSuccess))
 
-		err := c.exec(context.TODO(), addr, ctrStdin, ctrStdout, ctrStderr)
+		err := c.exec(ctx, addr, ctrStdin, ctrStdout, ctrStderr)
 		if err != nil {
 			stderrStr := stderrBuff.String()
 			socatErr := tryParseSocatError(network, addr, stderrStr)


### PR DESCRIPTION
# Changes

`DialContext` receives `ctx` as a parameter and the outer `select` watches `<-ctx.Done()` to return early when the caller cancels. The exec goroutine spawned at line 80, however, called `c.exec(context.TODO(), ...)` rather than passing `ctx`. On caller cancellation, `DialContext` returns immediately, but the goroutine keeps running and the exec stream against kube-apiserver stays open for the lifetime of the parent process.

Pass `ctx` to `c.exec`. The outer select still races `connectFailure` against `ctx.Done()` and `conn.closeWithError` is idempotent across both paths.

`Dial` at line 323 is unchanged. That `attach` goroutine is intentionally long-lived (held open by `emptyBlockingReader` waiting on the detach signal) and must outlive the `Dial` call.

/kind bug

```release-note
fix: k8s dialer exec goroutine now exits on caller cancellation
```
