### PR TITLE
fix(mcp): add readonly guard to createHandler

### DIFF
--- a/pkg/mcp/instructions_warning.md
+++ b/pkg/mcp/instructions_warning.md
@@ -7,20 +7,20 @@
 The Functions MCP server is currently running in **read-only mode**.
 
 **Available operations:**
-- Create Functions
-- Build Functions
 - Configure Functions (envs, labels, volumes)
 - Inspect Functions
 
 **Disabled operations:**
+- Create Functions
+- Build Function images
 - Deploy to cluster
 - Delete from cluster
 
-These write operations are disabled to prevent unintended cluster modifications.
+These write operations are disabled to prevent unintended local or cluster modifications.
 
 ## Enabling Write Mode
 
-If the user needs to deploy or delete Functions, you MUST inform them to enable write mode:
+If the user needs to create, build, deploy, or delete Functions, you MUST inform them to enable write mode:
 
 1. Close/exit this application completely
 2. Set the environment variable: `FUNC_ENABLE_MCP_WRITE=true`

--- a/pkg/mcp/tools_create.go
+++ b/pkg/mcp/tools_create.go
@@ -21,7 +21,7 @@ var createTool = &mcp.Tool{
 
 func (s *Server) createHandler(ctx context.Context, r *mcp.CallToolRequest, input CreateInput) (result *mcp.CallToolResult, output CreateOutput, err error) {
 	if s.readonly.Load() {
-		err = fmt.Errorf("the server is currently in readonly mode.  Please set FUNC_ENABLE_MCP_WRITE and restart the client")
+		err = fmt.Errorf("the server is currently in read-only mode; to enable write operations, set FUNC_ENABLE_MCP_WRITE in the server environment and restart the server")
 		return
 	}
 	out, err := s.executor.Execute(ctx, "create", input.Args()...)

--- a/pkg/mcp/tools_create.go
+++ b/pkg/mcp/tools_create.go
@@ -20,6 +20,10 @@ var createTool = &mcp.Tool{
 }
 
 func (s *Server) createHandler(ctx context.Context, r *mcp.CallToolRequest, input CreateInput) (result *mcp.CallToolResult, output CreateOutput, err error) {
+	if s.readonly.Load() {
+		err = fmt.Errorf("the server is currently in readonly mode.  Please set FUNC_ENABLE_MCP_WRITE and restart the client")
+		return
+	}
 	out, err := s.executor.Execute(ctx, "create", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))

--- a/pkg/mcp/tools_create_test.go
+++ b/pkg/mcp/tools_create_test.go
@@ -123,3 +123,25 @@ func TestTool_Create_BinaryFailure(t *testing.T) {
 		t.Errorf("expected error to include binary output, got: %s", resultToString(result))
 	}
 }
+
+// TestTool_Create_Readonly ensures the create tool rejects requests in readonly mode.
+func TestTool_Create_Readonly(t *testing.T) {
+	client, _, err := newTestPairWithReadonly(t, true) // readonly = true
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "create",
+		Arguments: map[string]any{"language": "go", "path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected create to be rejected in readonly mode")
+	}
+	if !strings.Contains(resultToString(result), "readonly mode") {
+		t.Errorf("expected readonly error message, got: %s", resultToString(result))
+	}
+}

--- a/pkg/mcp/tools_create_test.go
+++ b/pkg/mcp/tools_create_test.go
@@ -141,7 +141,7 @@ func TestTool_Create_Readonly(t *testing.T) {
 	if !result.IsError {
 		t.Fatal("expected create to be rejected in readonly mode")
 	}
-	if !strings.Contains(resultToString(result), "readonly mode") {
+	if !strings.Contains(resultToString(result), "read-only mode") {
 		t.Errorf("expected readonly error message, got: %s", resultToString(result))
 	}
 }


### PR DESCRIPTION
## Problem

The createHandler in pkg/mcp/tools_create.go lacks the s.readonly.Load() check that is present in other mutating tools like deployHandler and deleteHandler.

Because of this, an MCP client can execute the create command (which writes project scaffolding files to the disk) even when the server is operating in readonly mode.

## Fix

Added the s.readonly.Load() guard to match the behavior of other tools.

Fixes #3810