### PR TITLE
fix: forward CLI overrides to in-cluster deploy for Git-based remote deploys

### DIFF
--- a/cmd/func-util/main.go
+++ b/cmd/func-util/main.go
@@ -153,6 +153,22 @@ func deploy(ctx context.Context) error {
 	if f.Deploy.Image == "" {
 		f.Deploy.Image = f.Image
 	}
+
+	// For Git-based remote deploys the on-cluster func.yaml comes from the
+	// committed repo and never contains CLI overrides supplied by the user
+	// (--image-pull-secret, --service-account, --deployer).  The pipeline run
+	// forwards those overrides as environment variables so they can be applied
+	// here before deploying.
+	if v := os.Getenv("FUNC_IMAGE_PULL_SECRET"); v != "" {
+		f.Deploy.ImagePullSecret = v
+	}
+	if v := os.Getenv("FUNC_SERVICE_ACCOUNT"); v != "" {
+		f.Deploy.ServiceAccountName = v
+	}
+	if v := os.Getenv("FUNC_DEPLOYER"); v != "" {
+		f.Deploy.Deployer = v
+	}
+
 	if f.Deploy.Deployer == "" {
 		f.Deploy.Deployer = knative.KnativeDeployerName
 	}

--- a/pkg/pipelines/tekton/task-buildpack.yaml.tmpl
+++ b/pkg/pipelines/tekton/task-buildpack.yaml.tmpl
@@ -67,6 +67,15 @@ spec:
     - name: COMMIT
       description: Git commit SHA of the function source
       default: ""
+    - name: IMAGE_PULL_SECRET
+      description: Image pull secret name forwarded from the CLI to the in-cluster deploy step
+      default: ""
+    - name: SERVICE_ACCOUNT
+      description: Service account name forwarded from the CLI to the in-cluster deploy step
+      default: ""
+    - name: DEPLOYER
+      description: Deployer type forwarded from the CLI to the in-cluster deploy step (knative, raw, keda)
+      default: ""
   stepTemplate:
     env:
       - name: CNB_PLATFORM_API
@@ -292,6 +301,13 @@ spec:
     - name: func-deploy
       image: '{{.DeployerImage}}'
       workingDir: $(workspaces.source.path)
+      env:
+        - name: FUNC_IMAGE_PULL_SECRET
+          value: $(params.IMAGE_PULL_SECRET)
+        - name: FUNC_SERVICE_ACCOUNT
+          value: $(params.SERVICE_ACCOUNT)
+        - name: FUNC_DEPLOYER
+          value: $(params.DEPLOYER)
       command: ["deploy", $(params.SOURCE_SUBPATH), "$(params.APP_IMAGE)"]
   volumes:
     - name: empty-dir

--- a/pkg/pipelines/tekton/task-s2i.yaml.tmpl
+++ b/pkg/pipelines/tekton/task-s2i.yaml.tmpl
@@ -45,6 +45,15 @@ spec:
     - name: COMMIT
       description: Git commit SHA of the function source
       default: ""
+    - name: IMAGE_PULL_SECRET
+      description: Image pull secret name forwarded from the CLI to the in-cluster deploy step
+      default: ""
+    - name: SERVICE_ACCOUNT
+      description: Service account name forwarded from the CLI to the in-cluster deploy step
+      default: ""
+    - name: DEPLOYER
+      description: Deployer type forwarded from the CLI to the in-cluster deploy step (knative, raw, keda)
+      default: ""
   workspaces:
     - name: source
     - name: cache
@@ -148,6 +157,13 @@ spec:
     - name: func-deploy
       image: '{{.DeployerImage}}'
       workingDir: $(workspaces.source.path)
+      env:
+        - name: FUNC_IMAGE_PULL_SECRET
+          value: $(params.IMAGE_PULL_SECRET)
+        - name: FUNC_SERVICE_ACCOUNT
+          value: $(params.SERVICE_ACCOUNT)
+        - name: FUNC_DEPLOYER
+          value: $(params.DEPLOYER)
       command: ["deploy", $(params.PATH_CONTEXT), "$(params.IMAGE)"]
   volumes:
     - emptyDir: {}

--- a/pkg/pipelines/tekton/templates.go
+++ b/pkg/pipelines/tekton/templates.go
@@ -93,6 +93,14 @@ type templateData struct {
 
 	// Git commit SHA of the function source
 	Commit string
+
+	// CLI overrides forwarded to the in-cluster func-deploy task step.
+	// For Git-based remote deploys the on-cluster func.yaml comes from the
+	// committed repo and never contains these values; they must be threaded
+	// through the pipeline run as discrete params.
+	ImagePullSecret    string
+	ServiceAccountName string
+	Deployer           string
 }
 
 // createPipelineTemplatePAC creates a Pipeline template used for PAC on-cluster build
@@ -412,6 +420,10 @@ func createAndApplyPipelineRunTemplate(f fn.Function, namespace string, labels m
 
 		RepoUrl:  f.Build.Git.URL,
 		Revision: pipelinesTargetBranch,
+
+		ImagePullSecret:    f.Deploy.ImagePullSecret,
+		ServiceAccountName: f.Deploy.ServiceAccountName,
+		Deployer:           f.Deploy.Deployer,
 	}
 
 	var template string

--- a/pkg/pipelines/tekton/templates_pack.go
+++ b/pkg/pipelines/tekton/templates_pack.go
@@ -44,6 +44,18 @@ spec:
       name: commit
       default: ''
       type: string
+    - description: Image pull secret name forwarded to the in-cluster deploy step
+      name: imagePullSecret
+      default: ''
+      type: string
+    - description: Service account name forwarded to the in-cluster deploy step
+      name: serviceAccount
+      default: ''
+      type: string
+    - description: Deployer type forwarded to the in-cluster deploy step (knative, raw, keda)
+      name: deployer
+      default: ''
+      type: string
   tasks:
     - name: build
       params:
@@ -64,6 +76,12 @@ spec:
             - '$(params.buildEnvs[*])'
         - name: COMMIT
           value: $(params.commit)
+        - name: IMAGE_PULL_SECRET
+          value: $(params.imagePullSecret)
+        - name: SERVICE_ACCOUNT
+          value: $(params.serviceAccount)
+        - name: DEPLOYER
+          value: $(params.deployer)
         {{- if eq .TlsVerify "false"}}
         - name: INSECURE_REGISTRIES
           value: $(params.registry)
@@ -123,6 +141,12 @@ spec:
         {{end}}
     - name: commit
       value: "{{.Commit}}"
+    - name: imagePullSecret
+      value: "{{.ImagePullSecret}}"
+    - name: serviceAccount
+      value: "{{.ServiceAccountName}}"
+    - name: deployer
+      value: "{{.Deployer}}"
   pipelineRef:
    name: {{.PipelineName}}
   podTemplate:

--- a/pkg/pipelines/tekton/templates_s2i.go
+++ b/pkg/pipelines/tekton/templates_s2i.go
@@ -52,6 +52,18 @@ spec:
       name: commit
       default: ''
       type: string
+    - description: Image pull secret name forwarded to the in-cluster deploy step
+      name: imagePullSecret
+      default: ''
+      type: string
+    - description: Service account name forwarded to the in-cluster deploy step
+      name: serviceAccount
+      default: ''
+      type: string
+    - description: Deployer type forwarded to the in-cluster deploy step (knative, raw, keda)
+      name: deployer
+      default: ''
+      type: string
   tasks:
     - name: build
       params:
@@ -76,6 +88,12 @@ spec:
           value: $(params.tlsVerify)
         - name: COMMIT
           value: $(params.commit)
+        - name: IMAGE_PULL_SECRET
+          value: $(params.imagePullSecret)
+        - name: SERVICE_ACCOUNT
+          value: $(params.serviceAccount)
+        - name: DEPLOYER
+          value: $(params.deployer)
       {{.FuncS2iTaskRef}}
       workspaces:
         - name: source
@@ -134,6 +152,12 @@ spec:
       value: {{.TlsVerify}}
     - name: commit
       value: "{{.Commit}}"
+    - name: imagePullSecret
+      value: "{{.ImagePullSecret}}"
+    - name: serviceAccount
+      value: "{{.ServiceAccountName}}"
+    - name: deployer
+      value: "{{.Deployer}}"
   pipelineRef:
    name: {{.PipelineName}}
   podTemplate:


### PR DESCRIPTION
Fixes #3768

## Problem

When `func deploy` uses a Git-based pipeline (`f.Build.Git.URL` is set), CLI flags like `--image-pull-secret`, `--service-account`, and `--deployer` are silently ignored. The on-cluster `func-deploy` task step reads `func.yaml` directly from the cloned Git repo, which never contains in-memory CLI overrides — unlike the PVC-upload path fixed by #3663.

## Solution

Forward the three CLI overrides as discrete Tekton params on the pipeline run and apply them as environment variables on the `func-deploy` task step. The in-cluster `deploy` binary reads these env vars and applies them over the values loaded from `func.yaml`.

## How it works

```
func deploy --image-pull-secret my-secret --deployer raw
  → templateData.ImagePullSecret / Deployer populated
  → PipelineRun param: imagePullSecret=my-secret, deployer=raw
  → Pipeline threads params to Task: IMAGE_PULL_SECRET, DEPLOYER
  → func-deploy step env: FUNC_IMAGE_PULL_SECRET, FUNC_DEPLOYER
  → deploy binary: os.Getenv overrides f loaded from committed func.yaml
```

The env vars are only applied when non-empty, so existing behaviour is unchanged when no overrides are passed.

## Changes

- `cmd/func-util/main.go` — read `FUNC_IMAGE_PULL_SECRET`, `FUNC_SERVICE_ACCOUNT`, `FUNC_DEPLOYER` env vars after loading `func.yaml` and apply them over the struct before deploying
- `task-buildpack.yaml.tmpl` / `task-s2i.yaml.tmpl` — add `IMAGE_PULL_SECRET`, `SERVICE_ACCOUNT`, `DEPLOYER` params; set corresponding `FUNC_*` env vars on the `func-deploy` step
- `templates_pack.go` / `templates_s2i.go` — add the three params to the Pipeline spec and thread them to the task; add them to the PipelineRun params
- `templates.go` — add `ImagePullSecret`, `ServiceAccountName`, `Deployer` to `templateData`; populate from `f.Deploy.*` in `createAndApplyPipelineRunTemplate`

## Notes

- The `DeployerImage` is `scratch`-based with no shell, so env vars are used instead of a bash script with conditional flag appending.
- This is the Git-path equivalent of #3663, which fixed the same bug for the PVC-upload path.