### PR TITLE
fix: make MCP readonly state immutable after construction

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -95,7 +95,7 @@ DESCRIPTION
 	return cmd
 }
 
-func runMCPStart(cmd *cobra.Command, args []string, newClient ClientFactory) error {
+func runMCPStart(cmd *cobra.Command, args []string, newClient ClientFactory, extraMCPOpts ...mcp.Option) error {
 	// Configure write mode
 	writeEnabled := false
 	if val := os.Getenv("FUNC_ENABLE_MCP_WRITE"); val != "" {
@@ -110,14 +110,14 @@ func runMCPStart(cmd *cobra.Command, args []string, newClient ClientFactory) err
 	rootCmd := cmd.Root()
 	cmdPrefix := rootCmd.Use
 
-	// Instantiate
+	mcpOpts := []mcp.Option{
+		mcp.WithPrefix(cmdPrefix),
+		mcp.WithReadonly(!writeEnabled),
+	}
+	mcpOpts = append(mcpOpts, extraMCPOpts...)
 	client, done := newClient(ClientConfig{},
-		fn.WithMCPServer(mcp.New(
-			mcp.WithPrefix(cmdPrefix),
-			mcp.WithReadonly(!writeEnabled))))
+		fn.WithMCPServer(mcp.New(mcpOpts...)))
 	defer done()
 
-	// Start
-	return client.StartMCPServer(cmd.Context(), writeEnabled)
-
+	return client.StartMCPServer(cmd.Context())
 }

--- a/cmd/mcp_test.go
+++ b/cmd/mcp_test.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
-	"context"
 	"testing"
 
+	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	fn "knative.dev/func/pkg/functions"
+	"knative.dev/func/pkg/mcp"
 	"knative.dev/func/pkg/mock"
 	. "knative.dev/func/pkg/testing"
 )
@@ -30,37 +31,95 @@ func TestMCP_Start(t *testing.T) {
 	}
 }
 
