### PR TITLE
fix(keda): add defensive length check when accessing service Ports

### DIFF
--- a/pkg/keda/deployer.go
+++ b/pkg/keda/deployer.go
@@ -136,6 +136,10 @@ func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (fn.DeploymentResu
 }
 
 func (d *Deployer) httpScaledObject(f fn.Function, namespace string, deployment *v1.Deployment, service *corev1.Service, hosts []string) (*httpv1alpha1.HTTPScaledObject, error) {
+	if len(service.Spec.Ports) == 0 {
+		return nil, fmt.Errorf("service %s has no ports defined", service.Name)
+	}
+
 	labels, err := deployer.GenerateCommonLabels(f, d.decorator)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate common labels: %w", err)


### PR DESCRIPTION
## Problem

In pkg/keda/deployer.go, the code accesses service.Spec.Ports[0].Port to build the HTTP ScaledObject. The service object is fetched live from the Kubernetes cluster.

While the upstream deployers will always generate a service with exactly one port during normal operations, this code lacks a defensive length check on the Ports slice. If a user or an external controller manually modifies the service in the cluster to remove its ports, the KEDA deployer will crash with an out of bounds panic during reconciliation.

## Fix

Added a defensive check for len(service.Spec.Ports) > 0 to prevent this.

Fixes #3812