### PR TITLE
mcp: Add logs tool to retrieve deployed Function logs

### DIFF
--- a/pkg/mcp/instructions.md
+++ b/pkg/mcp/instructions.md
@@ -57,6 +57,7 @@ This is essential because:
 - Before 'deploy' → Read `func://help/deploy`
 - Before 'build' → Read `func://help/build`
 - Before 'list' → Read `func://help/list`
+- Before 'logs' → Read `func://help/logs`
 - Before 'delete' → Read `func://help/delete`
 
 The help text provides authoritative parameter information and usage context.
@@ -130,6 +131,17 @@ A first-time deploy can be detected by checking the func.yaml for a value in the
 - Does NOT use path parameter (operates on cluster, not local files)
 - Optional `namespace` parameter to list Functions in specific namespace
 - Returns list of deployed Functions in current/specified namespace
+
+### logs
+
+- **FIRST:** Read `func://help/logs` for authoritative usage information
+- Identify the Function by **path** (reads func.yaml) OR by **name** — never both at the same time
+- `path` must be an absolute path to the Function project directory
+- `name` is the deployed Function name on the cluster
+- Optional `namespace` parameter to target a specific Kubernetes namespace
+- Optional `since` parameter controls the time window of returned logs (e.g. `30s`, `5m`, `2h`; default is `1m`)
+- This tool is **read-only** — it never modifies any state
+- Use logs to diagnose a deployed Function after `deploy`, especially when combined with `invoke` to trigger the Function and observe its output
 
 ### delete
 

--- a/pkg/mcp/instructions.md
+++ b/pkg/mcp/instructions.md
@@ -63,6 +63,7 @@ This is essential because:
 - Before 'invoke' → Read `func://help/invoke`
 - Before 'list' → Read `func://help/list`
 - Before 'describe' → Read `func://help/describe`
+- Before 'logs' → Read `func://help/logs`
 - Before 'delete' → Read `func://help/delete`
 - Before 'run' → Read `func://help/run`
 
@@ -167,6 +168,17 @@ A first-time deploy can be detected by checking the func.yaml for a value in the
 - Exactly ONE of 'path' or 'name' must be provided, not both
 - 'namespace' is only valid together with 'name'; providing both 'path' and 'namespace' is rejected, since path mode already determines the namespace from the Function's own deploy identity
 - Read-only; does not modify local files or cluster resources
+
+### logs
+
+- **FIRST:** Read `func://help/logs` for authoritative usage information
+- Identify the Function by **path** (reads func.yaml) OR by **name** — never both at the same time
+- `path` must be an absolute path to the Function project directory
+- `name` is the deployed Function name on the cluster
+- Optional `namespace` parameter to target a specific Kubernetes namespace
+- Optional `since` parameter controls the time window of returned logs (e.g. `30s`, `5m`, `2h`; default is `1m`)
+- This tool is **read-only** — it never modifies any state
+- Use logs to diagnose a deployed Function after `deploy`, especially when combined with `invoke` to trigger the Function and observe its output
 
 ### delete
 

--- a/pkg/mcp/instructions.md
+++ b/pkg/mcp/instructions.md
@@ -42,7 +42,7 @@ This is essential because:
 
 **Exceptions:**
 - The `list` tool operates on the cluster, not local files, so it does NOT use a path parameter (it uses namespace instead)
-- The `delete` and `describe` tools each require exactly one of `path` or `name`; they do NOT support a no-argument CWD mode (the MCP server process has its own working directory unrelated to the Function being managed)
+- The `delete`, `describe` and `logs` tools each require exactly one of `path` or `name`; they do NOT support a no-argument CWD mode (the MCP server process has its own working directory unrelated to the Function being managed)
 
 ## Deployment Behavior
 
@@ -175,13 +175,15 @@ A first-time deploy can be detected by checking the func.yaml for a value in the
 - Exactly one of `path` or `name` is required (same shape as `delete` / `describe`) — never both, and never neither
 - `path` must be an absolute path to the Function project directory (reads func.yaml); `name` is the deployed Function name on the cluster
 - The Function must already be **deployed** — in path mode the tool still talks to the cluster via the project's deploy identity, so calling it before `deploy` is a usage error, not a tool bug
-- Returns a **finite snapshot** of recent logs (it prints and exits; it is not a live stream); the default is every line the Function's pods have retained, so bound the output with `since` (time window, e.g. `30s`, `5m`, `2h`) and/or `tail` (most recent lines per pod) whenever the volume is large or unknown
+- Returns a **finite snapshot** of recent logs (it prints and exits; it is not a live stream); the default is the most recent 1000 lines per pod, so the output is bounded even when you pass neither `since` nor `tail`
+- Narrow it further with `since` (time window, e.g. `30s`, `5m`, `2h`) and/or a smaller `tail` (most recent lines per pod); a negative `tail` means unlimited, and is the only way to ask for every retained line
 - If the payload exceeds the tool's size limit, only the most recent lines are returned and `truncated` is set to true; re-run with `tail` or `since` rather than assuming the output is complete
 - **Always read `warnings` before concluding a Function produced no output.** Empty or partial `logs` with a zero exit is normal and explained there: the Function may have scaled to zero (no pods, therefore no logs), or the logs of only some of its pods could be read
-- The `namespace` parameter is only valid together with `name`; providing both `path` and `namespace` is rejected, since path mode determines the namespace from the Function's own deploy identity
+- `namespace` applies when identifying the Function by `name`. In `path` mode the namespace is read from the Function's own deploy identity in func.yaml and `namespace` has no effect — the same behavior as `func logs`, which this tool does not add rules on top of
 - When more than one pod serves the Function, each line is prefixed with `[pod/<name>] `
 - `follow`/streaming is deliberately not exposed: it never terminates, so it is unusable from an agent. Use `since`/`tail` and call again to observe new output
 - Only Functions deployed with the default **knative** deployer are supported; for other deployers the CLI returns an error directing you to `kubectl logs`
+- `verbose` output is written to the same stream the notices come back on, so enabling it makes `warnings` considerably noisier; the returned notices are bounded and older ones are dropped when they overflow
 - This tool is **read-only** — it never modifies any state
 - Use logs to diagnose a deployed Function after `deploy`, especially when combined with `invoke` to trigger the Function and observe its output
 

--- a/pkg/mcp/instructions.md
+++ b/pkg/mcp/instructions.md
@@ -175,8 +175,12 @@ A first-time deploy can be detected by checking the func.yaml for a value in the
 - Exactly one of `path` or `name` is required (same shape as `delete` / `describe`) — never both, and never neither
 - `path` must be an absolute path to the Function project directory (reads func.yaml); `name` is the deployed Function name on the cluster
 - The Function must already be **deployed** — in path mode the tool still talks to the cluster via the project's deploy identity, so calling it before `deploy` is a usage error, not a tool bug
-- Returns a **finite snapshot** of recent logs (it prints and exits; it is not a live stream); use the optional `since` parameter to bound the window (e.g. `30s`, `5m`, `2h`; default is all available logs)
-- Optional `namespace` parameter to target a specific Kubernetes namespace
+- Returns a **finite snapshot** of recent logs (it prints and exits; it is not a live stream); the default is every line the Function's pods have retained, so bound the output with `since` (time window, e.g. `30s`, `5m`, `2h`) and/or `tail` (most recent lines per pod) whenever the volume is large or unknown
+- If the payload exceeds the tool's size limit, only the most recent lines are returned and `truncated` is set to true; re-run with `tail` or `since` rather than assuming the output is complete
+- **Always read `warnings` before concluding a Function produced no output.** Empty or partial `logs` with a zero exit is normal and explained there: the Function may have scaled to zero (no pods, therefore no logs), or the logs of only some of its pods could be read
+- The `namespace` parameter is only valid together with `name`; providing both `path` and `namespace` is rejected, since path mode determines the namespace from the Function's own deploy identity
+- When more than one pod serves the Function, each line is prefixed with `[pod/<name>] `
+- `follow`/streaming is deliberately not exposed: it never terminates, so it is unusable from an agent. Use `since`/`tail` and call again to observe new output
 - Only Functions deployed with the default **knative** deployer are supported; for other deployers the CLI returns an error directing you to `kubectl logs`
 - This tool is **read-only** — it never modifies any state
 - Use logs to diagnose a deployed Function after `deploy`, especially when combined with `invoke` to trigger the Function and observe its output

