### PR TITLE
fix(knative): clean up stale triggers on deploy

### DIFF
--- a/pkg/knative/deployer.go
+++ b/pkg/knative/deployer.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -408,6 +409,46 @@ func createTriggers(ctx context.Context, f fn.Function, client clientservingv1.K
 		if err != nil && !errors.IsAlreadyExists(err) {
 			err = fmt.Errorf("knative deployer failed to create the Trigger: %v", err)
 			return err
+		}
+	}
+
+	// Clean up stale triggers that are no longer in the desired subscription set.
+	triggerPrefix := fmt.Sprintf("%s-function-trigger-", ksvc.GetName())
+	existingTriggers, err := eventingClient.ListTriggers(ctx)
+	if err != nil {
+		if errors.IsNotFound(err) || strings.HasPrefix(err.Error(), "no or newer Knative Eventing API found on the backend") {
+			return nil
+		}
+		return fmt.Errorf("knative deployer failed to list triggers for cleanup: %v", err)
+	}
+	triggerNames := make([]string, len(existingTriggers.Items))
+	for i, t := range existingTriggers.Items {
+		triggerNames[i] = t.Name
+	}
+	return deleteStaleTriggers(triggerNames, triggerPrefix, len(f.Deploy.Subscriptions), func(name string) error {
+		return eventingClient.DeleteTrigger(ctx, name)
+	})
+}
+
+// deleteStaleTriggers removes triggers whose numeric index suffix is >= desiredCount.
+// The knative deployer names triggers as <prefix><index>. If the subscription count
+// decreases, triggers with higher indices become orphaned and must be cleaned up.
+func deleteStaleTriggers(triggerNames []string, triggerPrefix string, desiredCount int, deleteFn func(name string) error) error {
+	for _, name := range triggerNames {
+		if !strings.HasPrefix(name, triggerPrefix) {
+			continue
+		}
+		idxStr := strings.TrimPrefix(name, triggerPrefix)
+		idx, parseErr := strconv.Atoi(idxStr)
+		if parseErr != nil {
+			continue
+		}
+		if idx >= desiredCount {
+			fmt.Fprintf(os.Stderr, "Deleting stale trigger: %s\n", name)
+			delErr := deleteFn(name)
+			if delErr != nil && !errors.IsNotFound(delErr) {
+				return fmt.Errorf("knative deployer failed to delete stale trigger %s: %v", name, delErr)
+			}
 		}
 	}
 	return nil

--- a/pkg/knative/deployer.go
+++ b/pkg/knative/deployer.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"strconv"
+	"reflect"
 	"strings"
 	"time"
 
@@ -44,6 +44,9 @@ import (
 
 const (
 	KnativeDeployerName = "knative"
+
+	knativeTriggerManagedByAnnotation = "func.knative.dev/managed-by"
+	knativeTriggerManagedByValue      = "func-knative-deployer"
 )
 
 type DeployerOpt func(*Deployer)
@@ -372,86 +375,126 @@ func createTriggers(ctx context.Context, f fn.Function, client clientservingv1.K
 
 	fmt.Fprintf(os.Stderr, "🎯 Creating Triggers on the cluster\n")
 
+	desiredTriggers := make(map[string]*eventingv1.Trigger, len(f.Deploy.Subscriptions))
 	for i, sub := range f.Deploy.Subscriptions {
-		// create the filter:
-		attributes := make(map[string]string)
-		for key, value := range sub.Filters {
-			attributes[key] = value
-		}
+		trigger := newKnativeTrigger(ksvc, sub, i)
+		desiredTriggers[trigger.Name] = trigger
 
-		err := eventingClient.CreateTrigger(ctx, &eventingv1.Trigger{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("%s-function-trigger-%d", ksvc.GetName(), i),
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: ksvc.APIVersion,
-						Kind:       ksvc.Kind,
-						Name:       ksvc.GetName(),
-						UID:        ksvc.GetUID(),
-					},
-				},
-			},
-			Spec: eventingv1.TriggerSpec{
-				Broker: sub.Source,
-
-				Subscriber: duckv1.Destination{
-					Ref: &duckv1.KReference{
-						APIVersion: ksvc.APIVersion,
-						Kind:       ksvc.Kind,
-						Name:       ksvc.GetName(),
-					}},
-
-				Filter: &eventingv1.TriggerFilter{
-					Attributes: attributes,
-				},
-			},
-		})
+		err := eventingClient.CreateTrigger(ctx, trigger)
 		if err != nil && !errors.IsAlreadyExists(err) {
 			err = fmt.Errorf("knative deployer failed to create the Trigger: %v", err)
 			return err
 		}
 	}
 