-// TestMCP_StartWriteable ensures that the server is started with write
-// enabled only when the environment variable FUNC_ENABLE_MCP_WRITE is set.
+// passthroughClientFactory is a ClientFactory that applies all options
+// provided at invocation time (i.e. by the command itself) to the client,
+// rather than substituting its own. This allows runMCPStart to construct
+// and inject its own mcp.Server, which the test then exercises directly.
+func passthroughClientFactory(_ ClientConfig, options ...fn.Option) (*fn.Client, func()) {
+	return fn.New(options...), func() {}
+}
+
+// TestMCP_StartWriteable ensures the server is started with write enabled only
+// when FUNC_ENABLE_MCP_WRITE is set. Tool capability is verified behaviorally
+// by connecting a real MCP client over an in-memory transport to the server
+// that runMCPStart constructs.
 func TestMCP_StartWriteable(t *testing.T) {
 	_ = FromTempDirectory(t)
 
-	// Ensure it defaults to off.
-	server := mock.NewMCPServer()
-	server.StartFn = func(_ context.Context, writeEnabled bool) error {
-		if writeEnabled {
-			t.Fatal("MCP server started write-enabled by default")
-		}
-		return nil
-	}
-	cmd := NewMCPCmd(NewTestClient(fn.WithMCPServer(server)))
-	cmd.SetArgs([]string{"start"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name       string
+		envVal     string
+		wantDeploy bool
+		wantDelete bool
+	}{
+		{
+			name:       "readonly by default",
+			wantDeploy: false,
+			wantDelete: false,
+		},
+		{
+			name:       "writeable when FUNC_ENABLE_MCP_WRITE=true",
+			envVal:     "true",
+			wantDeploy: true,
+			wantDelete: true,
+		},
 	}
 
-	// Ensure it is set to true on proper truthy value
-	t.Setenv("FUNC_ENABLE_MCP_WRITE", "true")
-	server = mock.NewMCPServer()
-	server.StartFn = func(_ context.Context, writeEnabled bool) error {
-		if !writeEnabled {
-			t.Fatal("MCP server was not enabled")
-		}
-		return nil
-	}
-	cmd = NewMCPCmd(NewTestClient(fn.WithMCPServer(server)))
-	cmd.SetArgs([]string{"start"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envVal != "" {
+				t.Setenv("FUNC_ENABLE_MCP_WRITE", tc.envVal)
+			}
+
+			// In-memory transport pair: the server side is injected into the
+			// mcp.Server that runMCPStart constructs; the client side lets us
+			// verify tool capabilities without stdio or network I/O.
+			serverTpt, clientTpt := sdk.NewInMemoryTransports()
+
+			// runMCPStart blocks until its transport is closed. Run it in a
+			// goroutine and collect any unexpected errors.
+			errCh := make(chan error, 1)
+			go func() {
+				root := NewMCPCmd(passthroughClientFactory)
+				root.SetContext(t.Context())
+				errCh <- runMCPStart(root, nil, passthroughClientFactory,
+					mcp.WithTransport(serverTpt))
+			}()
+
+			// Connect a test client. Connect() completes the MCP protocol
+			// handshake synchronously before returning, so the tool list is
+			// immediately available.
+			sdkClient := sdk.NewClient(&sdk.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+			session, err := sdkClient.Connect(t.Context(), clientTpt, nil)
+			if err != nil {
+				// Surface a server-side error if it caused the connect failure.
+				select {
+				case serverErr := <-errCh:
+					t.Fatalf("server error: %v (connect error: %v)", serverErr, err)
+				default:
+				}
+				t.Fatalf("failed to connect MCP client: %v", err)
+			}
+
+			res, err := session.ListTools(t.Context(), &sdk.ListToolsParams{})
+			if err != nil {
+				t.Fatalf("failed to list tools: %v", err)
+			}
+
+			exposed := make(map[string]bool, len(res.Tools))
+			for _, tool := range res.Tools {
+				exposed[tool.Name] = true
+			}
+
+			if exposed["deploy"] != tc.wantDeploy {
+				t.Errorf("deploy tool exposed=%v, want %v", exposed["deploy"], tc.wantDeploy)
+			}
+			if exposed["delete"] != tc.wantDelete {
+				t.Errorf("delete tool exposed=%v, want %v", exposed["delete"], tc.wantDelete)
+			}
+		})
 	}
 }

--- a/pkg/functions/client.go
+++ b/pkg/functions/client.go
@@ -227,7 +227,7 @@ type PipelinesProvider interface {
 // MCPServer for a given client instance which performs bidirectional
 // communication with a client agent.
 type MCPServer interface {
-	Start(context.Context, bool) error
+	Start(context.Context) error
 }
 
 // New client for function management.
@@ -1266,8 +1266,8 @@ func (c *Client) Push(ctx context.Context, f Function) (Function, bool, error) {
 
 // StartMCPServer is currently a passthrough to the configured MCP Server
 // instance.
-func (c *Client) StartMCPServer(ctx context.Context, writeEnabled bool) error {
-	return c.mcpServer.Start(ctx, writeEnabled)
+func (c *Client) StartMCPServer(ctx context.Context) error {
+	return c.mcpServer.Start(ctx)
 }
 
 // ensureRunDataDir creates a .func directory at the given path, and
@@ -1555,4 +1555,4 @@ func (n *noopDNSProvider) Provide(_ Function) error { return nil }
 // MCPServer
 type noopMCPServer struct{}
 
-func (n *noopMCPServer) Start(_ context.Context, _ bool) error { return nil }
+func (n *noopMCPServer) Start(_ context.Context) error { return nil }

--- a/pkg/functions/client_test.go
+++ b/pkg/functions/client_test.go
@@ -1286,7 +1286,7 @@ func TestClient_StartMCPServer(t *testing.T) {
 
 	client := fn.New(fn.WithMCPServer(server))
 
-	if err := client.StartMCPServer(t.Context(), true); err != nil {
+	if err := client.StartMCPServer(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -25,6 +25,7 @@ type Server struct {
 	OnInit    func(context.Context) // Invoked when the server is initialized
 	prefix    string                // Command prefix ("func" or "kn func")
 	readonly  atomic.Bool           // disables deploy and delete when true
+	started   atomic.Bool           // double-start protection guard
 	executor  executor
 	transport mcp.Transport // Transport to use (defaults to StdioTransport)
 	impl      *mcp.Server   // implements the protocol
@@ -106,9 +107,13 @@ func New(options ...Option) *Server {
 	mcp.AddTool(i, healthCheckTool, s.healthcheckHandler)
 	mcp.AddTool(i, createTool, s.createHandler)
 	mcp.AddTool(i, buildTool, s.buildHandler)
-	mcp.AddTool(i, deployTool, s.deployHandler)
+	if !s.readonly.Load() {
+		mcp.AddTool(i, deployTool, s.deployHandler)
+	}
 	mcp.AddTool(i, listTool, s.listHandler)
-	mcp.AddTool(i, deleteTool, s.deleteHandler)
+	if !s.readonly.Load() {
+		mcp.AddTool(i, deleteTool, s.deleteHandler)
+	}
 	mcp.AddTool(i, configVolumesListTool, s.configVolumesListHandler)
 	mcp.AddTool(i, configVolumesAddTool, s.configVolumesAddHandler)
 	mcp.AddTool(i, configVolumesRemoveTool, s.configVolumesRemoveHandler)
@@ -158,8 +163,10 @@ func New(options ...Option) *Server {
 }
 
 // Start the MCP server using the configured transport
-func (s *Server) Start(ctx context.Context, writeEnabled bool) error {
-	s.readonly.Store(!writeEnabled)
+func (s *Server) Start(ctx context.Context) error {
+	if !s.started.CompareAndSwap(false, true) {
+		return nil
+	}
 	return s.impl.Run(ctx, s.transport)
 }
 

--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -84,7 +84,7 @@ func newTestPairCore(t *testing.T, readonly bool, options ...Option) (session *m
 
 	// Start the Server
 	go func() {
-		errCh <- server.Start(t.Context(), !readonly)
+		errCh <- server.Start(t.Context())
 	}()
 
 	// Connect a client to trigger initialization
@@ -219,5 +219,96 @@ func TestWithPrefix_Validation(t *testing.T) {
 			}()
 			New(WithPrefix(tc.prefix))
 		})
+	}
+}
+
+func hasExposedTool(t *testing.T, session *mcp.ClientSession, toolName string) bool {
+	t.Helper()
+	res, err := session.ListTools(t.Context(), &mcp.ListToolsParams{})
+	if err != nil {
+		t.Fatalf("failed to list tools: %v", err)
+	}
+	for _, tool := range res.Tools {
+		if tool.Name == toolName {
+			return true
+		}
+	}
+	return false
+}
+
+// TestMCP_ImmutableReadonly ensures that when the server is built with WithReadonly(true),
+// mutating tools (deploy, delete) are completely absent from the exposed tool set.
+func TestMCP_ImmutableReadonly(t *testing.T) {
+	session, _, err := newTestPairWithReadonly(t, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hasExposedTool(t, session, "deploy") {
+		t.Error("deploy tool should not be exposed in readonly mode")
+	}
+	if hasExposedTool(t, session, "delete") {
+		t.Error("delete tool should not be exposed in readonly mode")
+	}
+}
+
+// TestMCP_WriteableUnchanged ensures that when the server is built with WithReadonly(false),
+// mutating tools (deploy, delete) are present in the exposed tool set.
+func TestMCP_WriteableUnchanged(t *testing.T) {
+	session, _, err := newTestPairWithReadonly(t, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !hasExposedTool(t, session, "deploy") {
+		t.Error("deploy tool should be exposed in writeable mode")
+	}
+	if !hasExposedTool(t, session, "delete") {
+		t.Error("delete tool should be exposed in writeable mode")
+	}
+}
+
+// TestMCP_DeterministicLifecycle ensures that calling Start(ctx) twice returns no error
+// and does not change the tool set.
+func TestMCP_DeterministicLifecycle(t *testing.T) {
+	session, server, err := newTestPairWithReadonly(t, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hasExposedTool(t, session, "deploy") {
+		t.Error("deploy tool should not be exposed initially")
+	}
+
+	if err := server.Start(t.Context()); err != nil {
+		t.Fatalf("second call to Start failed: %v", err)
+	}
+
+	if hasExposedTool(t, session, "deploy") {
+		t.Error("deploy tool should not be exposed after second Start")
+	}
+}
+
+// TestMCP_NoSilentMutation ensures that the readonly field is never written after New().
+// We verify that the readonly behavior and tool exposure remain stable and consistent
+// across the server lifecycle.
+func TestMCP_NoSilentMutation(t *testing.T) {
+	session, server, err := newTestPairWithReadonly(t, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify mutating tool is absent initially
+	if hasExposedTool(t, session, "deploy") {
+		t.Error("deploy tool should not be exposed initially")
+	}
+
+	// Call Start, which is the only runtime execution path
+	if err := server.Start(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	if hasExposedTool(t, session, "deploy") {
+		t.Error("deploy tool should not be exposed after Start")
 	}
 }

--- a/pkg/mcp/tools_delete_test.go
+++ b/pkg/mcp/tools_delete_test.go
@@ -77,21 +77,18 @@ func TestTool_Delete_Args(t *testing.T) {
 	}
 }
 
-// TestTool_Delete_Readonly ensures the delete tool rejects requests in readonly mode.
+// TestTool_Delete_Readonly ensures the delete tool is not registered and rejects requests in readonly mode.
 func TestTool_Delete_Readonly(t *testing.T) {
 	client, _, err := newTestPairWithReadonly(t, true) // readonly = true
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+	_, err = client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "delete",
 		Arguments: map[string]any{"name": "my-function"},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !result.IsError {
-		t.Fatal("expected delete to be rejected in readonly mode")
+	if err == nil {
+		t.Fatal("expected delete to be rejected (unknown tool) in readonly mode")
 	}
 }

--- a/pkg/mcp/tools_deploy_test.go
+++ b/pkg/mcp/tools_deploy_test.go
@@ -80,21 +80,18 @@ func TestTool_Deploy_Args(t *testing.T) {
 	}
 }
 
-// TestTool_Deploy_Readonly ensures the deploy tool rejects requests in readonly mode.
+// TestTool_Deploy_Readonly ensures the deploy tool is not registered and rejects requests in readonly mode.
 func TestTool_Deploy_Readonly(t *testing.T) {
 	client, _, err := newTestPairWithReadonly(t, true) // readonly = true
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+	_, err = client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "deploy",
 		Arguments: map[string]any{"path": "."},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !result.IsError {
-		t.Fatal("expected deploy to be rejected in readonly mode")
+	if err == nil {
+		t.Fatal("expected deploy to be rejected (unknown tool) in readonly mode")
 	}
 }

--- a/pkg/mock/mcp_server.go
+++ b/pkg/mock/mcp_server.go
@@ -6,16 +6,16 @@ import (
 
 type MCPServer struct {
 	StartInvoked bool
-	StartFn      func(context.Context, bool) error
+	StartFn      func(context.Context) error
 }
 
 func NewMCPServer() *MCPServer {
 	return &MCPServer{
-		StartFn: func(context.Context, bool) error { return nil },
+		StartFn: func(context.Context) error { return nil },
 	}
 }
 
-func (s *MCPServer) Start(ctx context.Context, writeEnabled bool) error {
+func (s *MCPServer) Start(ctx context.Context) error {
 	s.StartInvoked = true
-	return s.StartFn(ctx, writeEnabled)
+	return s.StartFn(ctx)
 }


### PR DESCRIPTION
## Summary

This PR fixes an MCP readonly-state consistency issue where the server readonly mode could be changed during `Start()`, even after MCP instructions and tool capabilities had already been generated during `New()`.

Previously:

* readonly state was configured during construction using `WithReadonly(...)`
* MCP instructions/tool exposure were derived from that initial readonly state
* `Start(ctx, writeEnabled bool)` could later silently override the readonly value

This created a lifecycle inconsistency where:

* MCP instructions could describe readonly behavior,
* while the runtime server state could become writeable.

Fixes #3785

---

## Root cause

The MCP server generated instructions/tool exposure during construction:

```go
s.instructions = buildInstructions(s.readonly)
```

However, `Start()` later mutated the readonly state again:

```go
s.readonly.Store(!writeEnabled)
```

This allowed the effective runtime enforcement state and the already-generated MCP instructions to drift apart.

---

## What changed

### Single source of truth for readonly state

Readonly state is now immutable after construction.

Changes:

* `Start(ctx, writeEnabled bool)` → `Start(ctx)`
* removed runtime readonly mutation
* readonly configuration is now handled exclusively during server creation via `WithReadonly(...)`

This removes the possibility of instruction/runtime desynchronization entirely.

### Deterministic lifecycle behavior

Added a lightweight idempotency guard using `atomic.Bool` so repeated `Start()` calls become safe no-op operations.

### MCP capability consistency

Mutating MCP tools (`deploy`, `delete`) are now:

* registered only in writeable mode
* omitted entirely in readonly mode

This keeps exposed MCP capabilities aligned with effective runtime behavior.

### Behavioral invariant tests

Added/refined behavioral MCP tests that:

* validate readonly/writeable tool exposure through real MCP protocol interactions
* verify deterministic lifecycle behavior
* verify readonly behavior remains stable across the server lifecycle

The tests intentionally avoid:

* reflection
* unsafe access
* private field inspection
* instruction string parsing

and instead validate behavior through MCP capability exposure.

---

## Behavior changes

| Behavior | Before | After |
| --- | --- | --- |
| Readonly source | `WithReadonly(...)` + `Start(..., writeEnabled)` | `WithReadonly(...)` only |
| Runtime readonly mutation | Allowed | Removed |
| MCP tool exposure in readonly mode | Tools registered then rejected | Tools omitted entirely |
| Repeated `Start()` calls | Multiple initialization attempts possible | Safe no-op |
| Instruction/runtime drift | Possible | Structurally impossible |

---

## Why this approach

The goal was to fix the root cause by simplifying the lifecycle model instead of adding runtime validation or synchronization logic.

This change:

* removes dual readonly-state authority
* makes invalid states structurally impossible
* reduces lifecycle complexity
* preserves deterministic behavior
* keeps runtime overhead minimal
* keeps MCP capability exposure aligned with enforcement behavior

---

## Verification

Verified with:

```bash
go test -v ./pkg/mcp/...
go test -v ./cmd/...
go test -v ./pkg/functions/...
make check
make test
```

All relevant MCP, CLI, and client tests pass successfully.