--- a/pkg/mcp/instructions.md
+++ b/pkg/mcp/instructions.md
@@ -172,11 +172,12 @@ A first-time deploy can be detected by checking the func.yaml for a value in the
 ### logs
 
 - **FIRST:** Read `func://help/logs` for authoritative usage information
-- Identify the Function by **path** (reads func.yaml) OR by **name** — never both at the same time
-- `path` must be an absolute path to the Function project directory
-- `name` is the deployed Function name on the cluster
+- Exactly one of `path` or `name` is required (same shape as `delete` / `describe`) — never both, and never neither
+- `path` must be an absolute path to the Function project directory (reads func.yaml); `name` is the deployed Function name on the cluster
+- The Function must already be **deployed** — in path mode the tool still talks to the cluster via the project's deploy identity, so calling it before `deploy` is a usage error, not a tool bug
+- Returns a **finite snapshot** of recent logs (it prints and exits; it is not a live stream); use the optional `since` parameter to bound the window (e.g. `30s`, `5m`, `2h`; default is all available logs)
 - Optional `namespace` parameter to target a specific Kubernetes namespace
-- Optional `since` parameter controls the time window of returned logs (e.g. `30s`, `5m`, `2h`; default is `1m`)
+- Only Functions deployed with the default **knative** deployer are supported; for other deployers the CLI returns an error directing you to `kubectl logs`
 - This tool is **read-only** — it never modifies any state
 - Use logs to diagnose a deployed Function after `deploy`, especially when combined with `invoke` to trigger the Function and observe its output
 

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -108,6 +108,7 @@ func New(options ...Option) *Server {
 	mcp.AddTool(i, buildTool, s.buildHandler)
 	mcp.AddTool(i, deployTool, s.deployHandler)
 	mcp.AddTool(i, listTool, s.listHandler)
+	mcp.AddTool(i, logsTool, s.logsHandler)
 	mcp.AddTool(i, deleteTool, s.deleteHandler)
 	mcp.AddTool(i, configVolumesListTool, s.configVolumesListHandler)
 	mcp.AddTool(i, configVolumesAddTool, s.configVolumesAddHandler)
@@ -138,6 +139,7 @@ func New(options ...Option) *Server {
 	i.AddResource(newHelpResource(s, "Build Help", "help for 'build'", "build"))
 	i.AddResource(newHelpResource(s, "Deploy Help", "help for 'deploy'", "deploy"))
 	i.AddResource(newHelpResource(s, "List Help", "help for 'list'", "list"))
+	i.AddResource(newHelpResource(s, "Logs Help", "help for 'logs'", "logs"))
 	i.AddResource(newHelpResource(s, "Delete Help", "help for delete", "delete"))
 
 	i.AddResource(newHelpResource(s, "Volumes Help", "general help for volumes", "config", "volumes"))

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -137,6 +137,7 @@ func New(options ...Option) *Server {
 	mcp.AddTool(i, invokeTool, s.invokeHandler)
 	mcp.AddTool(i, listTool, s.listHandler)
 	mcp.AddTool(i, describeTool, s.describeHandler)
+	mcp.AddTool(i, logsTool, s.logsHandler)
 	mcp.AddTool(i, deleteTool, s.deleteHandler)
 	mcp.AddTool(i, runTool, s.runHandler)
 	mcp.AddTool(i, runStopTool, s.runStopHandler)
@@ -179,6 +180,7 @@ func New(options ...Option) *Server {
 	i.AddResource(newHelpResource(s, "Invoke Help", "help for 'invoke'", "invoke"))
 	i.AddResource(newHelpResource(s, "List Help", "help for 'list'", "list"))
 	i.AddResource(newHelpResource(s, "Describe Help", "help for 'describe'", "describe"))
+	i.AddResource(newHelpResource(s, "Logs Help", "help for 'logs'", "logs"))
 	i.AddResource(newHelpResource(s, "Delete Help", "help for delete", "delete"))
 
 	i.AddResource(newHelpResource(s, "Volumes Help", "general help for volumes", "config", "volumes"))

--- a/pkg/mcp/tools_logs.go
+++ b/pkg/mcp/tools_logs.go
@@ -1,0 +1,68 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+var logsTool = &mcp.Tool{
+	Name:        "logs",
+	Title:       "Get Function Logs",
+	Description: "Retrieve recent logs from a deployed Function. Use --since to control the time window (e.g. '5m', '1h'). Identify the Function by path (reads func.yaml) or by name.",
+	Annotations: &mcp.ToolAnnotations{
+		Title:           "Get Function Logs",
+		ReadOnlyHint:    true,
+		DestructiveHint: ptr(false),
+		IdempotentHint:  true,
+	},
+}
+
+func (s *Server) logsHandler(ctx context.Context, r *mcp.CallToolRequest, input LogsInput) (result *mcp.CallToolResult, output LogsOutput, err error) {
+	if input.Path != nil && input.Name != nil {
+		err = fmt.Errorf("'path' and 'name' are mutually exclusive: provide exactly one")
+		return
+	}
+
+	out, err := s.executor.Execute(ctx, "logs", input.Args()...)
+	if err != nil {
+		err = fmt.Errorf("%w\n%s", err, string(out))
+		return
+	}
+	output = LogsOutput{
+		Logs: string(out),
+	}
+	return
+}
+
+// LogsInput defines the input parameters for the logs tool.
+// At most one of Path or Name may be provided; if neither is given the
+// server's working directory is used (same default behaviour as the CLI).
+type LogsInput struct {
+	Path      *string `json:"path,omitempty"      jsonschema:"Absolute path to the Function project directory (mutually exclusive with name)"`
+	Name      *string `json:"name,omitempty"      jsonschema:"Name of the deployed Function to fetch logs for (mutually exclusive with path)"`
+	Namespace *string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace of the Function (default: current namespace)"`
+	Since     *string `json:"since,omitempty"     jsonschema:"Return logs newer than a relative duration such as 30s, 5m, or 2h (default: 1m)"`
+	Verbose   *bool   `json:"verbose,omitempty"   jsonschema:"Enable verbose logging output"`
+}
+
+func (i LogsInput) Args() []string {
+	args := []string{}
+
+	if i.Path != nil {
+		args = append(args, "--path", *i.Path)
+	} else if i.Name != nil {
+		args = append(args, "--name", *i.Name)
+	}
+
+	args = appendStringFlag(args, "--namespace", i.Namespace)
+	args = appendStringFlag(args, "--since", i.Since)
+	args = appendBoolFlag(args, "--verbose", i.Verbose)
+	return args
+}
+
+// LogsOutput defines the structured output returned by the logs tool.
+type LogsOutput struct {
+	Logs string `json:"logs" jsonschema:"Log output from the deployed Function"`
+}

--- a/pkg/mcp/tools_logs.go
+++ b/pkg/mcp/tools_logs.go
@@ -10,7 +10,7 @@ import (
 var logsTool = &mcp.Tool{
 	Name:        "logs",
 	Title:       "Get Function Logs",
-	Description: "Retrieve recent logs from a deployed Function. Use --since to control the time window (e.g. '5m', '1h'). Identify the Function by path (reads func.yaml) or by name.",
+	Description: "Retrieve recent logs from a deployed Function. Use the since argument to control the time window (e.g. '5m', '1h'). Identify the Function by path (reads func.yaml) or by name.",
 	Annotations: &mcp.ToolAnnotations{
 		Title:           "Get Function Logs",
 		ReadOnlyHint:    true,
@@ -21,7 +21,7 @@ var logsTool = &mcp.Tool{
 
 func (s *Server) logsHandler(ctx context.Context, r *mcp.CallToolRequest, input LogsInput) (result *mcp.CallToolResult, output LogsOutput, err error) {
 	if input.Path != nil && input.Name != nil {
-		err = fmt.Errorf("'path' and 'name' are mutually exclusive: provide exactly one")
+		err = fmt.Errorf("'path' and 'name' are mutually exclusive: provide at most one")
 		return
 	}
 

--- a/pkg/mcp/tools_logs.go
+++ b/pkg/mcp/tools_logs.go
@@ -10,40 +10,48 @@ import (
 var logsTool = &mcp.Tool{
 	Name:        "logs",
 	Title:       "Get Function Logs",
-	Description: "Retrieve recent logs from a deployed Function. Use the since argument to control the time window (e.g. '5m', '1h'). Identify the Function by path (reads func.yaml) or by name.",
+	Description: "Retrieve a finite snapshot of recent logs from a deployed Function (prints and returns, does not stream). Use --since to bound the time window (e.g. '5m', '1h'). Identify the Function by path (reads func.yaml) or by name.",
 	Annotations: &mcp.ToolAnnotations{
-		Title:           "Get Function Logs",
-		ReadOnlyHint:    true,
+		Title:        "Get Function Logs",
+		ReadOnlyHint: true,
+		// A logs snapshot is read-only but not idempotent: the same call
+		// made later returns a different (growing) set of log lines, so
+		// IdempotentHint is intentionally left unset (false).
 		DestructiveHint: ptr(false),
-		IdempotentHint:  true,
 	},
 }
 
 func (s *Server) logsHandler(ctx context.Context, r *mcp.CallToolRequest, input LogsInput) (result *mcp.CallToolResult, output LogsOutput, err error) {
-	if input.Path != nil && input.Name != nil {
-		err = fmt.Errorf("'path' and 'name' are mutually exclusive: provide at most one")
+	// Unlike the CLI, the MCP tool does not fall back to the server's working
+	// directory: an agent has no meaningful cwd, so require an explicit target.
+	// Exactly one of Path or Name must be provided (same shape as describe/delete).
+	if (input.Path != nil && input.Name != nil) || (input.Path == nil && input.Name == nil) {
+		err = fmt.Errorf("exactly one of 'path' or 'name' must be provided")
 		return
 	}
 
-	out, err := s.executor.Execute(ctx, "logs", input.Args()...)
+	// ExecuteSplit (rather than Execute/CombinedOutput) is required here so the
+	// returned logs are clean stdout only. `func logs` writes a status banner to
+	// stderr (e.g. "Logs for function '…' in namespace '…' since '…'...") that
+	// would otherwise be interleaved into the log output an agent parses.
+	stdout, stderr, err := s.executor.ExecuteSplit(ctx, "logs", input.Args()...)
 	if err != nil {
-		err = fmt.Errorf("%w\n%s", err, string(out))
+		err = fmt.Errorf("%w\nstdout: %s\nstderr: %s", err, string(stdout), string(stderr))
 		return
 	}
 	output = LogsOutput{
-		Logs: string(out),
+		Logs: string(stdout),
 	}
 	return
 }
 
 // LogsInput defines the input parameters for the logs tool.
-// At most one of Path or Name may be provided; if neither is given the
-// server's working directory is used (same default behaviour as the CLI).
+// Exactly one of Path or Name must be provided.
 type LogsInput struct {
 	Path      *string `json:"path,omitempty"      jsonschema:"Absolute path to the Function project directory (mutually exclusive with name)"`
 	Name      *string `json:"name,omitempty"      jsonschema:"Name of the deployed Function to fetch logs for (mutually exclusive with path)"`
 	Namespace *string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace of the Function (default: current namespace)"`
-	Since     *string `json:"since,omitempty"     jsonschema:"Return logs newer than a relative duration such as 30s, 5m, or 2h (default: 1m)"`
+	Since     *string `json:"since,omitempty"     jsonschema:"Return logs newer than a relative duration such as 30s, 5m, or 2h (default: all available logs)"`
 	Verbose   *bool   `json:"verbose,omitempty"   jsonschema:"Enable verbose logging output"`
 }
 

--- a/pkg/mcp/tools_logs.go
+++ b/pkg/mcp/tools_logs.go
@@ -3,22 +3,44 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// maxLogBytes bounds the log payload returned by the logs tool.  A snapshot
-// defaults to every line the Function's pods have retained (see 'func logs
-// --tail'), which for a chatty Function is more than an agent's context can
-// hold.  The most recent lines are kept, and the fact that older lines were
-// dropped is reported via LogsOutput.Truncated rather than being silent.
+// defaultTailLines bounds at the source how much log output the CLI is asked
+// to gather when the caller has not bounded it themselves.  'func logs'
+// defaults to every line the Function's pods have retained, and the executor
+// buffers that in full before this package sees any of it, so a default is
+// applied here rather than gathering everything and discarding most of it
+// after the fact.  It is declared in the tool's input schema, and a negative
+// 'tail' still means unlimited, exactly as it does in the CLI.
+const defaultTailLines = 1000
+
+// maxLogBytes is a backstop on the log payload returned to the caller, for
+// the cases defaultTailLines does not bound: an explicitly large (or
+// unlimited) 'tail', or a Function served by many pods, each contributing its
+// own tail.  The most recent lines are kept, and the fact that older lines
+// were dropped is reported via LogsOutput.Truncated rather than being silent.
 const maxLogBytes = 256 * 1024
+
+// maxWarningBytes bounds the notices returned alongside the logs.  stderr is
+// not necessarily a line or two: 'verbose' writes its output there, as does
+// one warning per pod whose logs could not be read, so it needs a bound of
+// its own rather than being returned whole.
+const maxWarningBytes = 8 * 1024
+
+// warningsTruncatedMarker introduces a warnings payload which was itself too
+// large to return, so that the notices which remain are not mistaken for all
+// of them.
+const warningsTruncatedMarker = "[...older notices omitted...]"
 
 var logsTool = &mcp.Tool{
 	Name:        "logs",
 	Title:       "Get Function Logs",
-	Description: "Retrieve a finite snapshot of recent logs from a deployed Function (prints and returns, does not stream). Bound the output with 'since' (time window, e.g. '5m') and 'tail' (most recent lines per pod). Identify the Function by path (reads func.yaml) or by name.",
+	Description: "Retrieve a finite snapshot of recent logs from a deployed Function (prints and returns, does not stream). Returns the most recent 1000 lines per pod by default; bound it explicitly with 'tail' and/or 'since' (time window, e.g. '5m'). Identify the Function by path (reads func.yaml) or by name.",
 	Annotations: &mcp.ToolAnnotations{
 		Title:        "Get Function Logs",
 		ReadOnlyHint: true,
@@ -32,18 +54,15 @@ func (s *Server) logsHandler(ctx context.Context, r *mcp.CallToolRequest, input 
 	// Unlike the CLI, the MCP tool does not fall back to the server's working
 	// directory: an agent has no meaningful cwd, so require an explicit target.
 	// Exactly one of Path or Name must be provided (same shape as describe/delete).
+	//
+	// NOTE: no further validation is performed here.  In particular
+	// 'namespace' is forwarded as given, including alongside 'path', where
+	// the CLI reads the namespace from the Function's own deploy identity and
+	// ignores the flag.  Rejecting that combination would be a rule this tool
+	// enforces and 'func logs' does not, which is a divergence between the two
+	// surfaces rather than a fix.
 	if (input.Path != nil && input.Name != nil) || (input.Path == nil && input.Name == nil) {
 		err = fmt.Errorf("exactly one of 'path' or 'name' must be provided")
-		return
-	}
-
-	// Validate: namespace only makes sense alongside 'name'.  When fetching
-	// logs by 'path', the CLI resolves the Function's name and namespace from
-	// its own deploy identity (func.yaml) and ignores --namespace entirely.
-	// Rejecting the combination is the same rule the describe tool applies,
-	// and avoids returning another namespace's logs while reporting success.
-	if input.Path != nil && input.Namespace != nil {
-		err = fmt.Errorf("'namespace' is only valid with 'name'; when fetching logs by 'path', the namespace is read from the Function's own deploy identity")
 		return
 	}
 
@@ -60,16 +79,15 @@ func (s *Server) logsHandler(ctx context.Context, r *mcp.CallToolRequest, input 
 		return
 	}
 
-	logs, truncated := truncateLogs(string(stdout))
+	// Truncation of the logs is reported by Truncated alone.  It is
+	// deliberately not also described in Warnings: two channels for one fact
+	// invite the caller to report it twice, and Warnings is what the CLI
+	// said, not what this tool did to the payload.
+	logs, truncated := truncateTail(string(stdout), maxLogBytes)
 
-	warnings := strings.TrimSpace(string(stderr))
-	if truncated {
-		notice := fmt.Sprintf("Output exceeded %d bytes: only the most recent lines are included. Use 'tail' or 'since' to bound the window.", maxLogBytes)
-		if warnings == "" {
-			warnings = notice
-		} else {
-			warnings += "\n" + notice
-		}
+	warnings, warningsTruncated := truncateTail(strings.TrimSpace(string(stderr)), maxWarningBytes)
+	if warningsTruncated {
+		warnings = warningsTruncatedMarker + "\n" + warnings
 	}
 
 	output = LogsOutput{
@@ -80,18 +98,49 @@ func (s *Server) logsHandler(ctx context.Context, r *mcp.CallToolRequest, input 
 	return
 }
 
-// truncateLogs bounds logs to maxLogBytes, keeping the most recent lines and
-// reporting whether anything was dropped.  Truncation is to a line boundary so
-// the first line returned is not a fragment of an older one.
-func truncateLogs(logs string) (string, bool) {
-	if len(logs) <= maxLogBytes {
-		return logs, false
+// truncateTail bounds s to its last 'limit' bytes, keeping the most recent lines
+// and reporting whether anything was dropped.
+//
+// Whole lines are preserved in both directions: the first line returned is
+// never a fragment of an older one, and no complete line is discarded in
+// order to reach a line boundary the cut had already landed on.  A single
+// line longer than the limit is the one case which cannot be honored; its tail is
+// returned, trimmed to a rune boundary so that the result is still valid
+// UTF-8.
+func truncateTail(s string, limit int) (string, bool) {
+	if len(s) <= limit {
+		return s, false
 	}
-	truncated := logs[len(logs)-maxLogBytes:]
-	if i := strings.IndexByte(truncated, '\n'); i >= 0 {
-		truncated = truncated[i+1:]
+	cut := len(s) - limit // >= 1, since len(s) > limit
+
+	// A cut which lands immediately after a newline already begins a whole,
+	// intact line.  Searching forward for a newline from here would find that
+	// line's own terminator and silently drop the entire line.
+	if s[cut-1] == '\n' {
+		return s[cut:], true
 	}
-	return truncated, true
+
+	// Otherwise the cut landed inside a line; drop that line's remainder.
+	if i := strings.IndexByte(s[cut:], '\n'); i >= 0 {
+		return s[cut+i+1:], true
+	}
+
+	// No newline anywhere in the retained window: a single line longer than
+	// the limit, such as one JSON log record or an un-terminated stack trace.
+	return trimPartialRune(s[cut:]), true
+}
+
+// trimPartialRune drops the leading bytes of a UTF-8 sequence which a
+// byte-wise cut left incomplete, so that s begins on a rune boundary.
+// Without it, cutting multi-byte content mid-rune yields invalid UTF-8, which
+// JSON encoding replaces with U+FFFD.
+func trimPartialRune(s string) string {
+	for i := 0; i < len(s) && i < utf8.UTFMax; i++ {
+		if utf8.RuneStart(s[i]) {
+			return s[i:]
+		}
+	}
+	return s
 }
 
 // LogsInput defines the input parameters for the logs tool.
@@ -99,10 +148,10 @@ func truncateLogs(logs string) (string, bool) {
 type LogsInput struct {
 	Path      *string `json:"path,omitempty"      jsonschema:"Absolute path to the Function project directory (mutually exclusive with name)"`
 	Name      *string `json:"name,omitempty"      jsonschema:"Name of the deployed Function to fetch logs for (mutually exclusive with path)"`
-	Namespace *string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace of the Function (default: current namespace). Only valid together with 'name'; when fetching logs by 'path' the namespace is read from the Function's own deploy identity"`
-	Since     *string `json:"since,omitempty"     jsonschema:"Return logs newer than a relative duration such as 30s, 5m, or 2h (default: all available logs)"`
-	Tail      *int    `json:"tail,omitempty"      jsonschema:"Number of most recent log lines to return per pod (default: unlimited). Prefer bounding large or unknown log volumes with this rather than fetching everything"`
-	Verbose   *bool   `json:"verbose,omitempty"   jsonschema:"Enable verbose logging output"`
+	Namespace *string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace of the Function (default: current namespace). Applies when identifying the Function by 'name'; in 'path' mode the namespace is read from the Function's own deploy identity in func.yaml and this has no effect, as in the CLI"`
+	Since     *string `json:"since,omitempty"     jsonschema:"Return logs newer than a relative duration such as 30s, 5m, or 2h (default: all retained logs, subject to tail)"`
+	Tail      *int    `json:"tail,omitempty"      jsonschema:"Number of most recent log lines to return per pod (default: 1000; a negative value means unlimited, as in the CLI). Lower it, or add 'since', to bound a large or unknown log volume further"`
+	Verbose   *bool   `json:"verbose,omitempty"   jsonschema:"Enable verbose logging output. Note this is written to the same stream as the notices returned in 'warnings'"`
 }
 
 func (i LogsInput) Args() []string {
@@ -116,9 +165,15 @@ func (i LogsInput) Args() []string {
 
 	args = appendStringFlag(args, "--namespace", i.Namespace)
 	args = appendStringFlag(args, "--since", i.Since)
+
+	// Always bounded at the source: the caller's value when given, otherwise
+	// the default.  See defaultTailLines.
+	tail := defaultTailLines
 	if i.Tail != nil {
-		args = append(args, "--tail", fmt.Sprintf("%d", *i.Tail))
+		tail = *i.Tail
 	}
+	args = append(args, "--tail", strconv.Itoa(tail))
+
 	args = appendBoolFlag(args, "--verbose", i.Verbose)
 	return args
 }
@@ -126,6 +181,6 @@ func (i LogsInput) Args() []string {
 // LogsOutput defines the structured output returned by the logs tool.
 type LogsOutput struct {
 	Logs      string `json:"logs" jsonschema:"Log output from the deployed Function. When more than one pod is serving the Function, each line is prefixed with the pod it came from"`
-	Truncated bool   `json:"truncated,omitempty" jsonschema:"True if older lines were dropped because the output exceeded the size limit; only the most recent lines are included"`
-	Warnings  string `json:"warnings,omitempty" jsonschema:"Non-fatal notices emitted while gathering the logs. Empty or partial output is explained here: that the Function has scaled to zero and so has no logs to print, or that the logs of some of its pods could not be read. Always check this before concluding that a Function produced no output"`
+	Truncated bool   `json:"truncated,omitempty" jsonschema:"True if older lines were dropped because the output exceeded the tool's size limit; only the most recent lines are included. Re-run with a smaller 'tail' or a shorter 'since' window rather than assuming the output is complete"`
+	Warnings  string `json:"warnings,omitempty" jsonschema:"Non-fatal notices the CLI emitted while gathering the logs. Empty or partial output is explained here: that the Function has scaled to zero and so has no logs to print, or that the logs of some of its pods could not be read. Always check this before concluding that a Function produced no output"`
 }

--- a/pkg/mcp/tools_logs.go
+++ b/pkg/mcp/tools_logs.go
@@ -3,21 +3,28 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// maxLogBytes bounds the log payload returned by the logs tool.  A snapshot
+// defaults to every line the Function's pods have retained (see 'func logs
+// --tail'), which for a chatty Function is more than an agent's context can
+// hold.  The most recent lines are kept, and the fact that older lines were
+// dropped is reported via LogsOutput.Truncated rather than being silent.
+const maxLogBytes = 256 * 1024
+
 var logsTool = &mcp.Tool{
 	Name:        "logs",
 	Title:       "Get Function Logs",
-	Description: "Retrieve a finite snapshot of recent logs from a deployed Function (prints and returns, does not stream). Use --since to bound the time window (e.g. '5m', '1h'). Identify the Function by path (reads func.yaml) or by name.",
+	Description: "Retrieve a finite snapshot of recent logs from a deployed Function (prints and returns, does not stream). Bound the output with 'since' (time window, e.g. '5m') and 'tail' (most recent lines per pod). Identify the Function by path (reads func.yaml) or by name.",
 	Annotations: &mcp.ToolAnnotations{
 		Title:        "Get Function Logs",
 		ReadOnlyHint: true,
 		// A logs snapshot is read-only but not idempotent: the same call
 		// made later returns a different (growing) set of log lines, so
 		// IdempotentHint is intentionally left unset (false).
-		DestructiveHint: ptr(false),
 	},
 }
 
@@ -30,19 +37,61 @@ func (s *Server) logsHandler(ctx context.Context, r *mcp.CallToolRequest, input 
 		return
 	}
 
-	// ExecuteSplit (rather than Execute/CombinedOutput) is required here so the
-	// returned logs are clean stdout only. `func logs` writes a status banner to
-	// stderr (e.g. "Logs for function '…' in namespace '…' since '…'...") that
-	// would otherwise be interleaved into the log output an agent parses.
+	// Validate: namespace only makes sense alongside 'name'.  When fetching
+	// logs by 'path', the CLI resolves the Function's name and namespace from
+	// its own deploy identity (func.yaml) and ignores --namespace entirely.
+	// Rejecting the combination is the same rule the describe tool applies,
+	// and avoids returning another namespace's logs while reporting success.
+	if input.Path != nil && input.Namespace != nil {
+		err = fmt.Errorf("'namespace' is only valid with 'name'; when fetching logs by 'path', the namespace is read from the Function's own deploy identity")
+		return
+	}
+
+	// ExecuteSplit (rather than Execute/CombinedOutput) is required here so
+	// that the log content is clean stdout only.  `func logs` uses stderr for
+	// everything which is not a log line, including notices which accompany a
+	// successful, zero-exit call: that the Function has scaled to zero and so
+	// has no logs, and that the logs of some (but not all) of its pods could
+	// be read.  Those are surfaced separately as Warnings, since an empty or
+	// partial payload is otherwise indistinguishable from a complete one.
 	stdout, stderr, err := s.executor.ExecuteSplit(ctx, "logs", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\nstdout: %s\nstderr: %s", err, string(stdout), string(stderr))
 		return
 	}
+
+	logs, truncated := truncateLogs(string(stdout))
+
+	warnings := strings.TrimSpace(string(stderr))
+	if truncated {
+		notice := fmt.Sprintf("Output exceeded %d bytes: only the most recent lines are included. Use 'tail' or 'since' to bound the window.", maxLogBytes)
+		if warnings == "" {
+			warnings = notice
+		} else {
+			warnings += "\n" + notice
+		}
+	}
+
 	output = LogsOutput{
-		Logs: string(stdout),
+		Logs:      logs,
+		Truncated: truncated,
+		Warnings:  warnings,
 	}
 	return
+}
+
+// truncateLogs bounds logs to maxLogBytes, keeping the most recent lines and
+// reporting whether anything was dropped.  Truncation is to a line boundary so
+// the first line returned is not a fragment of an older one.
+func truncateLogs(logs string) (string, bool) {
+	if len(logs) <= maxLogBytes {
+		return logs, false
+	}
+	truncated := logs[len(logs)-maxLogBytes:]
+	if i := strings.IndexByte(truncated, '\n'); i >= 0 {
+		truncated = truncated[i+1:]
+	}
+	return truncated, true
 }
 
 // LogsInput defines the input parameters for the logs tool.
@@ -50,8 +99,9 @@ func (s *Server) logsHandler(ctx context.Context, r *mcp.CallToolRequest, input 
 type LogsInput struct {
 	Path      *string `json:"path,omitempty"      jsonschema:"Absolute path to the Function project directory (mutually exclusive with name)"`
 	Name      *string `json:"name,omitempty"      jsonschema:"Name of the deployed Function to fetch logs for (mutually exclusive with path)"`
-	Namespace *string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace of the Function (default: current namespace)"`
+	Namespace *string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace of the Function (default: current namespace). Only valid together with 'name'; when fetching logs by 'path' the namespace is read from the Function's own deploy identity"`
 	Since     *string `json:"since,omitempty"     jsonschema:"Return logs newer than a relative duration such as 30s, 5m, or 2h (default: all available logs)"`
+	Tail      *int    `json:"tail,omitempty"      jsonschema:"Number of most recent log lines to return per pod (default: unlimited). Prefer bounding large or unknown log volumes with this rather than fetching everything"`
 	Verbose   *bool   `json:"verbose,omitempty"   jsonschema:"Enable verbose logging output"`
 }
 
@@ -66,11 +116,16 @@ func (i LogsInput) Args() []string {
 
 	args = appendStringFlag(args, "--namespace", i.Namespace)
 	args = appendStringFlag(args, "--since", i.Since)
+	if i.Tail != nil {
+		args = append(args, "--tail", fmt.Sprintf("%d", *i.Tail))
+	}
 	args = appendBoolFlag(args, "--verbose", i.Verbose)
 	return args
 }
 
 // LogsOutput defines the structured output returned by the logs tool.
 type LogsOutput struct {
-	Logs string `json:"logs" jsonschema:"Log output from the deployed Function"`
+	Logs      string `json:"logs" jsonschema:"Log output from the deployed Function. When more than one pod is serving the Function, each line is prefixed with the pod it came from"`
+	Truncated bool   `json:"truncated,omitempty" jsonschema:"True if older lines were dropped because the output exceeded the size limit; only the most recent lines are included"`
+	Warnings  string `json:"warnings,omitempty" jsonschema:"Non-fatal notices emitted while gathering the logs. Empty or partial output is explained here: that the Function has scaled to zero and so has no logs to print, or that the logs of some of its pods could not be read. Always check this before concluding that a Function produced no output"`
 }

--- a/pkg/mcp/tools_logs_test.go
+++ b/pkg/mcp/tools_logs_test.go
@@ -1,0 +1,163 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"knative.dev/func/pkg/mcp/mock"
+)
+
+// TestTool_Logs_Args_ByPath ensures the logs tool passes all arguments correctly
+// when identifying the Function by path.
+func TestTool_Logs_Args_ByPath(t *testing.T) {
+	stringFlags := map[string]struct {
+		jsonKey string
+		flag    string
+		value   string
+	}{
+		"path":      {"path", "--path", "/home/user/myfunc"},
+		"namespace": {"namespace", "--namespace", "prod"},
+		"since":     {"since", "--since", "10m"},
+	}
+
+	boolFlags := map[string]string{
+		"verbose": "--verbose",
+	}
+
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		if subcommand != "logs" {
+			t.Fatalf("expected subcommand 'logs', got %q", subcommand)
+		}
+		validateArgLength(t, args, len(stringFlags), len(boolFlags))
+		validateStringFlags(t, args, stringFlags)
+		validateBoolFlags(t, args, boolFlags)
+		return []byte("2024/01/01 12:00:00 INFO handler invoked\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "logs",
+		Arguments: buildInputArgs(stringFlags, boolFlags),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_Logs_Args_ByName ensures the logs tool passes --name when the
+// Function is identified by name instead of path.
+func TestTool_Logs_Args_ByName(t *testing.T) {
+	stringFlags := map[string]struct {
+		jsonKey string
+		flag    string
+		value   string
+	}{
+		"name": {"name", "--name", "my-function"},
+	}
+
+	boolFlags := map[string]string{}
+
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		if subcommand != "logs" {
+			t.Fatalf("expected subcommand 'logs', got %q", subcommand)
+		}
+		validateArgLength(t, args, len(stringFlags), len(boolFlags))
+		validateStringFlags(t, args, stringFlags)
+		return []byte("log line 1\nlog line 2\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "logs",
+		Arguments: buildInputArgs(stringFlags, boolFlags),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_Logs_MutuallyExclusive ensures that providing both 'path' and 'name'
+// returns an error rather than executing the command.
+func TestTool_Logs_MutuallyExclusive(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		t.Fatal("executor should not be called when both path and name are provided")
+		return nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "logs",
+		Arguments: map[string]any{
+			"path": "/home/user/myfunc",
+			"name": "my-function",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected an error result when both path and name are provided")
+	}
+}
+
+// TestTool_Logs_NoArgs ensures the logs tool works without any arguments,
+// falling back to the server's working directory (CLI default behaviour).
+func TestTool_Logs_NoArgs(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		if subcommand != "logs" {
+			t.Fatalf("expected subcommand 'logs', got %q", subcommand)
+		}
+		if len(args) != 0 {
+			t.Fatalf("expected no args when nothing is provided, got %v", args)
+		}
+		return []byte("no logs yet\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "logs",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}

--- a/pkg/mcp/tools_logs_test.go
+++ b/pkg/mcp/tools_logs_test.go
@@ -3,8 +3,10 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"knative.dev/func/pkg/mcp/mock"
@@ -102,8 +104,13 @@ func TestTool_Logs_Args_ByName(t *testing.T) {
 		if subcommand != "logs" {
 			t.Fatalf("expected subcommand 'logs', got %q", subcommand)
 		}
-		validateArgLength(t, args, len(stringFlags), len(boolFlags))
+		// No 'tail' was provided, so the default bound is forwarded in
+		// addition to the flags under test.
+		validateArgLength(t, args, len(stringFlags)+1, len(boolFlags))
 		validateStringFlags(t, args, stringFlags)
+		if got := argsToMap(args)["--tail"]; got != strconv.Itoa(defaultTailLines) {
+			t.Fatalf("expected --tail %d, got %q", defaultTailLines, got)
+		}
 		return []byte(wantLogs), nil, nil
 	}
 
@@ -191,15 +198,22 @@ func TestTool_Logs_RequiresPathOrName(t *testing.T) {
 	}
 }
 
-// TestTool_Logs_NamespaceRequiresName ensures 'namespace' is rejected when
-// combined with 'path'. The CLI resolves the namespace from the Function's own
-// deploy identity in path mode and ignores --namespace, so accepting it would
-// return another namespace's logs while reporting success.
-func TestTool_Logs_NamespaceRequiresName(t *testing.T) {
+// TestTool_Logs_NamespaceWithPath ensures 'namespace' is forwarded even when
+// combined with 'path', rather than being rejected. The CLI accepts the
+// combination (it reads the namespace from the Function's own deploy identity
+// and ignores the flag), so rejecting it here would make the tool enforce a
+// rule 'func logs' does not.
+func TestTool_Logs_NamespaceWithPath(t *testing.T) {
 	executor := mock.NewExecutor()
 	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
-		t.Fatal("executor should not be called when namespace is combined with path")
-		return nil, nil, nil
+		argsMap := argsToMap(args)
+		if got := argsMap["--path"]; got != "/home/user/myfunc" {
+			t.Fatalf("expected --path /home/user/myfunc, got %q", got)
+		}
+		if got := argsMap["--namespace"]; got != "prod" {
+			t.Fatalf("expected --namespace prod, got %q", got)
+		}
+		return []byte("log line\n"), nil, nil
 	}
 
 	client, _, err := newTestPair(t, WithExecutor(executor))
@@ -217,8 +231,41 @@ func TestTool_Logs_NamespaceRequiresName(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !result.IsError {
-		t.Fatal("expected an error result when namespace is combined with path")
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+	if !executor.ExecuteSplitInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_Logs_TailUnlimited ensures an explicit negative 'tail' is passed
+// through rather than being replaced by the default bound. Negative means
+// unlimited in the CLI, and is the caller's only way to ask for every
+// retained line.
+func TestTool_Logs_TailUnlimited(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
+		if got := argsToMap(args)["--tail"]; got != "-1" {
+			t.Fatalf("expected --tail -1, got %q", got)
+		}
+		return []byte("log line\n"), nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "logs",
+		Arguments: map[string]any{"name": "myfunc", "tail": -1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
 	}
 }
 
@@ -307,8 +354,140 @@ func TestTool_Logs_Truncated(t *testing.T) {
 	if first, _, _ := strings.Cut(output.Logs, "\n"); first != "a log line of some length" {
 		t.Errorf("expected truncation to a line boundary, got partial first line %q", first)
 	}
-	if output.Warnings == "" {
-		t.Error("expected truncation to be reported in warnings")
+	// Truncation is reported by 'truncated' alone. Repeating it in
+	// 'warnings' would give the caller two channels for one fact, and
+	// 'warnings' is reserved for what the CLI reported.
+	if output.Warnings != "" {
+		t.Errorf("expected truncation to be reported by 'truncated' only, got warnings %q", output.Warnings)
+	}
+}
+
+// TestTool_Logs_WarningsBounded ensures the notices returned alongside the
+// logs are themselves bounded. stderr is not guaranteed to be a line or two:
+// 'verbose' writes there, as does one warning per unreadable pod, so an
+// unbounded 'warnings' would defeat the cap on the payload as a whole.
+func TestTool_Logs_WarningsBounded(t *testing.T) {
+	const lastNotice = "Warning: the newest notice"
+	oversized := strings.Repeat("Warning: a pod's logs could not be read\n", (maxWarningBytes/40)+100) + lastNotice
+
+	executor := mock.NewExecutor()
+	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
+		return []byte("log line\n"), []byte(oversized), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "logs",
+		Arguments: map[string]any{"name": "myfunc"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+
+	var output LogsOutput
+	if err := unmarshalStructuredContent(result, &output); err != nil {
+		t.Fatal(err)
+	}
+	if len(output.Warnings) > maxWarningBytes+len(warningsTruncatedMarker)+1 {
+		t.Errorf("expected warnings bounded to ~%d bytes, got %d", maxWarningBytes, len(output.Warnings))
+	}
+	if !strings.HasPrefix(output.Warnings, warningsTruncatedMarker) {
+		t.Error("expected dropped notices to be marked, so the remainder is not mistaken for all of them")
+	}
+	if !strings.HasSuffix(output.Warnings, lastNotice) {
+		t.Error("expected the most recent notices to be retained")
+	}
+	// Bounding the notices must not be confused with bounding the logs.
+	if output.Truncated {
+		t.Error("expected 'truncated' to describe the logs only, not the warnings")
+	}
+}
+
+// TestTruncateTail exercises the bounding directly, with a small limit so the
+// boundary cases are exact. Two of them are regressions: a cut which lands on
+// a line boundary must not consume the intact line which begins there, and a
+// line longer than the limit must not be returned as a broken rune.
+func TestTruncateTail(t *testing.T) {
+	tests := []struct {
+		name          string
+		logs          string
+		limit         int
+		want          string
+		wantTruncated bool
+	}{
+		{
+			name: "under the limit is returned whole",
+			logs: "aaaa\nbbbb\n", limit: 100,
+			want: "aaaa\nbbbb\n", wantTruncated: false,
+		},
+		{
+			name: "exactly at the limit is returned whole",
+			logs: "aaaa\nbbbb\n", limit: 10,
+			want: "aaaa\nbbbb\n", wantTruncated: false,
+		},
+		{
+			// The cut falls immediately after "aaaa\n", so "bbbb" is a
+			// whole, intact line. Searching forward for a newline from
+			// there would find that line's own terminator and drop it.
+			name: "cut on a line boundary keeps the line beginning there",
+			logs: "aaaa\nbbbb\ncccc\n", limit: 10,
+			want: "bbbb\ncccc\n", wantTruncated: true,
+		},
+		{
+			// The cut falls inside "aaaa", whose remainder must go.
+			name: "cut inside a line drops that line's remainder",
+			logs: "aaaa\nbbbb\ncccc\n", limit: 12,
+			want: "bbbb\ncccc\n", wantTruncated: true,
+		},
+		{
+			name: "single line longer than the limit keeps its tail",
+			logs: "abcdef", limit: 3,
+			want: "def", wantTruncated: true,
+		},
+		{
+			// Three-byte runes and no newline to re-align on: a byte-wise
+			// cut lands mid-rune and would otherwise emit invalid UTF-8,
+			// which JSON encoding silently replaces with U+FFFD.
+			name: "single long line is trimmed to a rune boundary",
+			logs: "世世世世", limit: 5,
+			want: "世", wantTruncated: true,
+		},
+		{
+			// Content which was not valid UTF-8 to begin with (binary
+			// written to stdout) cannot be made valid by trimming. The
+			// contract is only that this introduces no corruption of its
+			// own, so such input is passed through as it was found.
+			name: "input which is already invalid UTF-8 is passed through",
+			logs: "\xb8\xb8\xb8\xb8", limit: 3,
+			want: "\xb8\xb8\xb8", wantTruncated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, truncated := truncateTail(tt.logs, tt.limit)
+			if got != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, got)
+			}
+			if truncated != tt.wantTruncated {
+				t.Errorf("expected truncated %v, got %v", tt.wantTruncated, truncated)
+			}
+			if len(got) > tt.limit && tt.limit > 0 {
+				t.Errorf("expected at most %d bytes, got %d", tt.limit, len(got))
+			}
+			// Bounding must not introduce invalid UTF-8 into content which
+			// was valid: JSON encoding replaces it with U+FFFD.
+			if utf8.ValidString(tt.logs) && !utf8.ValidString(got) {
+				t.Errorf("expected valid UTF-8, got % x", got)
+			}
+		})
 	}
 }
 

--- a/pkg/mcp/tools_logs_test.go
+++ b/pkg/mcp/tools_logs_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 // TestTool_Logs_Args_ByPath ensures the logs tool passes all arguments correctly
-// when identifying the Function by path.
+// when identifying the Function by path, and returns the executor's stdout as
+// the log content.
 func TestTool_Logs_Args_ByPath(t *testing.T) {
 	stringFlags := map[string]struct {
 		jsonKey string
@@ -25,15 +26,18 @@ func TestTool_Logs_Args_ByPath(t *testing.T) {
 		"verbose": "--verbose",
 	}
 
+	const wantLogs = "2024/01/01 12:00:00 INFO handler invoked\n"
+
 	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
 		if subcommand != "logs" {
 			t.Fatalf("expected subcommand 'logs', got %q", subcommand)
 		}
 		validateArgLength(t, args, len(stringFlags), len(boolFlags))
 		validateStringFlags(t, args, stringFlags)
 		validateBoolFlags(t, args, boolFlags)
-		return []byte("2024/01/01 12:00:00 INFO handler invoked\n"), nil
+		// stderr carries the status banner, which must not leak into the logs.
+		return []byte(wantLogs), []byte("Logs for function 'myfunc' in namespace 'prod'...\n"), nil
 	}
 
 	client, _, err := newTestPair(t, WithExecutor(executor))
@@ -51,13 +55,21 @@ func TestTool_Logs_Args_ByPath(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result)
 	}
-	if !executor.ExecuteInvoked {
+	if !executor.ExecuteSplitInvoked {
 		t.Fatal("executor was not invoked")
+	}
+
+	var output LogsOutput
+	if err := unmarshalStructuredContent(result, &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.Logs != wantLogs {
+		t.Errorf("expected logs %q, got %q", wantLogs, output.Logs)
 	}
 }
 
 // TestTool_Logs_Args_ByName ensures the logs tool passes --name when the
-// Function is identified by name instead of path.
+// Function is identified by name instead of path, and returns the log content.
 func TestTool_Logs_Args_ByName(t *testing.T) {
 	stringFlags := map[string]struct {
 		jsonKey string
@@ -69,14 +81,16 @@ func TestTool_Logs_Args_ByName(t *testing.T) {
 
 	boolFlags := map[string]string{}
 
+	const wantLogs = "log line 1\nlog line 2\n"
+
 	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
 		if subcommand != "logs" {
 			t.Fatalf("expected subcommand 'logs', got %q", subcommand)
 		}
 		validateArgLength(t, args, len(stringFlags), len(boolFlags))
 		validateStringFlags(t, args, stringFlags)
-		return []byte("log line 1\nlog line 2\n"), nil
+		return []byte(wantLogs), nil, nil
 	}
 
 	client, _, err := newTestPair(t, WithExecutor(executor))
@@ -94,8 +108,16 @@ func TestTool_Logs_Args_ByName(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result)
 	}
-	if !executor.ExecuteInvoked {
+	if !executor.ExecuteSplitInvoked {
 		t.Fatal("executor was not invoked")
+	}
+
+	var output LogsOutput
+	if err := unmarshalStructuredContent(result, &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.Logs != wantLogs {
+		t.Errorf("expected logs %q, got %q", wantLogs, output.Logs)
 	}
 }
 
@@ -103,9 +125,9 @@ func TestTool_Logs_Args_ByName(t *testing.T) {
 // returns an error rather than executing the command.
 func TestTool_Logs_MutuallyExclusive(t *testing.T) {
 	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
 		t.Fatal("executor should not be called when both path and name are provided")
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	client, _, err := newTestPair(t, WithExecutor(executor))
@@ -128,18 +150,14 @@ func TestTool_Logs_MutuallyExclusive(t *testing.T) {
 	}
 }
 
-// TestTool_Logs_NoArgs ensures the logs tool works without any arguments,
-// falling back to the server's working directory (CLI default behaviour).
-func TestTool_Logs_NoArgs(t *testing.T) {
+// TestTool_Logs_RequiresPathOrName ensures the logs tool errors when neither
+// 'path' nor 'name' is provided. Unlike the CLI, the MCP tool does not fall
+// back to the server's working directory, since an agent has no meaningful cwd.
+func TestTool_Logs_RequiresPathOrName(t *testing.T) {
 	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
-		if subcommand != "logs" {
-			t.Fatalf("expected subcommand 'logs', got %q", subcommand)
-		}
-		if len(args) != 0 {
-			t.Fatalf("expected no args when nothing is provided, got %v", args)
-		}
-		return []byte("no logs yet\n"), nil
+	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
+		t.Fatal("executor should not be called when neither path nor name is provided")
+		return nil, nil, nil
 	}
 
 	client, _, err := newTestPair(t, WithExecutor(executor))
@@ -154,10 +172,7 @@ func TestTool_Logs_NoArgs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.IsError {
-		t.Fatalf("unexpected error result: %v", result)
-	}
-	if !executor.ExecuteInvoked {
-		t.Fatal("executor was not invoked")
+	if !result.IsError {
+		t.Fatal("expected an error result when neither path nor name is provided")
 	}
 }

--- a/pkg/mcp/tools_logs_test.go
+++ b/pkg/mcp/tools_logs_test.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -17,9 +19,8 @@ func TestTool_Logs_Args_ByPath(t *testing.T) {
 		flag    string
 		value   string
 	}{
-		"path":      {"path", "--path", "/home/user/myfunc"},
-		"namespace": {"namespace", "--namespace", "prod"},
-		"since":     {"since", "--since", "10m"},
+		"path":  {"path", "--path", "/home/user/myfunc"},
+		"since": {"since", "--since", "10m"},
 	}
 
 	boolFlags := map[string]string{
@@ -33,11 +34,16 @@ func TestTool_Logs_Args_ByPath(t *testing.T) {
 		if subcommand != "logs" {
 			t.Fatalf("expected subcommand 'logs', got %q", subcommand)
 		}
-		validateArgLength(t, args, len(stringFlags), len(boolFlags))
+		// '--tail 20' is a flag/value pair like the string flags, but is
+		// passed as an integer in the tool's input schema, so it is checked
+		// separately from the table-driven string flags.
+		validateArgLength(t, args, len(stringFlags)+1, len(boolFlags))
 		validateStringFlags(t, args, stringFlags)
 		validateBoolFlags(t, args, boolFlags)
-		// stderr carries the status banner, which must not leak into the logs.
-		return []byte(wantLogs), []byte("Logs for function 'myfunc' in namespace 'prod'...\n"), nil
+		if got := argsToMap(args)["--tail"]; got != "20" {
+			t.Fatalf("expected --tail 20, got %q", got)
+		}
+		return []byte(wantLogs), nil, nil
 	}
 
 	client, _, err := newTestPair(t, WithExecutor(executor))
@@ -45,9 +51,12 @@ func TestTool_Logs_Args_ByPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	args := buildInputArgs(stringFlags, boolFlags)
+	args["tail"] = 20
+
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "logs",
-		Arguments: buildInputArgs(stringFlags, boolFlags),
+		Arguments: args,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -66,17 +75,22 @@ func TestTool_Logs_Args_ByPath(t *testing.T) {
 	if output.Logs != wantLogs {
 		t.Errorf("expected logs %q, got %q", wantLogs, output.Logs)
 	}
+	if output.Truncated {
+		t.Error("expected output to not be marked truncated")
+	}
 }
 
 // TestTool_Logs_Args_ByName ensures the logs tool passes --name when the
-// Function is identified by name instead of path, and returns the log content.
+// Function is identified by name instead of path, that 'namespace' is
+// forwarded in this mode, and that the log content is returned.
 func TestTool_Logs_Args_ByName(t *testing.T) {
 	stringFlags := map[string]struct {
 		jsonKey string
 		flag    string
 		value   string
 	}{
-		"name": {"name", "--name", "my-function"},
+		"name":      {"name", "--name", "my-function"},
+		"namespace": {"namespace", "--namespace", "prod"},
 	}
 
 	boolFlags := map[string]string{}
@@ -174,5 +188,154 @@ func TestTool_Logs_RequiresPathOrName(t *testing.T) {
 	}
 	if !result.IsError {
 		t.Fatal("expected an error result when neither path nor name is provided")
+	}
+}
+
+// TestTool_Logs_NamespaceRequiresName ensures 'namespace' is rejected when
+// combined with 'path'. The CLI resolves the namespace from the Function's own
+// deploy identity in path mode and ignores --namespace, so accepting it would
+// return another namespace's logs while reporting success.
+func TestTool_Logs_NamespaceRequiresName(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
+		t.Fatal("executor should not be called when namespace is combined with path")
+		return nil, nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "logs",
+		Arguments: map[string]any{
+			"path":      "/home/user/myfunc",
+			"namespace": "prod",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected an error result when namespace is combined with path")
+	}
+}
+
+// TestTool_Logs_Warnings ensures the notices 'func logs' writes to stderr on an
+// otherwise-successful call are surfaced rather than discarded, and that they
+// do not leak into the log content itself. A Function scaled to zero exits
+// zero with empty stdout, which is otherwise indistinguishable from a Function
+// which ran and printed nothing.
+func TestTool_Logs_Warnings(t *testing.T) {
+	const notice = "No running or recently terminated pods found for function 'myfunc' in namespace 'prod'. It may have scaled to zero, in which case there are no logs to print."
+
+	executor := mock.NewExecutor()
+	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
+		return nil, []byte(notice + "\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "logs",
+		Arguments: map[string]any{"name": "myfunc", "namespace": "prod"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+
+	var output LogsOutput
+	if err := unmarshalStructuredContent(result, &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.Logs != "" {
+		t.Errorf("expected empty logs, got %q", output.Logs)
+	}
+	if output.Warnings != notice {
+		t.Errorf("expected warnings %q, got %q", notice, output.Warnings)
+	}
+}
+
+// TestTool_Logs_Truncated ensures a log payload larger than the limit is
+// bounded to its most recent lines and reported as truncated, rather than
+// being returned whole or silently shortened.
+func TestTool_Logs_Truncated(t *testing.T) {
+	const lastLine = "the most recent line\n"
+	oversized := strings.Repeat("a log line of some length\n", (maxLogBytes/26)+100) + lastLine
+
+	executor := mock.NewExecutor()
+	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
+		return []byte(oversized), nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "logs",
+		Arguments: map[string]any{"name": "myfunc"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+
+	var output LogsOutput
+	if err := unmarshalStructuredContent(result, &output); err != nil {
+		t.Fatal(err)
+	}
+	if !output.Truncated {
+		t.Error("expected output to be marked truncated")
+	}
+	if len(output.Logs) > maxLogBytes {
+		t.Errorf("expected at most %d bytes of logs, got %d", maxLogBytes, len(output.Logs))
+	}
+	if !strings.HasSuffix(output.Logs, lastLine) {
+		t.Error("expected the most recent lines to be retained")
+	}
+	if first, _, _ := strings.Cut(output.Logs, "\n"); first != "a log line of some length" {
+		t.Errorf("expected truncation to a line boundary, got partial first line %q", first)
+	}
+	if output.Warnings == "" {
+		t.Error("expected truncation to be reported in warnings")
+	}
+}
+
+// TestTool_Logs_ExecutorError ensures a failed command surfaces as a tool error
+// which includes both streams, since the CLI reports why it failed on stderr.
+func TestTool_Logs_ExecutorError(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
+		return nil, []byte("function not deployed or not found"), fmt.Errorf("exit status 1")
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "logs",
+		Arguments: map[string]any{"name": "myfunc"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected an error result when the command fails")
+	}
+	if msg := resultToString(result); !strings.Contains(msg, "function not deployed or not found") {
+		t.Errorf("expected the command's stderr in the error, got %q", msg)
 	}
 }


### PR DESCRIPTION
<!-- PR Title: mcp: Add logs tool to retrieve deployed Function logs -->

# Changes

- :gift: Adds a `logs` MCP tool returning a snapshot of a deployed Function's logs, identified by exactly one of `path` or `name`.
- :gift: Bounds the output: `tail` defaults to 1000 lines per pod (the CLI's default is unlimited), and the payload is capped at 256 KiB, keeping the most recent lines and setting `truncated`.
- :gift: Returns the CLI's stderr notices as `warnings`, so a Function scaled to zero is not mistaken for one which printed nothing.
- :broom: Registers the tool and the `func://help/logs` resource, and documents its contract in `instructions.md`.

Streaming (`--follow`) is not exposed, as it never terminates. `namespace` is forwarded as given; in `path` mode `func logs` reads the namespace from the Function's deploy identity and ignores the flag.

/kind enhancement

Relates to #3999

**Release Note**

```release-note
The MCP server now provides a 'logs' tool, which returns a snapshot of a deployed Function's logs.
```

**Docs**

```docs

```
