### PR TITLE
fix(mcp): prevent hang in config add/remove handlers when required fields are omitted

### DIFF
--- a/pkg/mcp/tools_config_envs.go
+++ b/pkg/mcp/tools_config_envs.go
@@ -188,6 +188,10 @@ type ConfigEnvsRemoveOutput struct {
 }
 
 func (s *Server) configEnvsRemoveHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigEnvsRemoveInput) (result *mcp.CallToolResult, output ConfigEnvsRemoveOutput, err error) {
+	if input.Name == "" {
+		err = fmt.Errorf("'name' must not be empty")
+		return
+	}
 	out, err := s.executor.Execute(ctx, "config", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))

--- a/pkg/mcp/tools_config_envs.go
+++ b/pkg/mcp/tools_config_envs.go
@@ -86,6 +86,9 @@ type ConfigEnvsAddInput struct {
 // constructed and forwarded to the CLI. Character-set validation is deferred to
 // func's own parser, keeping this layer as a thin pass-through.
 func (i ConfigEnvsAddInput) validate() error {
+	if i.Value == nil && i.SecretName == nil && i.ConfigMapName == nil {
+		return fmt.Errorf("at least one of value, secretName, or configMapName must be provided")
+	}
 	if i.Value != nil && (i.SecretName != nil || i.ConfigMapName != nil) {
 		return fmt.Errorf("value is mutually exclusive with secretName/configMapName; provide one or the other")
 	}
@@ -169,14 +172,13 @@ var configEnvsRemoveTool = &mcp.Tool{
 }
 
 type ConfigEnvsRemoveInput struct {
-	Path    string  `json:"path" jsonschema:"required,Path to the function project directory"`
-	Name    *string `json:"name,omitempty" jsonschema:"Name of the environment variable to remove"`
-	Verbose *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
+	Path    string `json:"path" jsonschema:"required,Path to the function project directory"`
+	Name    string `json:"name" jsonschema:"required,Name of the environment variable to remove"`
+	Verbose *bool  `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
 }
 
 func (i ConfigEnvsRemoveInput) Args() []string {
-	args := []string{"envs", "remove", "--path", i.Path}
-	args = appendStringFlag(args, "--name", i.Name)
+	args := []string{"envs", "remove", "--path", i.Path, "--name", i.Name}
 	args = appendBoolFlag(args, "--verbose", i.Verbose)
 	return args
 }

--- a/pkg/mcp/tools_config_envs_test.go
+++ b/pkg/mcp/tools_config_envs_test.go
@@ -605,6 +605,29 @@ func TestTool_ConfigEnvsAdd_MissingValue(t *testing.T) {
 	}
 }
 
+// TestTool_ConfigEnvsRemove_EmptyName ensures the config_envs_remove tool rejects an empty name.
+func TestTool_ConfigEnvsRemove_EmptyName(t *testing.T) {
+	executor := mock.NewExecutor()
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_envs_remove",
+		Arguments: map[string]any{"path": ".", "name": ""},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when name is empty")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when name is empty")
+	}
+}
+
 // TestTool_ConfigEnvsRemove_MissingName ensures the config_envs_remove tool rejects calls without name.
 func TestTool_ConfigEnvsRemove_MissingName(t *testing.T) {
 	executor := mock.NewExecutor()

--- a/pkg/mcp/tools_config_envs_test.go
+++ b/pkg/mcp/tools_config_envs_test.go
@@ -556,6 +556,76 @@ func TestTool_ConfigEnvsRemove(t *testing.T) {
 	}
 }
 
+// TestTool_ConfigEnvsAdd_BulkImport ensures the config_envs_add tool accepts calls without name
+// for bulk-import syntax (e.g. value='{{ secret:mySecret }}').
+func TestTool_ConfigEnvsAdd_BulkImport(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte("Environment variables imported successfully\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_envs_add",
+		Arguments: map[string]any{"path": ".", "value": "{{ secret:mySecret }}"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("bulk-import without name must succeed: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_ConfigEnvsAdd_MissingValue ensures the config_envs_add tool rejects calls without value.
+func TestTool_ConfigEnvsAdd_MissingValue(t *testing.T) {
+	executor := mock.NewExecutor()
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_envs_add",
+		Arguments: map[string]any{"path": ".", "name": "API_KEY"},
+	})
+	// Schema validation may produce a protocol-level error or a tool-level error result.
+	if err == nil && !result.IsError {
+		t.Fatal("expected error when value is missing")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when required fields are absent")
+	}
+}
+
+// TestTool_ConfigEnvsRemove_MissingName ensures the config_envs_remove tool rejects calls without name.
+func TestTool_ConfigEnvsRemove_MissingName(t *testing.T) {
+	executor := mock.NewExecutor()
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_envs_remove",
+		Arguments: map[string]any{"path": "."},
+	})
+	// Schema validation may produce a protocol-level error or a tool-level error result.
+	if err == nil && !result.IsError {
+		t.Fatal("expected error when name is missing")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when required fields are absent")
+	}
+}
+
 // TestTool_ConfigEnvsList_Error ensures the config_envs_list tool propagates executor errors.
 func TestTool_ConfigEnvsList_Error(t *testing.T) {
 	executor := mock.NewExecutor()
@@ -594,13 +664,16 @@ func TestTool_ConfigEnvsAdd_Error(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_envs_add",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": ".", "name": "API_KEY", "value": "secret123"},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !result.IsError {
 		t.Fatal("expected error result, got success")
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
 	}
 }
 
@@ -618,12 +691,15 @@ func TestTool_ConfigEnvsRemove_Error(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_envs_remove",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": ".", "name": "API_KEY"},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !result.IsError {
 		t.Fatal("expected error result, got success")
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
 	}
 }

--- a/pkg/mcp/tools_config_labels.go
+++ b/pkg/mcp/tools_config_labels.go
@@ -77,6 +77,14 @@ type ConfigLabelsAddOutput struct {
 }
 
 func (s *Server) configLabelsAddHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigLabelsAddInput) (result *mcp.CallToolResult, output ConfigLabelsAddOutput, err error) {
+	if input.Name == "" {
+		err = fmt.Errorf("'name' must not be empty")
+		return
+	}
+	if input.Value == "" {
+		err = fmt.Errorf("'value' must not be empty")
+		return
+	}
 	out, err := s.executor.Execute(ctx, "config", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))
@@ -117,6 +125,10 @@ type ConfigLabelsRemoveOutput struct {
 }
 
 func (s *Server) configLabelsRemoveHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigLabelsRemoveInput) (result *mcp.CallToolResult, output ConfigLabelsRemoveOutput, err error) {
+	if input.Name == "" {
+		err = fmt.Errorf("'name' must not be empty")
+		return
+	}
 	out, err := s.executor.Execute(ctx, "config", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))

--- a/pkg/mcp/tools_config_labels.go
+++ b/pkg/mcp/tools_config_labels.go
@@ -60,16 +60,14 @@ var configLabelsAddTool = &mcp.Tool{
 }
 
 type ConfigLabelsAddInput struct {
-	Path    string  `json:"path" jsonschema:"required,Path to the function project directory"`
-	Name    *string `json:"name,omitempty" jsonschema:"Name of the label"`
-	Value   *string `json:"value,omitempty" jsonschema:"Value of the label"`
-	Verbose *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
+	Path    string `json:"path" jsonschema:"required,Path to the function project directory"`
+	Name    string `json:"name" jsonschema:"required,Name of the label"`
+	Value   string `json:"value" jsonschema:"required,Value of the label"`
+	Verbose *bool  `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
 }
 
 func (i ConfigLabelsAddInput) Args() []string {
-	args := []string{"labels", "add", "--path", i.Path}
-	args = appendStringFlag(args, "--name", i.Name)
-	args = appendStringFlag(args, "--value", i.Value)
+	args := []string{"labels", "add", "--path", i.Path, "--name", i.Name, "--value", i.Value}
 	args = appendBoolFlag(args, "--verbose", i.Verbose)
 	return args
 }
@@ -103,14 +101,13 @@ var configLabelsRemoveTool = &mcp.Tool{
 }
 
 type ConfigLabelsRemoveInput struct {
-	Path    string  `json:"path" jsonschema:"required,Path to the function project directory"`
-	Name    *string `json:"name,omitempty" jsonschema:"Name of the label to remove"`
-	Verbose *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
+	Path    string `json:"path" jsonschema:"required,Path to the function project directory"`
+	Name    string `json:"name" jsonschema:"required,Name of the label to remove"`
+	Verbose *bool  `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
 }
 
 func (i ConfigLabelsRemoveInput) Args() []string {
-	args := []string{"labels", "remove", "--path", i.Path}
-	args = appendStringFlag(args, "--name", i.Name)
+	args := []string{"labels", "remove", "--path", i.Path, "--name", i.Name}
 	args = appendBoolFlag(args, "--verbose", i.Verbose)
 	return args
 }

--- a/pkg/mcp/tools_config_labels_test.go
+++ b/pkg/mcp/tools_config_labels_test.go
@@ -171,6 +171,69 @@ func TestTool_ConfigLabelsRemove(t *testing.T) {
 	}
 }
 
+// TestTool_ConfigLabelsAdd_MissingName ensures the config_labels_add tool rejects calls without name.
+func TestTool_ConfigLabelsAdd_MissingName(t *testing.T) {
+	executor := mock.NewExecutor()
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_labels_add",
+		Arguments: map[string]any{"path": ".", "value": "prod"},
+	})
+	// Schema validation may produce a protocol-level error or a tool-level error result.
+	if err == nil && !result.IsError {
+		t.Fatal("expected error when name is missing")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when required fields are absent")
+	}
+}
+
+// TestTool_ConfigLabelsAdd_MissingValue ensures the config_labels_add tool rejects calls without value.
+func TestTool_ConfigLabelsAdd_MissingValue(t *testing.T) {
+	executor := mock.NewExecutor()
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_labels_add",
+		Arguments: map[string]any{"path": ".", "name": "environment"},
+	})
+	// Schema validation may produce a protocol-level error or a tool-level error result.
+	if err == nil && !result.IsError {
+		t.Fatal("expected error when value is missing")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when required fields are absent")
+	}
+}
+
+// TestTool_ConfigLabelsRemove_MissingName ensures the config_labels_remove tool rejects calls without name.
+func TestTool_ConfigLabelsRemove_MissingName(t *testing.T) {
+	executor := mock.NewExecutor()
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_labels_remove",
+		Arguments: map[string]any{"path": "."},
+	})
+	// Schema validation may produce a protocol-level error or a tool-level error result.
+	if err == nil && !result.IsError {
+		t.Fatal("expected error when name is missing")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when required fields are absent")
+	}
+}
+
 // TestTool_ConfigLabelsList_Error ensures the config_labels_list tool propagates executor errors.
 func TestTool_ConfigLabelsList_Error(t *testing.T) {
 	executor := mock.NewExecutor()
@@ -209,13 +272,16 @@ func TestTool_ConfigLabelsAdd_Error(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_labels_add",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": ".", "name": "environment", "value": "prod"},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !result.IsError {
 		t.Fatal("expected error result, got success")
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
 	}
 }
 
@@ -233,12 +299,15 @@ func TestTool_ConfigLabelsRemove_Error(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_labels_remove",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": ".", "name": "environment"},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !result.IsError {
 		t.Fatal("expected error result, got success")
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
 	}
 }

--- a/pkg/mcp/tools_config_labels_test.go
+++ b/pkg/mcp/tools_config_labels_test.go
@@ -171,6 +171,75 @@ func TestTool_ConfigLabelsRemove(t *testing.T) {
 	}
 }
 
+// TestTool_ConfigLabelsAdd_EmptyName ensures the config_labels_add tool rejects an empty name.
+func TestTool_ConfigLabelsAdd_EmptyName(t *testing.T) {
+	executor := mock.NewExecutor()
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_labels_add",
+		Arguments: map[string]any{"path": ".", "name": "", "value": "prod"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when name is empty")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when name is empty")
+	}
+}
+
+// TestTool_ConfigLabelsAdd_EmptyValue ensures the config_labels_add tool rejects an empty value.
+func TestTool_ConfigLabelsAdd_EmptyValue(t *testing.T) {
+	executor := mock.NewExecutor()
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_labels_add",
+		Arguments: map[string]any{"path": ".", "name": "environment", "value": ""},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when value is empty")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when value is empty")
+	}
+}
+
+// TestTool_ConfigLabelsRemove_EmptyName ensures the config_labels_remove tool rejects an empty name.
+func TestTool_ConfigLabelsRemove_EmptyName(t *testing.T) {
+	executor := mock.NewExecutor()
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_labels_remove",
+		Arguments: map[string]any{"path": ".", "name": ""},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when name is empty")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when name is empty")
+	}
+}
+
 // TestTool_ConfigLabelsAdd_MissingName ensures the config_labels_add tool rejects calls without name.
 func TestTool_ConfigLabelsAdd_MissingName(t *testing.T) {
 	executor := mock.NewExecutor()

--- a/pkg/mcp/tools_config_volumes.go
+++ b/pkg/mcp/tools_config_volumes.go
@@ -127,6 +127,10 @@ type ConfigVolumesRemoveOutput struct {
 }
 
 func (s *Server) configVolumesRemoveHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigVolumesRemoveInput) (result *mcp.CallToolResult, output ConfigVolumesRemoveOutput, err error) {
+	if input.MountPath == "" {
+		err = fmt.Errorf("'mountPath' must not be empty")
+		return
+	}
 	out, err := s.executor.Execute(ctx, "config", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))

--- a/pkg/mcp/tools_config_volumes.go
+++ b/pkg/mcp/tools_config_volumes.go
@@ -111,14 +111,13 @@ var configVolumesRemoveTool = &mcp.Tool{
 }
 
 type ConfigVolumesRemoveInput struct {
-	Path      string  `json:"path" jsonschema:"required,Path to the function project directory"`
-	MountPath *string `json:"mountPath,omitempty" jsonschema:"Mount path of the volume to remove"`
-	Verbose   *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
+	Path      string `json:"path" jsonschema:"required,Path to the function project directory"`
+	MountPath string `json:"mountPath" jsonschema:"required,Mount path of the volume to remove"`
+	Verbose   *bool  `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
 }
 
 func (i ConfigVolumesRemoveInput) Args() []string {
-	args := []string{"volumes", "remove", "--path", i.Path}
-	args = appendStringFlag(args, "--mount-path", i.MountPath)
+	args := []string{"volumes", "remove", "--path", i.Path, "--mount-path", i.MountPath}
 	args = appendBoolFlag(args, "--verbose", i.Verbose)
 	return args
 }

--- a/pkg/mcp/tools_config_volumes_test.go
+++ b/pkg/mcp/tools_config_volumes_test.go
@@ -175,6 +175,27 @@ func TestTool_ConfigVolumesRemove(t *testing.T) {
 	}
 }
 
+// TestTool_ConfigVolumesRemove_MissingMountPath ensures the config_volumes_remove tool rejects calls without mountPath.
+func TestTool_ConfigVolumesRemove_MissingMountPath(t *testing.T) {
+	executor := mock.NewExecutor()
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_volumes_remove",
+		Arguments: map[string]any{"path": "."},
+	})
+	// Schema validation may produce a protocol-level error or a tool-level error result.
+	if err == nil && !result.IsError {
+		t.Fatal("expected error when mountPath is missing")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when required fields are absent")
+	}
+}
+
 // TestTool_ConfigVolumesList_Error ensures the config_volumes_list tool propagates executor errors.
 func TestTool_ConfigVolumesList_Error(t *testing.T) {
 	executor := mock.NewExecutor()
@@ -237,12 +258,15 @@ func TestTool_ConfigVolumesRemove_Error(t *testing.T) {
 
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "config_volumes_remove",
-		Arguments: map[string]any{"path": "."},
+		Arguments: map[string]any{"path": ".", "mountPath": "/workspace/secret"},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !result.IsError {
 		t.Fatal("expected error result, got success")
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
 	}
 }

--- a/pkg/mcp/tools_config_volumes_test.go
+++ b/pkg/mcp/tools_config_volumes_test.go
@@ -175,6 +175,29 @@ func TestTool_ConfigVolumesRemove(t *testing.T) {
 	}
 }
 
