### PR TITLE
fix(k8s): propagate caller context in dialer DialContext

### DIFF
--- a/pkg/k8s/dialer.go
+++ b/pkg/k8s/dialer.go
@@ -106,8 +106,10 @@ func (c *contextDialer) DialContext(ctx context.Context, network string, addr st
 	case <-connectSuccess:
 		return conn, nil
 	case err := <-connectFailure:
+		execCancel()
 		return nil, err
 	case <-ctx.Done():
+		execCancel()
 		_ = conn.closeWithError(ctx.Err())
 		return nil, ctx.Err()
 	}

--- a/pkg/k8s/dialer.go
+++ b/pkg/k8s/dialer.go
@@ -77,11 +77,18 @@ func (c *contextDialer) DialContext(ctx context.Context, network string, addr st
 	ctrStdin, ctrStdout, conn := newConn()
 	connectSuccess := make(chan struct{})
 	connectFailure := make(chan error, 1)
+	// The exec stream must outlive the dial context: per net.Dialer.DialContext
+	// semantics, ctx governs connection *establishment* only. Once connected,
+	// expiry of ctx must not tear down the tunnel. We therefore give exec its
+	// own background-derived context and cancel it when the goroutine exits
+	// (which happens when the connection's pipes are closed).
+	execCtx, execCancel := context.WithCancel(context.Background())
 	go func() {
+		defer execCancel()
 		stderrBuff := bytes.NewBuffer(nil)
 		ctrStderr := io.MultiWriter(stderrBuff, detectConnSuccess(connectSuccess))
 
-		err := c.exec(context.TODO(), addr, ctrStdin, ctrStdout, ctrStderr)
+		err := c.exec(execCtx, addr, ctrStdin, ctrStdout, ctrStderr)
 		if err != nil {
 			stderrStr := stderrBuff.String()
 			socatErr := tryParseSocatError(network, addr, stderrStr)

--- a/pkg/k8s/dialer_int_test.go
+++ b/pkg/k8s/dialer_int_test.go
@@ -253,6 +253,11 @@ func TestInt_DialUnreachable(t *testing.T) {
 // DialContext continues to work after the dial context has expired.
 // Per net.Dialer.DialContext semantics: "Once successfully connected, any
 // expiration of the context will not affect the connection."
+//
+// We use the raw net.Conn returned by DialContext and perform an HTTP
+// request "by hand" so that only the dial step is governed by dialCtx.
+// (http.Client uses the request context for the entire request lifetime,
+// which would conflate what we are testing.)
 func TestInt_DialContextExpiry(t *testing.T) {
 	var setupCtx = t.Context()
 
@@ -320,47 +325,44 @@ func TestInt_DialContextExpiry(t *testing.T) {
 		t.Fatal("deployment never became ready:", err)
 	}
 
-	dialer := k8s.NewLazyInitInClusterDialer(clientConfig)
+	// Create the dialer pod eagerly so that pod creation is not tied to dialCtx.
+	dialer, err := k8s.NewInClusterDialer(setupCtx, clientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Cleanup(func() { dialer.Close() })
 
 	// Use a short-lived context for dial establishment only.
 	dialCtx, dialCancel := context.WithTimeout(setupCtx, 30*time.Second)
 
-	transport := &http.Transport{
-		DialContext: dialer.DialContext,
-	}
-	client := http.Client{Transport: transport}
-
-	svcURL := fmt.Sprintf("http://%s.%s.svc", svc.Name, svc.Namespace)
-
-	// First request — establishes the connection while dialCtx is alive.
-	resp, err := client.Get(svcURL)
+	// Dial directly to obtain a raw net.Conn.
+	addr := fmt.Sprintf("%s.%s.svc:80", svc.Name, svc.Namespace)
+	conn, err := dialer.DialContext(dialCtx, "tcp", addr)
 	if err != nil {
 		dialCancel()
 		t.Fatal(err)
 	}
-	_, _ = io.Copy(io.Discard, resp.Body)
-	resp.Body.Close()
-	if resp.StatusCode != 200 {
-		dialCancel()
-		t.Fatalf("unexpected status code: %d", resp.StatusCode)
-	}
-	t.Log("first request succeeded while dial context is alive")
+	t.Log("connection established while dial context is alive")
 
-	// Now cancel the dial context.
+	// Cancel the dial context — per net.Dialer semantics, the connection must survive.
 	dialCancel()
 	t.Log("dial context cancelled; connection should survive")
 
-	// Second request — reuses the established connection.
-	// If the exec stream was incorrectly tied to dialCtx, this will fail.
-	resp, err = client.Get(svcURL)
+	// Perform an HTTP request "by hand" over the raw connection.
+	_, err = fmt.Fprintf(conn, "GET / HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", addr)
 	if err != nil {
-		t.Fatalf("connection died after dial context expired: %v", err)
+		t.Fatalf("write failed after dial context expired: %v", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read failed after dial context expired: %v", err)
 	}
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, resp.Body)
+
 	if resp.StatusCode != 200 {
 		t.Fatalf("unexpected status code after dial context expired: %d", resp.StatusCode)
 	}
-	t.Log("second request succeeded after dial context expired — connection survived")
+	t.Log("HTTP request over raw conn succeeded after dial context expired — connection survived")
 }

--- a/pkg/k8s/dialer_int_test.go
+++ b/pkg/k8s/dialer_int_test.go
@@ -4,6 +4,7 @@ package k8s_test
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -246,4 +247,120 @@ func TestInt_DialUnreachable(t *testing.T) {
 	if !strings.Contains(err.Error(), "connection refused") {
 		t.Errorf("error %q doesn't contain expected substring: ", err.Error())
 	}
+}
+
+// TestInt_DialContextExpiry verifies that a connection established via
+// DialContext continues to work after the dial context has expired.
+// Per net.Dialer.DialContext semantics: "Once successfully connected, any
+// expiration of the context will not affect the connection."
+func TestInt_DialContextExpiry(t *testing.T) {
+	var setupCtx = t.Context()
+
+	clientConfig := k8s.GetClientConfig()
+	rc, err := clientConfig.ClientConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cliSet, err := kubernetes.NewForConfig(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pp := metaV1.DeletePropagationForeground
+	creatOpts := metaV1.CreateOptions{}
+	deleteOpts := metaV1.DeleteOptions{PropagationPolicy: &pp}
+
+	testingNS, _, err := clientConfig.Namespace()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rnd := rand.String(5)
+	one := int32(1)
+	labels := map[string]string{"app.kubernetes.io/name": "helloworld-ctx"}
+
+	deployment := &appsV1.Deployment{
+		ObjectMeta: metaV1.ObjectMeta{Name: "helloworld-ctx-" + rnd, Labels: labels},
+		Spec: appsV1.DeploymentSpec{
+			Replicas: &one,
+			Selector: &metaV1.LabelSelector{MatchLabels: labels},
+			Template: coreV1.PodTemplateSpec{
+				ObjectMeta: metaV1.ObjectMeta{Labels: labels},
+				Spec: coreV1.PodSpec{
+					Containers: []coreV1.Container{{
+						Name:  "helloworld",
+						Image: "gcr.io/knative-samples/helloworld-go@sha256:2babda8ec819e24d5a6342095e8f8a25a67b44eb7231ae253ecc2c448632f07e",
+						Ports: []coreV1.ContainerPort{{Name: "http", ContainerPort: 8080, Protocol: coreV1.ProtocolTCP}},
+						Env:   []coreV1.EnvVar{{Name: "PORT", Value: "8080"}},
+					}},
+				},
+			},
+		},
+	}
+	_, err = cliSet.AppsV1().Deployments(testingNS).Create(setupCtx, deployment, creatOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cliSet.AppsV1().Deployments(testingNS).Delete(setupCtx, deployment.Name, deleteOpts) })
+
+	svc := &coreV1.Service{
+		ObjectMeta: metaV1.ObjectMeta{Name: "helloworld-ctx-" + rnd},
+		Spec: coreV1.ServiceSpec{
+			Ports:    []coreV1.ServicePort{{Name: "http", Protocol: coreV1.ProtocolTCP, Port: 80, TargetPort: intstr.FromInt(8080)}},
+			Selector: labels,
+		},
+	}
+	svc, err = cliSet.CoreV1().Services(testingNS).Create(setupCtx, svc, creatOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cliSet.CoreV1().Services(testingNS).Delete(setupCtx, svc.Name, deleteOpts) })
+
+	if err := k8s.WaitForDeploymentAvailable(setupCtx, cliSet, testingNS, deployment.Name, 60*time.Second); err != nil {
+		t.Fatal("deployment never became ready:", err)
+	}
+
+	dialer := k8s.NewLazyInitInClusterDialer(clientConfig)
+	t.Cleanup(func() { dialer.Close() })
+
+	// Use a short-lived context for dial establishment only.
+	dialCtx, dialCancel := context.WithTimeout(setupCtx, 30*time.Second)
+
+	transport := &http.Transport{
+		DialContext: dialer.DialContext,
+	}
+	client := http.Client{Transport: transport}
+
+	svcURL := fmt.Sprintf("http://%s.%s.svc", svc.Name, svc.Namespace)
+
+	// First request — establishes the connection while dialCtx is alive.
+	resp, err := client.Get(svcURL)
+	if err != nil {
+		dialCancel()
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		dialCancel()
+		t.Fatalf("unexpected status code: %d", resp.StatusCode)
+	}
+	t.Log("first request succeeded while dial context is alive")
+
+	// Now cancel the dial context.
+	dialCancel()
+	t.Log("dial context cancelled; connection should survive")
+
+	// Second request — reuses the established connection.
+	// If the exec stream was incorrectly tied to dialCtx, this will fail.
+	resp, err = client.Get(svcURL)
+	if err != nil {
+		t.Fatalf("connection died after dial context expired: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != 200 {
+		t.Fatalf("unexpected status code after dial context expired: %d", resp.StatusCode)
+	}
+	t.Log("second request succeeded after dial context expired — connection survived")
 }


### PR DESCRIPTION
Replaces #3803 with the requested fixes from #3772.

1. Gives the exec stream its own background-derived context instead of reusing the dial connection context.
2. Cancels the exec stream when the connection pipes close.
3. Adds an integration test (\TestInt_DialContextExpiry\) to verify the connection survives after the dial context expires.