### PR TITLE
fix(k8s): propagate caller context in dialer DialContext

### DIFF
--- a/pkg/k8s/dialer.go
+++ b/pkg/k8s/dialer.go
@@ -81,7 +81,7 @@ func (c *contextDialer) DialContext(ctx context.Context, network string, addr st
 		stderrBuff := bytes.NewBuffer(nil)
 		ctrStderr := io.MultiWriter(stderrBuff, detectConnSuccess(connectSuccess))
 
-		err := c.exec(context.TODO(), addr, ctrStdin, ctrStdout, ctrStderr)
+		err := c.exec(ctx, addr, ctrStdin, ctrStdout, ctrStderr)
 		if err != nil {
 			stderrStr := stderrBuff.String()
 			socatErr := tryParseSocatError(network, addr, stderrStr)


### PR DESCRIPTION
## Changes

The DialContext method in pkg/k8s/dialer.go starts a goroutine (line 80) that calls c.exec with context.TODO() instead of the ctx parameter from DialContext.

This means the exec call does not directly respect the caller's context cancellation. When the parent context is cancelled, the caller gets ctx.Err() from the select, and the pipes are closed, which eventually causes exec to error out. But passing ctx directly to exec lets StreamWithContext respond to cancellation immediately without relying on the indirect pipe-closure path.

This is a one-line change from context.TODO() to ctx.

Fixes #3800