-	// Clean up stale triggers that are no longer in the desired subscription set.
-	triggerPrefix := fmt.Sprintf("%s-function-trigger-", ksvc.GetName())
+	return syncKnativeTriggers(ctx, eventingClient, ksvc, desiredTriggers)
+}
+
+func newKnativeTrigger(ksvc *servingv1.Service, sub fn.KnativeSubscription, index int) *eventingv1.Trigger {
+	attributes := make(map[string]string)
+	for key, value := range sub.Filters {
+		attributes[key] = value
+	}
+
+	return &eventingv1.Trigger{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-function-trigger-%d", ksvc.GetName(), index),
+			Annotations: map[string]string{
+				knativeTriggerManagedByAnnotation: knativeTriggerManagedByValue,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: ksvc.APIVersion,
+					Kind:       ksvc.Kind,
+					Name:       ksvc.GetName(),
+					UID:        ksvc.GetUID(),
+				},
+			},
+		},
+		Spec: eventingv1.TriggerSpec{
+			Broker: sub.Source,
+			Subscriber: duckv1.Destination{
+				Ref: &duckv1.KReference{
+					APIVersion: ksvc.APIVersion,
+					Kind:       ksvc.Kind,
+					Name:       ksvc.GetName(),
+				},
+			},
+			Filter: &eventingv1.TriggerFilter{
+				Attributes: attributes,
+			},
+		},
+	}
+}
+
+func syncKnativeTriggers(ctx context.Context, eventingClient clienteventingv1.KnEventingClient, ksvc *servingv1.Service, desiredTriggers map[string]*eventingv1.Trigger) error {
 	existingTriggers, err := eventingClient.ListTriggers(ctx)
 	if err != nil {
-		if errors.IsNotFound(err) || strings.HasPrefix(err.Error(), "no or newer Knative Eventing API found on the backend") {
+		if errors.IsNotFound(err) || isEventingUnavailable(err) {
 			return nil
 		}
 		return fmt.Errorf("knative deployer failed to list triggers for cleanup: %v", err)
 	}
-	triggerNames := make([]string, len(existingTriggers.Items))
-	for i, t := range existingTriggers.Items {
-		triggerNames[i] = t.Name
+	if existingTriggers == nil {
+		return nil
 	}
-	return deleteStaleTriggers(triggerNames, triggerPrefix, len(f.Deploy.Subscriptions), func(name string) error {
-		return eventingClient.DeleteTrigger(ctx, name)
-	})
-}
 
-// deleteStaleTriggers removes triggers whose numeric index suffix is >= desiredCount.
-// The knative deployer names triggers as <prefix><index>. If the subscription count
-// decreases, triggers with higher indices become orphaned and must be cleaned up.
-func deleteStaleTriggers(triggerNames []string, triggerPrefix string, desiredCount int, deleteFn func(name string) error) error {
-	for _, name := range triggerNames {
-		if !strings.HasPrefix(name, triggerPrefix) {
+	triggerPrefix := fmt.Sprintf("%s-function-trigger-", ksvc.GetName())
+	for _, trigger := range existingTriggers.Items {
+		if !strings.HasPrefix(trigger.Name, triggerPrefix) || !isOwnedKnativeTrigger(trigger, ksvc) {
 			continue
 		}
-		idxStr := strings.TrimPrefix(name, triggerPrefix)
-		idx, parseErr := strconv.Atoi(idxStr)
-		if parseErr != nil {
-			continue
-		}
-		if idx >= desiredCount {
-			fmt.Fprintf(os.Stderr, "Deleting stale trigger: %s\n", name)
-			delErr := deleteFn(name)
+
+		desiredTrigger, ok := desiredTriggers[trigger.Name]
+		if !ok {
+			fmt.Fprintf(os.Stderr, "Deleting stale trigger: %s\n", trigger.Name)
+			delErr := eventingClient.DeleteTrigger(ctx, trigger.Name)
 			if delErr != nil && !errors.IsNotFound(delErr) {
-				return fmt.Errorf("knative deployer failed to delete stale trigger %s: %v", name, delErr)
+				return fmt.Errorf("knative deployer failed to delete stale trigger %s: %v", trigger.Name, delErr)
+			}
+			continue
+		}
+
+		if triggerNeedsUpdate(trigger, desiredTrigger, ksvc) {
+			updated := trigger.DeepCopy()
+			updated.Spec = desiredTrigger.Spec
+			updated.OwnerReferences = desiredTrigger.OwnerReferences
+			if updated.Annotations == nil {
+				updated.Annotations = make(map[string]string)
+			}
+			updated.Annotations[knativeTriggerManagedByAnnotation] = knativeTriggerManagedByValue
+			if err := eventingClient.UpdateTrigger(ctx, updated); err != nil {
+				return fmt.Errorf("knative deployer failed to update trigger %s: %v", trigger.Name, err)
 			}
 		}
 	}
 	return nil
+}
+
+func isEventingUnavailable(err error) bool {
+	return strings.HasPrefix(err.Error(), "no or newer Knative Eventing API found on the backend")
+}
+
+func isOwnedKnativeTrigger(trigger eventingv1.Trigger, ksvc *servingv1.Service) bool {
+	if trigger.Annotations[knativeTriggerManagedByAnnotation] == knativeTriggerManagedByValue {
+		return true
+	}
+	return hasKnativeOwnerReference(trigger, ksvc)
+}
+
+func hasKnativeOwnerReference(trigger eventingv1.Trigger, ksvc *servingv1.Service) bool {
+	for _, owner := range trigger.OwnerReferences {
+		if owner.APIVersion == ksvc.APIVersion && owner.Kind == ksvc.Kind && owner.Name == ksvc.GetName() {
+			return ksvc.GetUID() == "" || owner.UID == ksvc.GetUID()
+		}
+	}
+	return false
+}
+
+func triggerNeedsUpdate(existing eventingv1.Trigger, desired *eventingv1.Trigger, ksvc *servingv1.Service) bool {
+	return !reflect.DeepEqual(existing.Spec, desired.Spec) ||
+		existing.Annotations[knativeTriggerManagedByAnnotation] != knativeTriggerManagedByValue ||
+		!hasKnativeOwnerReference(existing, ksvc)
 }
 
 func generateNewService(f fn.Function, decorator deployer.DeployDecorator, daprInstalled bool, referencedSecrets, referencedConfigMaps, referencedPVCs *sets.Set[string]) (*servingv1.Service, error) {

--- a/pkg/knative/deployer_test.go
+++ b/pkg/knative/deployer_test.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	clienteventingv1 "knative.dev/client/pkg/eventing/v1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	fn "knative.dev/func/pkg/functions"
 	"knative.dev/pkg/ptr"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -462,86 +464,110 @@ func assertAuth(uname, pwd string, w http.ResponseWriter, r *http.Request) bool 
 	return false
 }
 
-// TestDeleteStaleTriggers_NoStale ensures no triggers are deleted when all are within range.
-func TestDeleteStaleTriggers_NoStale(t *testing.T) {
-	triggers := []string{"my-func-function-trigger-0", "my-func-function-trigger-1"}
-	prefix := "my-func-function-trigger-"
-	var deleted []string
-	deleteFn := func(name string) error {
-		deleted = append(deleted, name)
-		return nil
+func TestSyncKnativeTriggers_DeletesOwnedStaleTrigger(t *testing.T) {
+	ksvc := testKnativeService("my-func")
+	desired := map[string]*eventingv1.Trigger{
+		"my-func-function-trigger-0": newKnativeTrigger(ksvc, fn.KnativeSubscription{Source: "default"}, 0),
 	}
-	err := deleteStaleTriggers(triggers, prefix, 2, deleteFn)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	existing := newKnativeTrigger(ksvc, fn.KnativeSubscription{Source: "old"}, 2)
+
+	client := clienteventingv1.NewMockKnEventingClient(t)
+	client.Recorder().ListTriggers(&eventingv1.TriggerList{Items: []eventingv1.Trigger{*existing}}, nil)
+	client.Recorder().DeleteTrigger("my-func-function-trigger-2", nil)
+
+	if err := syncKnativeTriggers(t.Context(), client, ksvc, desired); err != nil {
+		t.Fatalf("syncKnativeTriggers returned error: %v", err)
 	}
-	if len(deleted) != 0 {
-		t.Fatalf("expected no deletions, got %v", deleted)
-	}
+	client.Recorder().Validate()
 }
 
-// TestDeleteStaleTriggers_DeletesStale ensures triggers beyond desired count are deleted.
-func TestDeleteStaleTriggers_DeletesStale(t *testing.T) {
-	triggers := []string{
-		"my-func-function-trigger-0",
-		"my-func-function-trigger-1",
-		"my-func-function-trigger-2",
-		"my-func-function-trigger-3",
+func TestSyncKnativeTriggers_UpdatesChangedDesiredTrigger(t *testing.T) {
+	ksvc := testKnativeService("my-func")
+	existing := newKnativeTrigger(ksvc, fn.KnativeSubscription{Source: "old-broker"}, 0)
+	delete(existing.Annotations, knativeTriggerManagedByAnnotation)
+	desired := map[string]*eventingv1.Trigger{
+		"my-func-function-trigger-0": newKnativeTrigger(ksvc, fn.KnativeSubscription{
+			Source:  "new-broker",
+			Filters: map[string]string{"type": "dev.knative.func"},
+		}, 0),
 	}
-	prefix := "my-func-function-trigger-"
-	var deleted []string
-	deleteFn := func(name string) error {
-		deleted = append(deleted, name)
-		return nil
+
+	client := clienteventingv1.NewMockKnEventingClient(t)
+	client.Recorder().ListTriggers(&eventingv1.TriggerList{Items: []eventingv1.Trigger{*existing}}, nil)
+	client.Recorder().UpdateTrigger(func(t *testing.T, got any) {
+		trigger := got.(*eventingv1.Trigger)
+		if trigger.Name != "my-func-function-trigger-0" {
+			t.Fatalf("expected trigger name my-func-function-trigger-0, got %q", trigger.Name)
+		}
+		if trigger.Spec.Broker != "new-broker" {
+			t.Fatalf("expected broker new-broker, got %q", trigger.Spec.Broker)
+		}
+		if trigger.Spec.Filter.Attributes["type"] != "dev.knative.func" {
+			t.Fatalf("expected updated filter attributes, got %v", trigger.Spec.Filter.Attributes)
+		}
+		if trigger.Annotations[knativeTriggerManagedByAnnotation] != knativeTriggerManagedByValue {
+			t.Fatalf("expected managed annotation, got %v", trigger.Annotations)
+		}
+	}, nil)
+
+	if err := syncKnativeTriggers(t.Context(), client, ksvc, desired); err != nil {
+		t.Fatalf("syncKnativeTriggers returned error: %v", err)
 	}
-	// desiredCount=2 means indices 2 and 3 are stale
-	err := deleteStaleTriggers(triggers, prefix, 2, deleteFn)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(deleted) != 2 {
-		t.Fatalf("expected 2 deletions, got %v", deleted)
-	}
-	if deleted[0] != "my-func-function-trigger-2" || deleted[1] != "my-func-function-trigger-3" {
-		t.Fatalf("unexpected deleted triggers: %v", deleted)
-	}
+	client.Recorder().Validate()
 }
 
-// TestDeleteStaleTriggers_SkipsNonMatching ensures triggers that don't match the prefix or
-// have unparseable suffixes are skipped.
-func TestDeleteStaleTriggers_SkipsNonMatching(t *testing.T) {
-	triggers := []string{
-		"other-trigger-0",              // wrong prefix
-		"my-func-function-trigger-abc", // unparseable index
-		"my-func-function-trigger-2",   // stale, should be deleted
+func TestSyncKnativeTriggers_SkipsUnownedSamePrefixTrigger(t *testing.T) {
+	ksvc := testKnativeService("my-func")
+	existing := newKnativeTrigger(ksvc, fn.KnativeSubscription{Source: "old"}, 2)
+	existing.Annotations = nil
+	existing.OwnerReferences = nil
+
+	client := clienteventingv1.NewMockKnEventingClient(t)
+	client.Recorder().ListTriggers(&eventingv1.TriggerList{Items: []eventingv1.Trigger{*existing}}, nil)
+
+	if err := syncKnativeTriggers(t.Context(), client, ksvc, nil); err != nil {
+		t.Fatalf("syncKnativeTriggers returned error: %v", err)
 	}
-	prefix := "my-func-function-trigger-"
-	var deleted []string
-	deleteFn := func(name string) error {
-		deleted = append(deleted, name)
-		return nil
-	}
-	err := deleteStaleTriggers(triggers, prefix, 1, deleteFn)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(deleted) != 1 || deleted[0] != "my-func-function-trigger-2" {
-		t.Fatalf("expected only trigger-2 deleted, got %v", deleted)
-	}
+	client.Recorder().Validate()
 }
 
-// TestDeleteStaleTriggers_DeleteError ensures errors from the delete callback are returned.
-func TestDeleteStaleTriggers_DeleteError(t *testing.T) {
-	triggers := []string{"my-func-function-trigger-5"}
-	prefix := "my-func-function-trigger-"
-	deleteFn := func(name string) error {
-		return fmt.Errorf("connection refused")
+func TestSyncKnativeTriggers_EventingUnavailable(t *testing.T) {
+	ksvc := testKnativeService("my-func")
+	client := clienteventingv1.NewMockKnEventingClient(t)
+	client.Recorder().ListTriggers(nil, errors.New("no or newer Knative Eventing API found on the backend"))
+
+	if err := syncKnativeTriggers(t.Context(), client, ksvc, nil); err != nil {
+		t.Fatalf("expected eventing unavailable to be ignored, got %v", err)
 	}
-	err := deleteStaleTriggers(triggers, prefix, 1, deleteFn)
+	client.Recorder().Validate()
+}
+
+func TestSyncKnativeTriggers_DeleteError(t *testing.T) {
+	ksvc := testKnativeService("my-func")
+	existing := newKnativeTrigger(ksvc, fn.KnativeSubscription{Source: "old"}, 5)
+	client := clienteventingv1.NewMockKnEventingClient(t)
+	client.Recorder().ListTriggers(&eventingv1.TriggerList{Items: []eventingv1.Trigger{*existing}}, nil)
+	client.Recorder().DeleteTrigger("my-func-function-trigger-5", errors.New("connection refused"))
+
+	err := syncKnativeTriggers(t.Context(), client, ksvc, nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if !strings.Contains(err.Error(), "connection refused") {
 		t.Fatalf("expected 'connection refused' in error, got: %v", err)
+	}
+	client.Recorder().Validate()
+}
+
+func testKnativeService(name string) *servingv1.Service {
+	return &servingv1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "serving.knative.dev/v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			UID:  "ksvc-uid",
+		},
 	}
 }

--- a/pkg/knative/deployer_test.go
+++ b/pkg/knative/deployer_test.go
@@ -461,3 +461,87 @@ func assertAuth(uname, pwd string, w http.ResponseWriter, r *http.Request) bool 
 	_, _ = fmt.Fprintln(w, "Unauthorised.")
 	return false
 }
+
+// TestDeleteStaleTriggers_NoStale ensures no triggers are deleted when all are within range.
+func TestDeleteStaleTriggers_NoStale(t *testing.T) {
+	triggers := []string{"my-func-function-trigger-0", "my-func-function-trigger-1"}
+	prefix := "my-func-function-trigger-"
+	var deleted []string
+	deleteFn := func(name string) error {
+		deleted = append(deleted, name)
+		return nil
+	}
+	err := deleteStaleTriggers(triggers, prefix, 2, deleteFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(deleted) != 0 {
+		t.Fatalf("expected no deletions, got %v", deleted)
+	}
+}
+
+// TestDeleteStaleTriggers_DeletesStale ensures triggers beyond desired count are deleted.
+func TestDeleteStaleTriggers_DeletesStale(t *testing.T) {
+	triggers := []string{
+		"my-func-function-trigger-0",
+		"my-func-function-trigger-1",
+		"my-func-function-trigger-2",
+		"my-func-function-trigger-3",
+	}
+	prefix := "my-func-function-trigger-"
+	var deleted []string
+	deleteFn := func(name string) error {
+		deleted = append(deleted, name)
+		return nil
+	}
+	// desiredCount=2 means indices 2 and 3 are stale
+	err := deleteStaleTriggers(triggers, prefix, 2, deleteFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(deleted) != 2 {
+		t.Fatalf("expected 2 deletions, got %v", deleted)
+	}
+	if deleted[0] != "my-func-function-trigger-2" || deleted[1] != "my-func-function-trigger-3" {
+		t.Fatalf("unexpected deleted triggers: %v", deleted)
+	}
+}
+
+// TestDeleteStaleTriggers_SkipsNonMatching ensures triggers that don't match the prefix or
+// have unparseable suffixes are skipped.
+func TestDeleteStaleTriggers_SkipsNonMatching(t *testing.T) {
+	triggers := []string{
+		"other-trigger-0",              // wrong prefix
+		"my-func-function-trigger-abc", // unparseable index
+		"my-func-function-trigger-2",   // stale, should be deleted
+	}
+	prefix := "my-func-function-trigger-"
+	var deleted []string
+	deleteFn := func(name string) error {
+		deleted = append(deleted, name)
+		return nil
+	}
+	err := deleteStaleTriggers(triggers, prefix, 1, deleteFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(deleted) != 1 || deleted[0] != "my-func-function-trigger-2" {
+		t.Fatalf("expected only trigger-2 deleted, got %v", deleted)
+	}
+}
+
+// TestDeleteStaleTriggers_DeleteError ensures errors from the delete callback are returned.
+func TestDeleteStaleTriggers_DeleteError(t *testing.T) {
+	triggers := []string{"my-func-function-trigger-5"}
+	prefix := "my-func-function-trigger-"
+	deleteFn := func(name string) error {
+		return fmt.Errorf("connection refused")
+	}
+	err := deleteStaleTriggers(triggers, prefix, 1, deleteFn)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Fatalf("expected 'connection refused' in error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

createTriggers only creates triggers but never removes stale ones. If a user removes a subscription from func.yaml and redeploys, old triggers with higher indices remain orphaned on the cluster.

## Fix

Added a cleanup step after trigger creation that lists existing triggers matching the naming pattern and deletes any whose index exceeds the current subscription count. This mirrors the deleteStaleTriggers pattern used in the k8s deployer.

Fixes #3799