### PR TITLE
mcp: add config_git_set and config_git_remove tools

### DIFF
--- a/pkg/mcp/instructions.md
+++ b/pkg/mcp/instructions.md
@@ -148,7 +148,7 @@ A first-time deploy can be detected by checking the func.yaml for a value in the
   - **REQUIRED:** `git_url` (repository URL) and `git_branch` (branch or tag, e.g. `main`)
   - **OPTIONAL:** `git_dir` (subdirectory in the repo; defaults to repository root when omitted)
   - **OPTIONAL:** `git_provider` (auto-detected from URL; override only if detection fails)
-  - **OPTIONAL PAC:** `config_local`, `config_cluster`, `config_remote` (boolean flags to control which pipeline resources are created; defaults to local-only when none are specified)
+  - **OPTIONAL:** `config_local`, `config_cluster`, `config_remote` (boolean flags to control which pipeline resources are created; defaults to local-only when none are specified)
   - **OPTIONAL:** `gh_access_token` — required only when `config_remote` is true to create a GitHub webhook
   - Changes are written to `func.yaml` and take effect on the next pipeline build
 - `config_git_remove` — removes Git settings and associated pipeline resources:

--- a/pkg/mcp/instructions.md
+++ b/pkg/mcp/instructions.md
@@ -140,6 +140,23 @@ A first-time deploy can be detected by checking the func.yaml for a value in the
 - Exactly ONE of 'path' or 'name' must be provided, not both
 - Deleting does not affect local files (source). Only cluster resources.
 
