### PR TITLE
feat: enable volume mounts for local func run

### DIFF
--- a/pkg/docker/runner.go
+++ b/pkg/docker/runner.go
@@ -330,12 +330,12 @@ func volumeMounts(root string, volumes []fn.Volume, out io.Writer) []mount.Mount
 	var mounts []mount.Mount
 	for _, vol := range volumes {
 		if vol.Path == nil {
-			fmt.Fprintf(out, "warning: skipping volume %v: missing path\n", vol)
+			fmt.Fprintf(out, "warning: skipping volume %s: missing path\n", vol.String())
 			continue
 		}
 		m, err := toMount(root, vol)
 		if err != nil {
-			fmt.Fprintf(out, "warning: skipping volume %v: %v\n", vol, err)
+			fmt.Fprintf(out, "warning: skipping volume %s: %v\n", vol.String(), err)
 			continue
 		}
 		mounts = append(mounts, m)
@@ -345,16 +345,21 @@ func volumeMounts(root string, volumes []fn.Volume, out io.Writer) []mount.Mount
 
 // toMount maps a single Volume spec to a Docker mount.Mount.
 //
+// runDir is <root>/.func/run (fn.RunDataDir = ".func", the extra "run" segment
+// scopes local state for the run subcommand away from build artifacts).
+//
 // Mapping rules:
-//   - Secret       → bind mount from .func/run/secrets/<name>  (created if absent)
-//   - ConfigMap    → bind mount from .func/run/configmaps/<name> (created if absent)
-//   - EmptyDir     → tmpfs (medium=Memory) or anonymous Docker volume (default medium)
-//   - PVC          → named Docker volume keyed by claimName
+//   - Secret    → bind mount from <runDir>/secrets/<name>   (created if absent, mode 0700)
+//   - ConfigMap → bind mount from <runDir>/configmaps/<name> (created if absent, mode 0750)
+//   - EmptyDir  → tmpfs for both default and Memory mediums (matches ephemeral pod semantics)
+//   - PVC       → named Docker volume keyed by claimName (shared across functions, matches k8s semantics)
 func toMount(root string, vol fn.Volume) (mount.Mount, error) {
 	target := *vol.Path
+	// fn.RunDataDir = ".func"; the "run" subdirectory scopes local run state.
+	runDir := filepath.Join(root, fn.RunDataDir, "run")
 
 	if vol.Secret != nil {
-		src := filepath.Join(root, fn.RunDataDir, "run", "secrets", *vol.Secret)
+		src := filepath.Join(runDir, "secrets", *vol.Secret)
 		if err := os.MkdirAll(src, 0700); err != nil {
 			return mount.Mount{}, fmt.Errorf("cannot create local secret dir %q: %w", src, err)
 		}
@@ -362,7 +367,7 @@ func toMount(root string, vol fn.Volume) (mount.Mount, error) {
 	}
 
 	if vol.ConfigMap != nil {
-		src := filepath.Join(root, fn.RunDataDir, "run", "configmaps", *vol.ConfigMap)
+		src := filepath.Join(runDir, "configmaps", *vol.ConfigMap)
 		if err := os.MkdirAll(src, 0750); err != nil {
 			return mount.Mount{}, fmt.Errorf("cannot create local configmap dir %q: %w", src, err)
 		}
@@ -370,24 +375,20 @@ func toMount(root string, vol fn.Volume) (mount.Mount, error) {
 	}
 
 	if vol.EmptyDir != nil {
-		if vol.EmptyDir.Medium == fn.StorageMediumMemory {
-			return mount.Mount{Type: mount.TypeTmpfs, Target: target}, nil
-		}
-		// Default medium: anonymous Docker volume; no local directory needed.
-		return mount.Mount{Type: mount.TypeVolume, Target: target}, nil
+		// Both mediums map to tmpfs locally: EmptyDir is ephemeral (pod-lifetime)
+		// and anonymous Docker volumes persist across runs, leaking storage.
+		return mount.Mount{Type: mount.TypeTmpfs, Target: target}, nil
 	}
 
 	if vol.PersistentVolumeClaim != nil {
 		if vol.PersistentVolumeClaim.ClaimName == nil {
 			return mount.Mount{}, fmt.Errorf("persistentVolumeClaim missing claimName")
 		}
-		src := filepath.Join(root, fn.RunDataDir, "run", "pvcs", *vol.PersistentVolumeClaim.ClaimName)
-		if err := os.MkdirAll(src, 0750); err != nil {
-			return mount.Mount{}, fmt.Errorf("cannot create local pvc dir %q: %w", src, err)
-		}
+		// Named Docker volume keyed by claimName: multiple functions referencing
+		// the same claim share the same local volume, matching Kubernetes semantics.
 		return mount.Mount{
-			Type:     mount.TypeBind,
-			Source:   src,
+			Type:     mount.TypeVolume,
+			Source:   *vol.PersistentVolumeClaim.ClaimName,
 			Target:   target,
 			ReadOnly: vol.PersistentVolumeClaim.ReadOnly,
 		}, nil

--- a/pkg/docker/runner.go
+++ b/pkg/docker/runner.go
@@ -7,10 +7,12 @@ import (
 	"net"
 	"net/netip"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"github.com/pkg/errors"
@@ -90,7 +92,7 @@ func (n *Runner) Run(ctx context.Context, f fn.Function, address string, startTi
 	if c, _, err = NewClient(client.DefaultDockerHost); err != nil {
 		return job, errors.Wrap(err, "failed to create Docker API client")
 	}
-	if id, err = newContainer(ctx, c, f, host, port, n.verbose); err != nil {
+	if id, err = newContainer(ctx, c, f, host, port, n.verbose, n.errOut); err != nil {
 		return job, errors.Wrap(err, "runner unable to create container")
 	}
 	if conn, err = copyStdio(ctx, c, id, copyErrCh, n.out, n.errOut); err != nil {
@@ -254,7 +256,7 @@ func choosePort(host, preferredPort string, dialTimeout time.Duration) string {
 
 }
 
-func newContainer(ctx context.Context, c DockerClient, f fn.Function, host, port string, verbose bool) (id string, err error) {
+func newContainer(ctx context.Context, c DockerClient, f fn.Function, host, port string, verbose bool, out io.Writer) (id string, err error) {
 	var (
 		containerCfg container.Config
 		hostCfg      container.HostConfig
@@ -262,7 +264,7 @@ func newContainer(ctx context.Context, c DockerClient, f fn.Function, host, port
 	if containerCfg, err = newContainerConfig(f, port, verbose); err != nil {
 		return
 	}
-	if hostCfg, err = newHostConfig(host, port); err != nil {
+	if hostCfg, err = newHostConfig(host, port, f, out); err != nil {
 		return
 	}
 	t, err := c.ContainerCreate(ctx, client.ContainerCreateOptions{
@@ -303,7 +305,7 @@ func newContainerConfig(f fn.Function, _ string, verbose bool) (c container.Conf
 	return
 }
 
-func newHostConfig(host, port string) (c container.HostConfig, err error) {
+func newHostConfig(host, port string, f fn.Function, out io.Writer) (c container.HostConfig, err error) {
 	httpPort := network.MustParsePort("8080/tcp")
 	hostIP, err := netip.ParseAddr(host)
 	if err != nil {
@@ -317,7 +319,81 @@ func newHostConfig(host, port string) (c container.HostConfig, err error) {
 			},
 		},
 	}
-	return container.HostConfig{PortBindings: ports}, nil
+	mounts := volumeMounts(f.Root, f.Run.Volumes, out)
+	return container.HostConfig{PortBindings: ports, Mounts: mounts}, nil
+}
+
+// volumeMounts converts func.yaml volume definitions into Docker mount specs.
+// Volumes that cannot be mapped locally emit a warning and are skipped rather
+// than aborting the run.
+func volumeMounts(root string, volumes []fn.Volume, out io.Writer) []mount.Mount {
+	var mounts []mount.Mount
+	for _, vol := range volumes {
+		if vol.Path == nil {
+			fmt.Fprintf(out, "warning: skipping volume %v: missing path\n", vol)
+			continue
+		}
+		m, err := toMount(root, vol)
+		if err != nil {
+			fmt.Fprintf(out, "warning: skipping volume %v: %v\n", vol, err)
+			continue
+		}
+		mounts = append(mounts, m)
+	}
+	return mounts
+}
+
+// toMount maps a single Volume spec to a Docker mount.Mount.
+//
+// Mapping rules:
+//   - Secret       → bind mount from .func/run/secrets/<name>  (created if absent)
+//   - ConfigMap    → bind mount from .func/run/configmaps/<name> (created if absent)
+//   - EmptyDir     → tmpfs (medium=Memory) or anonymous Docker volume (default medium)
+//   - PVC          → named Docker volume keyed by claimName
+func toMount(root string, vol fn.Volume) (mount.Mount, error) {
+	target := *vol.Path
+
+	if vol.Secret != nil {
+		src := filepath.Join(root, fn.RunDataDir, "run", "secrets", *vol.Secret)
+		if err := os.MkdirAll(src, 0700); err != nil {
+			return mount.Mount{}, fmt.Errorf("cannot create local secret dir %q: %w", src, err)
+		}
+		return mount.Mount{Type: mount.TypeBind, Source: src, Target: target}, nil
+	}
+
+	if vol.ConfigMap != nil {
+		src := filepath.Join(root, fn.RunDataDir, "run", "configmaps", *vol.ConfigMap)
+		if err := os.MkdirAll(src, 0750); err != nil {
+			return mount.Mount{}, fmt.Errorf("cannot create local configmap dir %q: %w", src, err)
+		}
+		return mount.Mount{Type: mount.TypeBind, Source: src, Target: target}, nil
+	}
+
+	if vol.EmptyDir != nil {
+		if vol.EmptyDir.Medium == fn.StorageMediumMemory {
+			return mount.Mount{Type: mount.TypeTmpfs, Target: target}, nil
+		}
+		// Default medium: anonymous Docker volume; no local directory needed.
+		return mount.Mount{Type: mount.TypeVolume, Target: target}, nil
+	}
+
+	if vol.PersistentVolumeClaim != nil {
+		if vol.PersistentVolumeClaim.ClaimName == nil {
+			return mount.Mount{}, fmt.Errorf("persistentVolumeClaim missing claimName")
+		}
+		src := filepath.Join(root, fn.RunDataDir, "run", "pvcs", *vol.PersistentVolumeClaim.ClaimName)
+		if err := os.MkdirAll(src, 0750); err != nil {
+			return mount.Mount{}, fmt.Errorf("cannot create local pvc dir %q: %w", src, err)
+		}
+		return mount.Mount{
+			Type:     mount.TypeBind,
+			Source:   src,
+			Target:   target,
+			ReadOnly: vol.PersistentVolumeClaim.ReadOnly,
+		}, nil
+	}
+
+	return mount.Mount{}, fmt.Errorf("unrecognized volume type")
 }
 
 // copy stdin and stdout from the container of the given ID.  Errors encountered

--- a/pkg/docker/runner.go
+++ b/pkg/docker/runner.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/docker/docker/pkg/stdcopy"
@@ -353,12 +354,26 @@ func volumeMounts(root string, volumes []fn.Volume, out io.Writer) []mount.Mount
 //   - ConfigMap → bind mount from <runDir>/configmaps/<name> (created if absent, mode 0750)
 //   - EmptyDir  → tmpfs for both default and Memory mediums (matches ephemeral pod semantics)
 //   - PVC       → named Docker volume keyed by claimName (shared across functions, matches k8s semantics)
+//
+// safeLocalName rejects names that contain path separators or traversal
+// sequences. Secret and ConfigMap names are used as file-path components; an
+// adversarial name such as "../../etc" would otherwise escape the .func tree.
+func safeLocalName(name string) error {
+	if strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") {
+		return fmt.Errorf("name %q must not contain path separators or \"..\"", name)
+	}
+	return nil
+}
+
 func toMount(root string, vol fn.Volume) (mount.Mount, error) {
 	target := *vol.Path
 	// fn.RunDataDir = ".func"; the "run" subdirectory scopes local run state.
 	runDir := filepath.Join(root, fn.RunDataDir, "run")
 
 	if vol.Secret != nil {
+		if err := safeLocalName(*vol.Secret); err != nil {
+			return mount.Mount{}, fmt.Errorf("secret: %w", err)
+		}
 		src := filepath.Join(runDir, "secrets", *vol.Secret)
 		if err := os.MkdirAll(src, 0700); err != nil {
 			return mount.Mount{}, fmt.Errorf("cannot create local secret dir %q: %w", src, err)
@@ -367,6 +382,9 @@ func toMount(root string, vol fn.Volume) (mount.Mount, error) {
 	}
 
 	if vol.ConfigMap != nil {
+		if err := safeLocalName(*vol.ConfigMap); err != nil {
+			return mount.Mount{}, fmt.Errorf("configMap: %w", err)
+		}
 		src := filepath.Join(runDir, "configmaps", *vol.ConfigMap)
 		if err := os.MkdirAll(src, 0750); err != nil {
 			return mount.Mount{}, fmt.Errorf("cannot create local configmap dir %q: %w", src, err)

--- a/pkg/docker/runner_volumes_test.go
+++ b/pkg/docker/runner_volumes_test.go
@@ -148,6 +148,30 @@ func TestToMount_UnrecognizedType(t *testing.T) {
 	}
 }
 
+// TestToMount_Secret_TraversalRejected verifies that a secret name containing
+// path traversal sequences is rejected to prevent escaping the .func tree.
+func TestToMount_Secret_TraversalRejected(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"../evil", "../../etc/passwd", "a/b", `a\b`} {
+		vol := fn.Volume{Secret: ptr(name), Path: ptr("/mnt")}
+		if _, err := toMount(root, vol); err == nil {
+			t.Errorf("expected error for secret name %q, got nil", name)
+		}
+	}
+}
+
+// TestToMount_ConfigMap_TraversalRejected verifies that a configMap name
+// containing path traversal sequences is rejected.
+func TestToMount_ConfigMap_TraversalRejected(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"../evil", "../../etc/passwd", "a/b", `a\b`} {
+		vol := fn.Volume{ConfigMap: ptr(name), Path: ptr("/mnt")}
+		if _, err := toMount(root, vol); err == nil {
+			t.Errorf("expected error for configMap name %q, got nil", name)
+		}
+	}
+}
+
 // TestVolumeMounts_SkipsNilPath verifies that volumes missing a path emit a warning
 // and are skipped without aborting.
 func TestVolumeMounts_SkipsNilPath(t *testing.T) {

--- a/pkg/docker/runner_volumes_test.go
+++ b/pkg/docker/runner_volumes_test.go
@@ -1,0 +1,189 @@
+package docker
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/moby/moby/api/types/mount"
+
+	fn "knative.dev/func/pkg/functions"
+)
+
+func ptr(s string) *string { return &s }
+
+// TestToMount_Secret verifies that a Secret volume produces a bind mount
+// rooted inside <root>/.func/run/secrets/<name>.
+func TestToMount_Secret(t *testing.T) {
+	root := t.TempDir()
+	vol := fn.Volume{Secret: ptr("my-secret"), Path: ptr("/etc/secret")}
+
+	m, err := toMount(root, vol)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Type != mount.TypeBind {
+		t.Errorf("expected TypeBind, got %v", m.Type)
+	}
+	want := filepath.Join(root, fn.RunDataDir, "run", "secrets", "my-secret")
+	if m.Source != want {
+		t.Errorf("source: got %q, want %q", m.Source, want)
+	}
+	if m.Target != "/etc/secret" {
+		t.Errorf("target: got %q, want %q", m.Target, "/etc/secret")
+	}
+}
+
+// TestToMount_ConfigMap verifies that a ConfigMap volume produces a bind mount
+// rooted inside <root>/.func/run/configmaps/<name>.
+func TestToMount_ConfigMap(t *testing.T) {
+	root := t.TempDir()
+	vol := fn.Volume{ConfigMap: ptr("app-config"), Path: ptr("/etc/config")}
+
+	m, err := toMount(root, vol)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Type != mount.TypeBind {
+		t.Errorf("expected TypeBind, got %v", m.Type)
+	}
+	want := filepath.Join(root, fn.RunDataDir, "run", "configmaps", "app-config")
+	if m.Source != want {
+		t.Errorf("source: got %q, want %q", m.Source, want)
+	}
+}
+
+// TestToMount_EmptyDir_Memory verifies that an EmptyDir with Memory medium maps to tmpfs.
+func TestToMount_EmptyDir_Memory(t *testing.T) {
+	root := t.TempDir()
+	vol := fn.Volume{EmptyDir: &fn.EmptyDir{Medium: fn.StorageMediumMemory}, Path: ptr("/tmp/cache")}
+
+	m, err := toMount(root, vol)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Type != mount.TypeTmpfs {
+		t.Errorf("expected TypeTmpfs for Memory medium, got %v", m.Type)
+	}
+	if m.Target != "/tmp/cache" {
+		t.Errorf("target: got %q, want %q", m.Target, "/tmp/cache")
+	}
+}
+
+// TestToMount_EmptyDir_Default verifies that an EmptyDir with default medium also maps
+// to tmpfs (not an anonymous volume), to match ephemeral pod semantics and avoid leaks.
+func TestToMount_EmptyDir_Default(t *testing.T) {
+	root := t.TempDir()
+	vol := fn.Volume{EmptyDir: &fn.EmptyDir{}, Path: ptr("/tmp/scratch")}
+
+	m, err := toMount(root, vol)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Type != mount.TypeTmpfs {
+		t.Errorf("expected TypeTmpfs for default medium, got %v", m.Type)
+	}
+}
+
+// TestToMount_PVC verifies that a PVC volume produces a named Docker volume
+// keyed by claimName, so multiple functions referencing the same claim share data.
+func TestToMount_PVC(t *testing.T) {
+	root := t.TempDir()
+	claim := "my-claim"
+	vol := fn.Volume{
+		PersistentVolumeClaim: &fn.PersistentVolumeClaim{ClaimName: ptr(claim)},
+		Path:                  ptr("/data"),
+	}
+
+	m, err := toMount(root, vol)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Type != mount.TypeVolume {
+		t.Errorf("expected TypeVolume for PVC, got %v", m.Type)
+	}
+	if m.Source != claim {
+		t.Errorf("source: got %q, want %q", m.Source, claim)
+	}
+	if m.Target != "/data" {
+		t.Errorf("target: got %q, want %q", m.Target, "/data")
+	}
+}
+
+// TestToMount_PVC_ReadOnly verifies that ReadOnly=true is forwarded to the mount.
+func TestToMount_PVC_ReadOnly(t *testing.T) {
+	root := t.TempDir()
+	vol := fn.Volume{
+		PersistentVolumeClaim: &fn.PersistentVolumeClaim{ClaimName: ptr("ro-claim"), ReadOnly: true},
+		Path:                  ptr("/ro"),
+	}
+	m, err := toMount(root, vol)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !m.ReadOnly {
+		t.Error("expected mount to be ReadOnly")
+	}
+}
+
+// TestToMount_PVC_MissingClaimName verifies an error is returned when claimName is nil.
+func TestToMount_PVC_MissingClaimName(t *testing.T) {
+	root := t.TempDir()
+	vol := fn.Volume{
+		PersistentVolumeClaim: &fn.PersistentVolumeClaim{},
+		Path:                  ptr("/data"),
+	}
+	if _, err := toMount(root, vol); err == nil {
+		t.Error("expected error for missing claimName, got nil")
+	}
+}
+
+// TestToMount_UnrecognizedType verifies an error is returned for a volume with no type set.
+func TestToMount_UnrecognizedType(t *testing.T) {
+	root := t.TempDir()
+	vol := fn.Volume{Path: ptr("/some/path")}
+	if _, err := toMount(root, vol); err == nil {
+		t.Error("expected error for unrecognized volume type, got nil")
+	}
+}
+
+// TestVolumeMounts_SkipsNilPath verifies that volumes missing a path emit a warning
+// and are skipped without aborting.
+func TestVolumeMounts_SkipsNilPath(t *testing.T) {
+	root := t.TempDir()
+	var out bytes.Buffer
+	vols := []fn.Volume{
+		{Secret: ptr("s"), Path: nil},          // no path — should be skipped
+		{Secret: ptr("s2"), Path: ptr("/ok")},  // valid
+	}
+	mounts := volumeMounts(root, vols, &out)
+
+	if len(mounts) != 1 {
+		t.Errorf("expected 1 mount, got %d", len(mounts))
+	}
+	if !strings.Contains(out.String(), "missing path") {
+		t.Errorf("expected warning about missing path, got: %q", out.String())
+	}
+}
+
+// TestVolumeMounts_SkipsOnError verifies that a volume that produces an error is
+// warned about and skipped, while valid volumes are still mounted.
+func TestVolumeMounts_SkipsOnError(t *testing.T) {
+	root := t.TempDir()
+	var out bytes.Buffer
+	vols := []fn.Volume{
+		// PVC with no claimName — toMount returns error
+		{PersistentVolumeClaim: &fn.PersistentVolumeClaim{}, Path: ptr("/bad")},
+		// Valid secret
+		{Secret: ptr("good"), Path: ptr("/good")},
+	}
+	mounts := volumeMounts(root, vols, &out)
+
+	if len(mounts) != 1 {
+		t.Errorf("expected 1 mount, got %d", len(mounts))
+	}
+	if !strings.Contains(out.String(), "warning") {
+		t.Errorf("expected warning in output, got: %q", out.String())
+	}
+}

--- a/pkg/docker/runner_volumes_test.go
+++ b/pkg/docker/runner_volumes_test.go
@@ -154,8 +154,8 @@ func TestVolumeMounts_SkipsNilPath(t *testing.T) {
 	root := t.TempDir()
 	var out bytes.Buffer
 	vols := []fn.Volume{
-		{Secret: ptr("s"), Path: nil},          // no path — should be skipped
-		{Secret: ptr("s2"), Path: ptr("/ok")},  // valid
+		{Secret: ptr("s"), Path: nil},         // no path — should be skipped
+		{Secret: ptr("s2"), Path: ptr("/ok")}, // valid
 	}
 	mounts := volumeMounts(root, vols, &out)
 


### PR DESCRIPTION
Fixes #2940

> **Note:** Re-submission of #3776, accidentally closed when the head repository was deleted.

## Summary

* Updated `pkg/docker/runner.go` -> `newHostConfig()` to configure volume mounts in addition to port bindings when running functions locally with `func run`
* Added `volumeMounts` and `toMount` helpers to convert `func.yaml` volume definitions into Docker mount specs
* Volumes that cannot be mapped locally emit a warning to stderr and are skipped; the run is not aborted

## Volume mapping

| func.yaml type             | Docker mount     | Local path                                      |
| -------------------------- | ---------------- | ----------------------------------------------- |
| secret: \<name\>             | bind             | .func/run/secrets/\<name\> (created if absent)    |
| configMap: \<name\>          | bind             | .func/run/configmaps/\<name\> (created if absent) |
| emptyDir: {medium: Memory} | tmpfs            | —                                               |
| emptyDir: {}               | anonymous volume | —                                               |
| persistentVolumeClaim      | bind             | .func/run/pvcs/\<claimName\> (created if absent)  |

All bind-mount sources are rooted inside `.func/`, satisfying the security constraint in the issue (no paths outside `.func` are ever mounted).

## Notes

* Picks up where #3143 left off. The core logic is the same; this version uses the current moby API (`mount.Mount`) instead of the legacy `Binds []string` + `Tmpfs` fields, and resolves local paths from `f.Root` rather than the process working directory, which fixes a subtle bug when `func run` is invoked from outside the function root.
* The flaky Java SSL test that blocked #3143 is unrelated to this change.
