### PR TITLE
cleanup: replace docker.io image references with ghcr.io mirrors

### DIFF
--- a/hack/cmd/update-builder/main.go
+++ b/hack/cmd/update-builder/main.go
@@ -512,7 +512,7 @@ func addRustBuildpack(config *builder.Config) {
 				Version: "0.65.0",
 			},
 			ImageOrURI: dist.ImageOrURI{
-				BuildpackURI: dist.BuildpackURI{URI: "docker://docker.io/paketocommunity/rust:0.65.0"},
+				BuildpackURI: dist.BuildpackURI{URI: "docker://ghcr.io/paketocommunity/rust:0.65.0"},
 			},
 		},
 	}
@@ -553,7 +553,7 @@ func updateJavaBuildpacks(ctx context.Context, builderConfig *builder.Config, ar
 				return fmt.Errorf("cannot build %q buildpack: %w", bp, err)
 			}
 			for i := range builderConfig.Buildpacks {
-				if strings.HasPrefix(builderConfig.Buildpacks[i].URI, "docker://docker.io/paketobuildpacks/"+bp+":") {
+				if strings.HasPrefix(builderConfig.Buildpacks[i].URI, "docker://ghcr.io/paketobuildpacks/"+bp+":") {
 					builderConfig.Buildpacks[i].URI = "docker://ghcr.io/knative/buildpacks/" + bp + ":" + entry.Group[0].Version
 				}
 			}
@@ -578,7 +578,7 @@ func addQuarkusBuildpack(packageDesc *buildpackage.Config, bpDesc *dist.Buildpac
 
 	packageDesc.Dependencies = append(packageDesc.Dependencies, dist.ImageOrURI{
 		BuildpackURI: dist.BuildpackURI{
-			URI: "docker://index.docker.io/paketobuildpacks/quarkus:" + latestQuarkusVersion,
+			URI: "docker://ghcr.io/paketobuildpacks/quarkus:" + latestQuarkusVersion,
 		},
 	})
 	quarkusBP := dist.ModuleRef{


### PR DESCRIPTION
Closes #2720

## Summary

- Replace `docker://docker.io/paketocommunity/rust:0.65.0` with `docker://ghcr.io/paketocommunity/rust:0.65.0` in `addRustBuildpack`
- Update the `HasPrefix` check in `updateJavaBuildpacks` from `docker://docker.io/paketobuildpacks/` to `docker://ghcr.io/paketobuildpacks/` to match the upstream builder config which has already migrated to ghcr
- Replace `docker://index.docker.io/paketobuildpacks/quarkus:` with `docker://ghcr.io/paketobuildpacks/quarkus:` in `addQuarkusBuildpack`

## Motivation

Hard-coding docker.io URIs exposes CI and builds to Docker Hub rate limits and creates a dependency on an external registry the project does not control. The project already uses ghcr.io for its own images. This change consolidates on ghcr.io for paketo buildpack references in the builder update tooling.

## Notes

`pkg/oci/python_builder.go` uses `python:3.13-slim` which still implicitly resolves to docker.io since there is no ghcr.io mirror for the official Python base image. Addressing that is left as a separate maintainer decision per the issue thread.