### PR TITLE
fix(mcp): block build --push in read-only MCP mode

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -98,10 +98,10 @@ DESCRIPTION
 func runMCPStart(cmd *cobra.Command, args []string, newClient ClientFactory) error {
 	// Configure write mode
 	writeEnabled := false
-	if val := os.Getenv("FUNC_ENABLE_MCP_WRITE"); val != "" {
+	if val := os.Getenv(mcp.EnvMCPWrite); val != "" {
 		parsed, err := strconv.ParseBool(val)
 		if err != nil {
-			return fmt.Errorf("FUNC_ENABLE_MCP_WRITE should be a boolean (true/false, 1/0, etc). Received %q", val)
+			return fmt.Errorf("%s should be a boolean (true/false, 1/0, etc). Received %q", mcp.EnvMCPWrite, val)
 		}
 		writeEnabled = parsed
 	}

--- a/pkg/mcp/instructions_warning.md
+++ b/pkg/mcp/instructions_warning.md
@@ -15,12 +15,13 @@ The Functions MCP server is currently running in **read-only mode**.
 **Disabled operations:**
 - Deploy to cluster
 - Delete from cluster
+- Push a built image to a registry (`build` with `push` enabled)
 
 These write operations are disabled to prevent unintended cluster modifications.
 
 ## Enabling Write Mode
 
-If the user needs to deploy or delete Functions, you MUST inform them to enable write mode:
+If the user needs to deploy or delete Functions, or push a built image to a registry, you MUST inform them to enable write mode:
 
 1. Close/exit this application completely
 2. Set the environment variable: `FUNC_ENABLE_MCP_WRITE=true`

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -14,6 +14,11 @@ const (
 	name    = "func"
 	title   = "func"
 	version = "0.1.0"
+
+	// EnvMCPWrite is the environment variable that enables write operations
+	// (build, deploy, delete) on the MCP server. Set to "true" to allow
+	// mutations; the server runs in read-only mode by default.
+	EnvMCPWrite = "FUNC_ENABLE_MCP_WRITE"
 )
 
 // NOTE: Invoking prompts in some interfaces (such as Claude Code) when all

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -15,6 +15,11 @@ const (
 	name    = "func"
 	title   = "func"
 	version = "0.1.0"
+
+	// EnvMCPWrite is the environment variable that enables write operations
+	// (deploy, delete, and pushing built images) on the MCP server. Set to
+	// "true" to allow mutations; the server runs in read-only mode by default.
+	EnvMCPWrite = "FUNC_ENABLE_MCP_WRITE"
 )
 
 // NOTE: Invoking prompts in some interfaces (such as Claude Code) when all
@@ -25,7 +30,7 @@ const (
 type Server struct {
 	OnInit    func(context.Context) // Invoked when the server is initialized
 	prefix    string                // Command prefix ("func" or "kn func")
-	readonly  atomic.Bool           // disables deploy, delete, and build when true
+	readonly  atomic.Bool           // disables deploy, delete, and pushing built images when true
 	executor  executor
 	transport mcp.Transport // Transport to use (defaults to StdioTransport)
 	impl      *mcp.Server   // implements the protocol

--- a/pkg/mcp/tools_build.go
+++ b/pkg/mcp/tools_build.go
@@ -21,7 +21,7 @@ var buildTool = &mcp.Tool{
 
 func (s *Server) buildHandler(ctx context.Context, r *mcp.CallToolRequest, input BuildInput) (result *mcp.CallToolResult, output BuildOutput, err error) {
 	if s.readonly.Load() && input.Push != nil && *input.Push {
-		err = fmt.Errorf("the server is in read-only mode; set FUNC_ENABLE_MCP_WRITE=true to push images")
+		err = fmt.Errorf("pushing images is not allowed in read-only mode; set %s=true to enable write operations", EnvMCPWrite)
 		return
 	}
 	out, err := s.executor.Execute(ctx, "build", input.Args()...)

--- a/pkg/mcp/tools_build.go
+++ b/pkg/mcp/tools_build.go
@@ -20,11 +20,10 @@ var buildTool = &mcp.Tool{
 }
 
 func (s *Server) buildHandler(ctx context.Context, r *mcp.CallToolRequest, input BuildInput) (result *mcp.CallToolResult, output BuildOutput, err error) {
-	if s.readonly.Load() {
-		err = fmt.Errorf("the server is currently in read-only mode; to enable write operations, set FUNC_ENABLE_MCP_WRITE in the server environment and restart the server")
+	if s.readonly.Load() && input.Push != nil && *input.Push {
+		err = fmt.Errorf("the server is in read-only mode; set FUNC_ENABLE_MCP_WRITE=true to push images")
 		return
 	}
-
 	out, err := s.executor.Execute(ctx, "build", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))

--- a/pkg/mcp/tools_build_test.go
+++ b/pkg/mcp/tools_build_test.go
@@ -8,6 +8,55 @@ import (
 	"knative.dev/func/pkg/mcp/mock"
 )
 
+// TestTool_Build_ReadonlyPushRejected ensures build with push=true is rejected in readonly mode.
+func TestTool_Build_ReadonlyPushRejected(t *testing.T) {
+	client, _, err := newTestPairWithReadonly(t, true) // readonly = true
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "build",
+		Arguments: map[string]any{"path": ".", "push": true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected build --push to be rejected in readonly mode")
+	}
+}
+
+// TestTool_Build_ReadonlyWithoutPushAllowed ensures build without push is allowed in readonly mode.
+func TestTool_Build_ReadonlyWithoutPushAllowed(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(_ context.Context, subcommand string, _ ...string) ([]byte, error) {
+		if subcommand != "build" {
+			t.Fatalf("expected subcommand 'build', got %q", subcommand)
+		}
+		return []byte("OK\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithReadonly(true), WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "build",
+		Arguments: map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("expected build without push to succeed in readonly mode, got error: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
 // TestTool_Build_Args ensures the build tool executes with all arguments passed correctly.
 func TestTool_Build_Args(t *testing.T) {
 	// Test data - defined once and used for both input and validation

--- a/pkg/mcp/tools_delete.go
+++ b/pkg/mcp/tools_delete.go
@@ -21,7 +21,7 @@ var deleteTool = &mcp.Tool{
 
 func (s *Server) deleteHandler(ctx context.Context, r *mcp.CallToolRequest, input DeleteInput) (result *mcp.CallToolResult, output DeleteOutput, err error) {
 	if s.readonly.Load() {
-		err = fmt.Errorf("the server is currently in readonly mode.  Please set FUNC_ENABLE_MCP_WRITE and restart the client")
+		err = fmt.Errorf("delete is not allowed in read-only mode; set %s=true to enable write operations", EnvMCPWrite)
 		return
 	}
 

--- a/pkg/mcp/tools_delete.go
+++ b/pkg/mcp/tools_delete.go
@@ -21,7 +21,7 @@ var deleteTool = &mcp.Tool{
 
 func (s *Server) deleteHandler(ctx context.Context, r *mcp.CallToolRequest, input DeleteInput) (result *mcp.CallToolResult, output DeleteOutput, err error) {
 	if s.readonly.Load() {
-		err = fmt.Errorf("the server is currently in readonly mode. Please set FUNC_ENABLE_MCP_WRITE and restart the MCP server")
+		err = fmt.Errorf("the server is currently in readonly mode. Please set %s and restart the MCP server", EnvMCPWrite)
 		return
 	}
 

--- a/pkg/mcp/tools_deploy.go
+++ b/pkg/mcp/tools_deploy.go
@@ -21,7 +21,7 @@ var deployTool = &mcp.Tool{
 
 func (s *Server) deployHandler(ctx context.Context, r *mcp.CallToolRequest, input DeployInput) (result *mcp.CallToolResult, output DeployOutput, err error) {
 	if s.readonly.Load() {
-		err = fmt.Errorf("the server is currently in readonly mode.  Please set FUNC_ENABLE_MCP_WRITE and restart the client")
+		err = fmt.Errorf("deploy is not allowed in read-only mode; set %s=true to enable write operations", EnvMCPWrite)
 		return
 	}
 	out, err := s.executor.Execute(ctx, "deploy", input.Args()...)

--- a/pkg/mcp/tools_deploy.go
+++ b/pkg/mcp/tools_deploy.go
@@ -21,7 +21,7 @@ var deployTool = &mcp.Tool{
 
 func (s *Server) deployHandler(ctx context.Context, r *mcp.CallToolRequest, input DeployInput) (result *mcp.CallToolResult, output DeployOutput, err error) {
 	if s.readonly.Load() {
-		err = fmt.Errorf("the server is currently in readonly mode. Please set FUNC_ENABLE_MCP_WRITE and restart the MCP server")
+		err = fmt.Errorf("the server is currently in readonly mode. Please set %s and restart the MCP server", EnvMCPWrite)
 		return
 	}
 	out, err := s.executor.Execute(ctx, "deploy", input.Args()...)


### PR DESCRIPTION
> **Note:** Re-submission of #3741, accidentally closed when the head repository was deleted.

## Summary

When the MCP server runs in read-only mode (default unless `FUNC_ENABLE_MCP_WRITE` enables writes), `deploy` and `delete` are already rejected. `build` with `push: true` could still push images to a registry. This change rejects that path with a clear error.

## Motivation

Read-only mode is meant to avoid mutating external state. Pushing a built image to a registry is such a mutation and should align with the same policy as deploy/delete.

## Changes

* `pkg/mcp/tools_build.go`: in `buildHandler`, return an error when `s.readonly` is true and the tool input requests push (`Push != nil && *input.Push`).

## Testing

* `go test ./pkg/mcp/...` or `make test`

