### PR TITLE
fix(mcp): use result in error message instead of nil err in create test

### DIFF
--- a/pkg/mcp/tools_create_test.go
+++ b/pkg/mcp/tools_create_test.go
@@ -75,7 +75,7 @@ func TestTool_Create_Args(t *testing.T) {
 		t.Fatal(err)
 	}
 	if result.IsError {
-		t.Fatal(err)
+		t.Fatalf("unexpected error result: %v", result)
 	}
 	if !executor.ExecuteInvoked {
 		t.Fatal("executor was not invoked")


### PR DESCRIPTION
> **Note:** Re-submission of #3763, accidentally closed when the head repository was deleted.

## Problem

In `TestTool_Create_Args`, after a successful `client.CallTool` call, the error branch reads:

```go
if result.IsError {
    t.Fatal(err) // err is nil here
}
```

`CallTool` returned `(result, nil)` — `err` is guaranteed nil at this point since it was already checked on the lines above. If `result.IsError` ever triggers, `t.Fatal(nil)` prints `<nil>`, giving zero diagnostic information about what actually failed.

## Fix

Replace with the pattern used consistently across every other tool test in this package:

```go
if result.IsError {
    t.Fatalf("unexpected error result: %v", result)
}
```

No behaviour change — this only affects the failure message when the test fails.
