### PR TITLE
ci: skip functions workflow on doc-only changes

### DIFF
--- a/.github/workflows/ci-check.yaml
+++ b/.github/workflows/ci-check.yaml
@@ -4,9 +4,24 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**/*.md'
+      - '*.md'
+      - 'OWNERS'
+      - 'OWNERS_ALIASES'
+      - 'LICENSE'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**/*.md'
+      - '*.md'
+      - 'OWNERS'
+      - 'OWNERS_ALIASES'
+      - 'LICENSE'
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-check.yaml
+++ b/.github/workflows/ci-check.yaml
@@ -1,0 +1,31 @@
+name: Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  precheck:
+    name: Precheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: knative/actions/setup-go@main
+
+      - name: Check and Lint
+        run: make check
+      - name: Check Generated Schema File
+        run: make check-schema
+      - name: Check Templates
+        run: make check-templates
+      - name: Check Embedded FS
+        run: make check-embedded-fs

--- a/.github/workflows/ci-check.yaml
+++ b/.github/workflows/ci-check.yaml
@@ -1,0 +1,43 @@
+name: Check
+
+# Documentation-only companion to the Functions workflow.
+#
+# The Functions workflow ignores documentation changes (see its `paths-ignore`),
+# so this workflow covers exactly those paths and runs only the checks that
+# apply to them (`make check-docs`).  The two trigger sets are disjoint: a
+# doc-only change runs Check, a code change runs Functions.
+
+on:
+  push:
+    branches:
+      - main
+      - 'release-*'
+    paths:
+      - 'docs/**/*.md'
+      - '*.md'
+  pull_request:
+    branches:
+      - main
+      - 'release-*'
+    paths:
+      - 'docs/**/*.md'
+      - '*.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check-docs:
+    name: Check Docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: knative/actions/setup-go@main
+
+      - name: Check Docs
+        run: make check-docs

--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -12,9 +12,19 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'CODEOWNERS'
+      - 'LICENSE'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'CODEOWNERS'
+      - 'LICENSE'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -13,7 +13,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'docs/**'
+      - 'docs/**/*.md'
       - '*.md'
       - 'OWNERS'
       - 'OWNERS_ALIASES'
@@ -22,7 +22,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'docs/**'
+      - 'docs/**/*.md'
       - '*.md'
       - 'OWNERS'
       - 'OWNERS_ALIASES'

--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -14,16 +14,18 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
-      - '**/*.md'
-      - 'CODEOWNERS'
+      - '*.md'
+      - 'OWNERS'
+      - 'OWNERS_ALIASES'
       - 'LICENSE'
   pull_request:
     branches:
       - main
     paths-ignore:
       - 'docs/**'
-      - '**/*.md'
-      - 'CODEOWNERS'
+      - '*.md'
+      - 'OWNERS'
+      - 'OWNERS_ALIASES'
       - 'LICENSE'
   workflow_dispatch:
 

--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -18,10 +18,22 @@ on:
     branches:
       - main
       - 'release-*'
+    paths-ignore:
+      - 'docs/**/*.md'
+      - '*.md'
+      - 'OWNERS'
+      - 'OWNERS_ALIASES'
+      - 'LICENSE'
   pull_request:
     branches:
       - main
       - 'release-*'
+    paths-ignore:
+      - 'docs/**/*.md'
+      - '*.md'
+      - 'OWNERS'
+      - 'OWNERS_ALIASES'
+      - 'LICENSE'
   workflow_dispatch:
 
 concurrency:

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,15 @@ check-misspell: $(BIN_MISSPELL) ## Check for common misspellings
 		while IFS= read -r file; do [ -f "$$file" ] && echo "$$file"; done | \
 		xargs $(BIN_MISSPELL) -i importas -error
 
+.PHONY: check-docs
+check-docs: $(BIN_MISSPELL) ## Check documentation-only paths (see .github/workflows/ci-check.yaml)
+	@echo "Checking documentation for misspellings..."
+	@git ls-files -- ':(glob)*.md' ':(glob)docs/**/*.md' | \
+		git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$$' | cut -d: -f1 | \
+		git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$$' | cut -d: -f1 | \
+		while IFS= read -r file; do [ -f "$$file" ] && echo "$$file"; done | \
+		xargs $(BIN_MISSPELL) -i importas -error
+
 .PHONY: check-whitespace
 check-whitespace: ## Check for trailing whitespace
 	@echo "Checking for trailing whitespace..."


### PR DESCRIPTION
Closes #3634

> **Note:** Re-submission of #3631, accidentally closed when the head repository was deleted.

## Summary

* Adds `paths-ignore` filters to both `push` and `pull_request` triggers in the `Functions` CI workflow
* Skips the full CI suite (unit, template, integration, e2e) when only documentation or non-code files are changed
* Ignored paths: `docs/**`, `**/*.md`, `CODEOWNERS`, `LICENSE`

## Motivation

The `Functions` workflow spawns many expensive jobs (unit tests across 5 OSes, integration tests, 7-runtime E2E matrix). Running all of these on a docs-only commit wastes CI minutes and runner time.

## Test plan

* Open a PR that only modifies a `.md` file — verify `Functions` workflow is skipped
* Open a PR that modifies a `.go` file — verify `Functions` workflow still runs
