### PR TITLE
fix: listen on IPv6 loopback (::1) in addition to 127.0.0.1

### DIFF
--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -117,12 +117,21 @@ nodes:
     - containerPort: 80
       hostPort: 80
       listenAddress: "127.0.0.1"
+    - containerPort: 80
+      hostPort: 80
+      listenAddress: "::1"
     - containerPort: 443
       hostPort: 443
       listenAddress: "127.0.0.1"
+    - containerPort: 443
+      hostPort: 443
+      listenAddress: "::1"
     - containerPort: 30022
       hostPort: 30022
       listenAddress: "127.0.0.1"
+    - containerPort: 30022
+      hostPort: 30022
+      listenAddress: "::1"
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.localtest.me"]

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -146,6 +146,7 @@ EOF
   sleep 10
   $KUBECTL wait pod --for=condition=Ready -l '!job-name' -n kube-system --timeout=5m
   echo "${green}✅ Kubernetes${reset}"
+  docker network inspect kind
 }
 
 serving() {

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -106,7 +106,22 @@ allocate_cluster() {
   echo -e "\n${green}🎉 DONE${reset}\n"
 }
 
+docker_enable_ipv6() {
+  if [ "${GITHUB_ACTIONS:-false}" = "true" ] && [ "$CONTAINER_ENGINE" = "docker" ]; then
+    echo "${blue}Enabling Docker IPv6 support${reset}"
+    local daemon_json="/etc/docker/daemon.json"
+    if [ ! -f "$daemon_json" ]; then
+      echo '{}' | sudo tee "$daemon_json" > /dev/null
+    fi
+    sudo jq '. + {"ipv6": true, "ip6tables": true, "fixed-cidr-v6": "fd00::/80"}' "$daemon_json" > /tmp/daemon.json.tmp \
+      && sudo mv /tmp/daemon.json.tmp "$daemon_json"
+    sudo systemctl restart docker
+    echo "${green}✅ Docker IPv6${reset}"
+  fi
+}
+
 kubernetes() {
+  docker_enable_ipv6
   cat <<EOF | $KIND create cluster --name=func --kubeconfig="${KUBECONFIG}" --wait=60s --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4


### PR DESCRIPTION
# Changes
Add extraPortMappings for ::1 on ports 80, 443, and 30022 so the Kind cluster is reachable via both IPv4 and IPv6 loopback addresses.


