### PR TITLE
docs(mcp): fix delete tool instructions — no-args CWD mode not supported

### DIFF
--- a/pkg/mcp/instructions.md
+++ b/pkg/mcp/instructions.md
@@ -39,7 +39,7 @@ This is essential because:
 
 **Exceptions:**
 - The `list` tool operates on the cluster, not local files, so it does NOT use a path parameter (it uses namespace instead)
-- The `delete` tool can accept an optional named Function to delete, in which case the path is not necessary (no named parameter indicates 'delete the Function in my cwd')
+- The `delete` tool requires exactly one of `path` or `name`; it does NOT support a no-argument CWD mode (the MCP server process has its own working directory unrelated to the Function being managed)
 
 ## Deployment Behavior
 


### PR DESCRIPTION
> **Note:** Re-submission of #3764, accidentally closed when the head repository was deleted.

## Problem

The embedded MCP instructions at `pkg/mcp/instructions.md` stated:

> "no named parameter indicates 'delete the Function in my cwd'"

This implied that agents could call the `delete` tool with no `path` and no `name`, and the tool would delete the Function in the current working directory.

That is incorrect in the MCP context. The MCP server runs as a separate process with its own working directory, unrelated to the Function the agent is managing. The handler at `pkg/mcp/tools_delete.go` correctly enforces that exactly one of `path` or `name` must be provided, returning an error otherwise.

The result was a direct contradiction between two lines in the same file, causing agents following the incorrect guidance to send requests the handler would reject.

## Fix

Updated the description to accurately reflect the handler's contract: `delete` requires exactly one of `path` or `name` and does not support a no-argument CWD mode.

No code changes are needed. The handler behavior is correct.

## Files changed

* `pkg/mcp/instructions.md` — corrected description of the `delete` tool