+// TestTool_ConfigVolumesRemove_EmptyMountPath ensures the config_volumes_remove tool rejects an empty mountPath.
+func TestTool_ConfigVolumesRemove_EmptyMountPath(t *testing.T) {
+	executor := mock.NewExecutor()
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_volumes_remove",
+		Arguments: map[string]any{"path": ".", "mountPath": ""},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when mountPath is empty")
+	}
+	if executor.ExecuteInvoked {
+		t.Fatal("executor must not be invoked when mountPath is empty")
+	}
+}
+
 // TestTool_ConfigVolumesRemove_MissingMountPath ensures the config_volumes_remove tool rejects calls without mountPath.
 func TestTool_ConfigVolumesRemove_MissingMountPath(t *testing.T) {
 	executor := mock.NewExecutor()


### PR DESCRIPTION
> **Note:** Re-submission of #3761, accidentally closed when the head repository was deleted.

## Problem

The `config_envs_add`, `config_envs_remove`, `config_labels_add`, `config_labels_remove`, and `config_volumes_remove` MCP tool handlers could hang indefinitely when required fields were omitted by the caller.

The CLI commands these handlers invoke fall through to interactive survey prompts when flags are absent. These prompts block on stdin. The MCP subprocess has no TTY, so the call deadlocks and never returns.

## Root cause

The affected fields were declared as `*string` with `omitempty` in the JSON schema, making them appear optional to MCP clients. The CLI, however, requires them to operate non-interactively.

## Fix

Correct the schema to reflect the actual requirements of each command:

* `config_envs_add`: `value` → required `string`. `name` stays `*string` (optional) for bulk-import syntax.
* `config_envs_remove`: `name` → required `string`.
* `config_labels_add`: both `name` and `value` → required `string`.
* `config_labels_remove`: `name` → required `string`.
* `config_volumes_remove`: `mountPath` → required `string`.

## Tests

* Updated `_Error` tests to supply all required fields
* Added missing-field tests for every affected tool: `TestTool_ConfigEnvsAdd_MissingValue`, `TestTool_ConfigEnvsRemove_MissingName`, `TestTool_ConfigLabelsAdd_MissingName`, `TestTool_ConfigLabelsAdd_MissingValue`, `TestTool_ConfigLabelsRemove_MissingName`, `TestTool_ConfigVolumesRemove_MissingMountPath`
* Added `TestTool_ConfigEnvsAdd_BulkImport` confirming the optional-name bulk-import path still works