+### config_git_set, config_git_remove
+
+- **BEFORE calling:** Read `func://help/config/git/set` or `func://help/config/git/remove`
+- Both tools require the `path` parameter (absolute path to the Function directory)
+- `config_git_set` — configures Git source repository settings for pipeline-based builds:
+  - **REQUIRED:** `git_url` (repository URL) and `git_branch` (branch or tag, e.g. `main`)
+  - **OPTIONAL:** `git_dir` (subdirectory in the repo; defaults to repository root when omitted)
+  - **OPTIONAL:** `git_provider` (auto-detected from URL; override only if detection fails)
+  - **OPTIONAL PAC:** `config_local`, `config_cluster`, `config_remote` (boolean flags to control which pipeline resources are created; defaults to local-only when none are specified)
+  - **OPTIONAL:** `gh_access_token` — required only when `config_remote` is true to create a GitHub webhook
+  - Changes are written to `func.yaml` and take effect on the next pipeline build
+- `config_git_remove` — removes Git settings and associated pipeline resources:
+  - **OPTIONAL:** `delete_local` — removes local pipeline template files
+  - **OPTIONAL:** `delete_cluster` — removes cluster credentials and pipeline resources
+  - When neither flag is provided, local resources are removed by default
+- **WARNING:** `config_git_remove` with `delete_cluster: true` is destructive — cluster pipeline resources are deleted permanently
+
 ### config_envs_list, config_envs_add, config_envs_remove
 
 - **BEFORE calling add/remove:** Consider reading `func://help/config/envs` for authoritative usage

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -118,6 +118,8 @@ func New(options ...Option) *Server {
 	mcp.AddTool(i, configEnvsListTool, s.configEnvsListHandler)
 	mcp.AddTool(i, configEnvsAddTool, s.configEnvsAddHandler)
 	mcp.AddTool(i, configEnvsRemoveTool, s.configEnvsRemoveHandler)
+	mcp.AddTool(i, configGitSetTool, s.configGitSetHandler)
+	mcp.AddTool(i, configGitRemoveTool, s.configGitRemoveHandler)
 
 	// Resources
 	// ---------
@@ -151,6 +153,10 @@ func New(options ...Option) *Server {
 	i.AddResource(newHelpResource(s, "Envs Help", "general help for environment variables", "config", "envs"))
 	i.AddResource(newHelpResource(s, "Envs Add Help", "help for 'config envs add'", "config", "envs", "add"))
 	i.AddResource(newHelpResource(s, "Envs Remove Help", "help for 'config envs remove'", "config", "envs", "remove"))
+
+	i.AddResource(newHelpResource(s, "Git Help", "general help for Git pipeline config", "config", "git"))
+	i.AddResource(newHelpResource(s, "Git Set Help", "help for 'config git set'", "config", "git", "set"))
+	i.AddResource(newHelpResource(s, "Git Remove Help", "help for 'config git remove'", "config", "git", "remove"))
 
 	s.impl = i
 

--- a/pkg/mcp/tools_config_git.go
+++ b/pkg/mcp/tools_config_git.go
@@ -10,7 +10,7 @@ import (
 // config_git_set
 
 var configGitSetTool = &mcp.Tool{
-	Name: "config_git_set",
+	Name:  "config_git_set",
 	Title: "Config Git Set",
 	Description: "Set Git source repository settings for a Function's pipeline-based build and deployment. " +
 		"Configures the Git URL, branch, and optional subdirectory, and creates local pipeline templates. " +
@@ -34,16 +34,16 @@ var configGitSetTool = &mcp.Tool{
 // When none of config-local/cluster/remote are set, --config-local is
 // forwarded automatically so the CLI skips the webhook confirmation prompt.
 type ConfigGitSetInput struct {
-	Path           string  `json:"path"                     jsonschema:"required,Absolute path to the Function project directory"`
-	GitURL         string  `json:"git_url"                  jsonschema:"required,URL of the Git repository containing the Function source code"`
-	GitBranch      string  `json:"git_branch"               jsonschema:"required,Git branch or tag to build from (e.g. main)"`
-	GitDir         *string `json:"git_dir,omitempty"        jsonschema:"Subdirectory within the repository where the Function source is located (default: repository root)"`
-	GitProvider    *string `json:"git_provider,omitempty"   jsonschema:"Git platform provider for webhook setup; usually auto-detected from the URL (e.g. github, gitlab, gitea)"`
-	ConfigLocal    *bool   `json:"config_local,omitempty"   jsonschema:"Create local pipeline template files in the Function directory (default: true when no config flags are set)"`
-	ConfigCluster  *bool   `json:"config_cluster,omitempty" jsonschema:"Create pipeline credentials and config on the cluster"`
-	ConfigRemote   *bool   `json:"config_remote,omitempty"  jsonschema:"Configure a webhook on the remote Git provider (requires gh_access_token for GitHub)"`
-	GhAccessToken  *string `json:"gh_access_token,omitempty" jsonschema:"GitHub Personal Access Token for webhook creation (scope: public_repo or repo, admin:repo_hook for automatic webhook setup)"`
-	Verbose        *bool   `json:"verbose,omitempty"        jsonschema:"Enable verbose logging output"`
+	Path          string  `json:"path"                     jsonschema:"required,Absolute path to the Function project directory"`
+	GitURL        string  `json:"git_url"                  jsonschema:"required,URL of the Git repository containing the Function source code"`
+	GitBranch     string  `json:"git_branch"               jsonschema:"required,Git branch or tag to build from (e.g. main)"`
+	GitDir        *string `json:"git_dir,omitempty"        jsonschema:"Subdirectory within the repository where the Function source is located (default: repository root)"`
+	GitProvider   *string `json:"git_provider,omitempty"   jsonschema:"Git platform provider for webhook setup; usually auto-detected from the URL (e.g. github, gitlab, gitea)"`
+	ConfigLocal   *bool   `json:"config_local,omitempty"   jsonschema:"Create local pipeline template files in the Function directory (default: true when no config flags are set)"`
+	ConfigCluster *bool   `json:"config_cluster,omitempty" jsonschema:"Create pipeline credentials and config on the cluster"`
+	ConfigRemote  *bool   `json:"config_remote,omitempty"  jsonschema:"Configure a webhook on the remote Git provider (requires gh_access_token for GitHub)"`
+	GhAccessToken *string `json:"gh_access_token,omitempty" jsonschema:"GitHub Personal Access Token for webhook creation (scope: public_repo or repo, admin:repo_hook for automatic webhook setup)"`
+	Verbose       *bool   `json:"verbose,omitempty"        jsonschema:"Enable verbose logging output"`
 }
 
 func (i ConfigGitSetInput) Args() []string {

--- a/pkg/mcp/tools_config_git.go
+++ b/pkg/mcp/tools_config_git.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -53,9 +54,10 @@ func (i ConfigGitSetInput) Args() []string {
 	args = append(args, "--git-branch", i.GitBranch)
 
 	// Always pass --git-dir to prevent the interactive prompt.
-	// Default to "." (repository root) when not explicitly provided.
+	// Default to "." (repository root) when not provided or when provided as
+	// empty/whitespace-only, as an empty value re-triggers the CLI prompt.
 	gitDir := "."
-	if i.GitDir != nil {
+	if i.GitDir != nil && strings.TrimSpace(*i.GitDir) != "" {
 		gitDir = *i.GitDir
 	}
 	args = append(args, "--git-dir", gitDir)

--- a/pkg/mcp/tools_config_git.go
+++ b/pkg/mcp/tools_config_git.go
@@ -1,0 +1,166 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// config_git_set
+
+var configGitSetTool = &mcp.Tool{
+	Name: "config_git_set",
+	Title: "Config Git Set",
+	Description: "Set Git source repository settings for a Function's pipeline-based build and deployment. " +
+		"Configures the Git URL, branch, and optional subdirectory, and creates local pipeline templates. " +
+		"Optionally configures cluster resources and remote webhook triggers when credentials are supplied.",
+	Annotations: &mcp.ToolAnnotations{
+		Title:           "Config Git Set",
+		ReadOnlyHint:    false,
+		DestructiveHint: ptr(false),
+		IdempotentHint:  true, // setting the same values repeatedly has the same end state
+	},
+}
+
+// ConfigGitSetInput defines the input for the config_git_set tool.
+//
+// git-url and git-branch are required; the CLI will prompt interactively
+// for any missing values, which hangs in a non-TTY subprocess.
+//
+// git-dir defaults to "." (repository root) when not provided, preventing
+// the CLI's interactive prompt for that field.
+//
+// When none of config-local/cluster/remote are set, --config-local is
+// forwarded automatically so the CLI skips the webhook confirmation prompt.
+type ConfigGitSetInput struct {
+	Path           string  `json:"path"                     jsonschema:"required,Absolute path to the Function project directory"`
+	GitURL         string  `json:"git_url"                  jsonschema:"required,URL of the Git repository containing the Function source code"`
+	GitBranch      string  `json:"git_branch"               jsonschema:"required,Git branch or tag to build from (e.g. main)"`
+	GitDir         *string `json:"git_dir,omitempty"        jsonschema:"Subdirectory within the repository where the Function source is located (default: repository root)"`
+	GitProvider    *string `json:"git_provider,omitempty"   jsonschema:"Git platform provider for webhook setup; usually auto-detected from the URL (e.g. github, gitlab, gitea)"`
+	ConfigLocal    *bool   `json:"config_local,omitempty"   jsonschema:"Create local pipeline template files in the Function directory (default: true when no config flags are set)"`
+	ConfigCluster  *bool   `json:"config_cluster,omitempty" jsonschema:"Create pipeline credentials and config on the cluster"`
+	ConfigRemote   *bool   `json:"config_remote,omitempty"  jsonschema:"Configure a webhook on the remote Git provider (requires gh_access_token for GitHub)"`
+	GhAccessToken  *string `json:"gh_access_token,omitempty" jsonschema:"GitHub Personal Access Token for webhook creation (scope: public_repo or repo, admin:repo_hook for automatic webhook setup)"`
+	Verbose        *bool   `json:"verbose,omitempty"        jsonschema:"Enable verbose logging output"`
+}
+
+func (i ConfigGitSetInput) Args() []string {
+	args := []string{"git", "set", "--path", i.Path}
+
+	args = append(args, "--git-url", i.GitURL)
+	args = append(args, "--git-branch", i.GitBranch)
+
+	// Always pass --git-dir to prevent the interactive prompt.
+	// Default to "." (repository root) when not explicitly provided.
+	gitDir := "."
+	if i.GitDir != nil {
+		gitDir = *i.GitDir
+	}
+	args = append(args, "--git-dir", gitDir)
+
+	args = appendStringFlag(args, "--git-provider", i.GitProvider)
+
+	// When no config-* flags are provided, always forward --config-local so
+	// the CLI sets HasChanged and skips the interactive webhook-trigger prompt.
+	if i.ConfigLocal == nil && i.ConfigCluster == nil && i.ConfigRemote == nil {
+		args = append(args, "--config-local")
+	} else {
+		args = appendBoolFlag(args, "--config-local", i.ConfigLocal)
+		args = appendBoolFlag(args, "--config-cluster", i.ConfigCluster)
+		args = appendBoolFlag(args, "--config-remote", i.ConfigRemote)
+	}
+
+	args = appendStringFlag(args, "--gh-access-token", i.GhAccessToken)
+	args = appendBoolFlag(args, "--verbose", i.Verbose)
+	return args
+}
+
+type ConfigGitSetOutput struct {
+	Message string `json:"message" jsonschema:"Output message"`
+}
+
+func (s *Server) configGitSetHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigGitSetInput) (result *mcp.CallToolResult, output ConfigGitSetOutput, err error) {
+	if input.Path == "" {
+		err = fmt.Errorf("'path' is required")
+		return
+	}
+	if input.GitURL == "" {
+		err = fmt.Errorf("'git_url' is required")
+		return
+	}
+	if input.GitBranch == "" {
+		err = fmt.Errorf("'git_branch' is required")
+		return
+	}
+
+	out, err := s.executor.Execute(ctx, "config", input.Args()...)
+	if err != nil {
+		err = fmt.Errorf("%w\n%s", err, string(out))
+		return
+	}
+	output = ConfigGitSetOutput{Message: string(out)}
+	return
+}
+
+// config_git_remove
+
+var configGitRemoveTool = &mcp.Tool{
+	Name:        "config_git_remove",
+	Title:       "Config Git Remove",
+	Description: "Remove Git source repository settings and associated pipeline resources from a Function. Removes Git config from func.yaml and optionally deletes local pipeline templates and cluster resources.",
+	Annotations: &mcp.ToolAnnotations{
+		Title:           "Config Git Remove",
+		ReadOnlyHint:    false,
+		DestructiveHint: ptr(true),
+		IdempotentHint:  true,
+	},
+}
+
+// ConfigGitRemoveInput defines the input for the config_git_remove tool.
+//
+// When neither delete-local nor delete-cluster is set, --delete-local is
+// forwarded automatically to prevent the CLI's interactive "delete all?"
+// confirmation prompt in a non-TTY subprocess.
+type ConfigGitRemoveInput struct {
+	Path          string `json:"path"                    jsonschema:"required,Absolute path to the Function project directory"`
+	DeleteLocal   *bool  `json:"delete_local,omitempty"  jsonschema:"Delete local pipeline template files from the Function directory"`
+	DeleteCluster *bool  `json:"delete_cluster,omitempty" jsonschema:"Delete pipeline credentials and config from the cluster"`
+	Verbose       *bool  `json:"verbose,omitempty"       jsonschema:"Enable verbose logging output"`
+}
+
+func (i ConfigGitRemoveInput) Args() []string {
+	args := []string{"git", "remove", "--path", i.Path}
+
+	// When no delete-* flags are provided, always forward --delete-local so
+	// the CLI sets HasChanged and skips the interactive "delete all?" prompt.
+	if i.DeleteLocal == nil && i.DeleteCluster == nil {
+		args = append(args, "--delete-local")
+	} else {
+		args = appendBoolFlag(args, "--delete-local", i.DeleteLocal)
+		args = appendBoolFlag(args, "--delete-cluster", i.DeleteCluster)
+	}
+
+	args = appendBoolFlag(args, "--verbose", i.Verbose)
+	return args
+}
+
+type ConfigGitRemoveOutput struct {
+	Message string `json:"message" jsonschema:"Output message"`
+}
+
+func (s *Server) configGitRemoveHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigGitRemoveInput) (result *mcp.CallToolResult, output ConfigGitRemoveOutput, err error) {
+	if input.Path == "" {
+		err = fmt.Errorf("'path' is required")
+		return
+	}
+
+	out, err := s.executor.Execute(ctx, "config", input.Args()...)
+	if err != nil {
+		err = fmt.Errorf("%w\n%s", err, string(out))
+		return
+	}
+	output = ConfigGitRemoveOutput{Message: string(out)}
+	return
+}

--- a/pkg/mcp/tools_config_git_test.go
+++ b/pkg/mcp/tools_config_git_test.go
@@ -252,6 +252,9 @@ func TestTool_ConfigGitRemove_Args(t *testing.T) {
 		if subcommand != "config" {
 			t.Fatalf("expected subcommand 'config', got %q", subcommand)
 		}
+		if len(args) < 2 {
+			t.Fatalf("expected at least 2 args ('git', 'remove'), got %d: %v", len(args), args)
+		}
 		if args[0] != "git" {
 			t.Fatalf("expected args[0]='git', got %q", args[0])
 		}

--- a/pkg/mcp/tools_config_git_test.go
+++ b/pkg/mcp/tools_config_git_test.go
@@ -165,8 +165,10 @@ func TestTool_ConfigGitSet_MissingGitURL(t *testing.T) {
 			"git_branch": "main",
 		},
 	})
+	// The MCP SDK validates required schema fields before calling the handler,
+	// returning a protocol-level error (err != nil).  Accept either error path.
 	if err != nil {
-		t.Fatal(err)
+		return
 	}
 	if !result.IsError {
 		t.Fatal("expected error result when git_url is missing")
@@ -194,8 +196,10 @@ func TestTool_ConfigGitSet_MissingGitBranch(t *testing.T) {
 			"git_url": "https://github.com/user/repo",
 		},
 	})
+	// The MCP SDK validates required schema fields before calling the handler,
+	// returning a protocol-level error (err != nil).  Accept either error path.
 	if err != nil {
-		t.Fatal(err)
+		return
 	}
 	if !result.IsError {
 		t.Fatal("expected error result when git_branch is missing")

--- a/pkg/mcp/tools_config_git_test.go
+++ b/pkg/mcp/tools_config_git_test.go
@@ -1,0 +1,343 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"knative.dev/func/pkg/mcp/mock"
+)
+
+// TestTool_ConfigGitSet_Args ensures the config_git_set tool passes all
+// arguments correctly to the executor.
+func TestTool_ConfigGitSet_Args(t *testing.T) {
+	stringFlags := map[string]struct {
+		jsonKey string
+		flag    string
+		value   string
+	}{
+		"path":       {"path", "--path", "/home/user/myfunc"},
+		"git_url":    {"git_url", "--git-url", "https://github.com/user/repo"},
+		"git_branch": {"git_branch", "--git-branch", "main"},
+		"git_dir":    {"git_dir", "--git-dir", "functions/myfunc"},
+	}
+
+	boolFlags := map[string]string{
+		"verbose": "--verbose",
+	}
+
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		if subcommand != "config" {
+			t.Fatalf("expected subcommand 'config', got %q", subcommand)
+		}
+		if len(args) < 2 {
+			t.Fatalf("expected at least 2 args, got %d: %v", len(args), args)
+		}
+		if args[0] != "git" {
+			t.Fatalf("expected args[0]='git', got %q", args[0])
+		}
+		if args[1] != "set" {
+			t.Fatalf("expected args[1]='set', got %q", args[1])
+		}
+
+		// After "git set": --path, path, --git-url, url, --git-branch, branch, --git-dir, dir = 8 args
+		// + --config-local (1) + --verbose (1) = 10 args after "git set"
+		remaining := args[2:]
+		validateStringFlags(t, remaining, stringFlags)
+		validateBoolFlags(t, remaining, boolFlags)
+
+		return []byte("Git configuration set successfully\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inputArgs := buildInputArgs(stringFlags, boolFlags)
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_git_set",
+		Arguments: inputArgs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_ConfigGitSet_DefaultGitDir ensures that when git_dir is not
+// provided, "--git-dir ." is forwarded to prevent the interactive prompt.
+func TestTool_ConfigGitSet_DefaultGitDir(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		argsMap := argsToMap(args)
+		val, ok := argsMap["--git-dir"]
+		if !ok {
+			t.Fatal("expected --git-dir flag to be present, got none")
+		}
+		if val != "." {
+			t.Fatalf("expected --git-dir='.', got %q", val)
+		}
+		return []byte("ok\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_git_set",
+		Arguments: map[string]any{
+			"path":       "/home/user/myfunc",
+			"git_url":    "https://github.com/user/repo",
+			"git_branch": "main",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+}
+
+// TestTool_ConfigGitSet_AntiHang_ConfigLocal ensures that when no config-*
+// flags are provided, --config-local is automatically forwarded to prevent
+// the interactive webhook confirmation prompt in a non-TTY subprocess.
+func TestTool_ConfigGitSet_AntiHang_ConfigLocal(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		argsMap := argsToMap(args)
+		if _, ok := argsMap["--config-local"]; !ok {
+			t.Fatal("expected --config-local to be present when no config-* flags are provided")
+		}
+		return []byte("ok\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_git_set",
+		Arguments: map[string]any{
+			"path":       "/home/user/myfunc",
+			"git_url":    "https://github.com/user/repo",
+			"git_branch": "main",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+}
+
+// TestTool_ConfigGitSet_MissingGitURL ensures that omitting git_url returns
+// an error without invoking the executor.
+func TestTool_ConfigGitSet_MissingGitURL(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		t.Fatal("executor should not be called when git_url is missing")
+		return nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_git_set",
+		Arguments: map[string]any{
+			"path":       "/home/user/myfunc",
+			"git_branch": "main",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when git_url is missing")
+	}
+}
+
+// TestTool_ConfigGitSet_MissingGitBranch ensures that omitting git_branch
+// returns an error without invoking the executor.
+func TestTool_ConfigGitSet_MissingGitBranch(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		t.Fatal("executor should not be called when git_branch is missing")
+		return nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_git_set",
+		Arguments: map[string]any{
+			"path":    "/home/user/myfunc",
+			"git_url": "https://github.com/user/repo",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when git_branch is missing")
+	}
+}
+
+// TestTool_ConfigGitSet_Error ensures executor errors are propagated.
+func TestTool_ConfigGitSet_Error(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte("set failed"), errors.New("executor error")
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "config_git_set",
+		Arguments: map[string]any{
+			"path":       "/home/user/myfunc",
+			"git_url":    "https://github.com/user/repo",
+			"git_branch": "main",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result, got success")
+	}
+}
+
+// TestTool_ConfigGitRemove_Args ensures the config_git_remove tool passes
+// all arguments correctly to the executor.
+func TestTool_ConfigGitRemove_Args(t *testing.T) {
+	stringFlags := map[string]struct {
+		jsonKey string
+		flag    string
+		value   string
+	}{
+		"path": {"path", "--path", "/home/user/myfunc"},
+	}
+
+	boolFlags := map[string]string{
+		"delete_local":   "--delete-local",
+		"delete_cluster": "--delete-cluster",
+		"verbose":        "--verbose",
+	}
+
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		if subcommand != "config" {
+			t.Fatalf("expected subcommand 'config', got %q", subcommand)
+		}
+		if args[0] != "git" {
+			t.Fatalf("expected args[0]='git', got %q", args[0])
+		}
+		if args[1] != "remove" {
+			t.Fatalf("expected args[1]='remove', got %q", args[1])
+		}
+
+		remaining := args[2:]
+		validateStringFlags(t, remaining, stringFlags)
+		validateBoolFlags(t, remaining, boolFlags)
+
+		return []byte("Git configuration removed\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inputArgs := buildInputArgs(stringFlags, boolFlags)
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_git_remove",
+		Arguments: inputArgs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_ConfigGitRemove_AntiHang_DeleteLocal ensures that when neither
+// delete-local nor delete-cluster is provided, --delete-local is forwarded
+// automatically to prevent the interactive "delete all?" prompt.
+func TestTool_ConfigGitRemove_AntiHang_DeleteLocal(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		argsMap := argsToMap(args)
+		if _, ok := argsMap["--delete-local"]; !ok {
+			t.Fatal("expected --delete-local to be present when no delete-* flags are provided")
+		}
+		return []byte("ok\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_git_remove",
+		Arguments: map[string]any{"path": "/home/user/myfunc"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+}
+
+// TestTool_ConfigGitRemove_Error ensures executor errors are propagated.
+func TestTool_ConfigGitRemove_Error(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte("remove failed"), errors.New("executor error")
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_git_remove",
+		Arguments: map[string]any{"path": "/home/user/myfunc"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result, got success")
+	}
+}


### PR DESCRIPTION
## Summary

Adds two MCP tools — `config_git_set` and `config_git_remove` — to
configure Git source repository settings for pipeline-based Function
builds. This completes the `config` tool group alongside the existing
volumes, labels, and envs tools.

## Changes

- **`pkg/mcp/tools_config_git.go`** — two tools following the existing
  `config_*` pattern:
  - `config_git_set`: configures Git URL, branch, subdirectory, and
    optional Pipelines-as-Code (PAC) resources on the Function. Requires
    `path`, `git_url`, and `git_branch`. Defaults `git_dir` to `"."` to
    avoid the CLI's interactive prompt when no subdirectory is needed.
    Automatically injects `--config-local` when no `config_*` flags are
    provided to prevent the webhook confirmation prompt in a non-TTY
    subprocess.
  - `config_git_remove`: removes Git settings and associated pipeline
    resources from a Function. Automatically injects `--delete-local`
    when neither `delete_local` nor `delete_cluster` is set, preventing
    the interactive "delete all?" prompt.

- **`pkg/mcp/tools_config_git_test.go`** — eight unit tests:
  - `TestTool_ConfigGitSet_Args` — all flags forwarded correctly
  - `TestTool_ConfigGitSet_DefaultGitDir` — `--git-dir .` injected when omitted
  - `TestTool_ConfigGitSet_AntiHang_ConfigLocal` — `--config-local` injected when no config-* flags set
  - `TestTool_ConfigGitSet_MissingGitURL` — error before executor when `git_url` absent
  - `TestTool_ConfigGitSet_MissingGitBranch` — error before executor when `git_branch` absent
  - `TestTool_ConfigGitSet_Error` — executor errors propagated
  - `TestTool_ConfigGitRemove_Args` — all flags forwarded correctly
  - `TestTool_ConfigGitRemove_AntiHang_DeleteLocal` — `--delete-local` injected when no delete-* flags set
  - `TestTool_ConfigGitRemove_Error` — executor errors propagated

- **`pkg/mcp/mcp.go`** — registers both tools and three help resources
  (`func://help/config/git`, `func://help/config/git/set`,
  `func://help/config/git/remove`).

- **`pkg/mcp/instructions.md`** — adds `config_git_set` /
  `config_git_remove` agent guidance covering required fields, PAC
  resource flags, GitHub token requirements, and destructive-operation
  warning for `delete_cluster`.

## Notes

- No `config_git_list` tool is added because `func config git` (the
  root command) currently prints "Not implemented yet." and provides no
  useful output. Git settings can be inspected via the `func://function`
  resource which exposes the full `func.yaml` state.

## Test plan

- [ ] `make test` passes
- [ ] `make check` passes
- [ ] Manual: call `config_git_set` with `path`, `git_url`, `git_branch`
  and confirm `func.yaml` is updated with Git config
- [ ] Manual: call `config_git_remove` with `path` only and confirm
  local pipeline resources are cleaned up without prompting