### PR TITLE
fix: make Quarkus default builder image multi-arch

### DIFF
--- a/pkg/buildpacks/builder.go
+++ b/pkg/buildpacks/builder.go
@@ -30,6 +30,7 @@ const DefaultName = builders.Pack
 
 var DefaultBaseBuilder = "ghcr.io/knative/builder-jammy-base:v2"
 var DefaultTinyBuilder = "ghcr.io/knative/builder-jammy-tiny:v2"
+var DefaultQuarkusBuilder = "paketobuildpacks/builder-ubi8-base" // Multi-arch support for s390x/ppc64le
 
 var (
 	DefaultBuilderImages = map[string]string{
@@ -38,7 +39,7 @@ var (
 		"typescript": DefaultBaseBuilder,
 		"go":         DefaultTinyBuilder,
 		"python":     DefaultBaseBuilder,
-		"quarkus":    DefaultTinyBuilder,
+		"quarkus":    DefaultQuarkusBuilder, // Changed to multi-arch builder
 		"rust":       DefaultBaseBuilder,
 		"springboot": DefaultBaseBuilder,
 	}

--- a/pkg/buildpacks/builder_test.go
+++ b/pkg/buildpacks/builder_test.go
@@ -82,6 +82,34 @@ func TestBuild_BuilderImageDefault(t *testing.T) {
 
 }
 
+// TestBuild_QuarkusBuilderMultiArch ensures that the Quarkus runtime uses
+// a multi-arch builder image (paketobuildpacks/builder-ubi8-base) instead of
+// the amd64-only builder, to support s390x/ppc64le clusters.
+// See: https://github.com/knative/func/issues/3781
+func TestBuild_QuarkusBuilderMultiArch(t *testing.T) {
+	var (
+		i = &mockImpl{}
+		b = NewBuilder(WithImpl(i))
+		f = fn.Function{Runtime: "quarkus"}
+	)
+
+	i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
+		expected := DefaultQuarkusBuilder
+		if opts.Builder != expected {
+			t.Fatalf("expected Quarkus builder image '%v' (multi-arch), got '%v'", expected, opts.Builder)
+		}
+		// Verify it's the multi-arch builder, not the old amd64-only one
+		if opts.Builder == DefaultTinyBuilder {
+			t.Fatal("Quarkus should not use DefaultTinyBuilder (amd64-only)")
+		}
+		return nil
+	}
+
+	if err := b.Build(t.Context(), f, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestBuild_BuildpacksDefault ensures that, if there are default buildpacks
 // defined in-code, but none defined on the function, the defaults will be
 // used.


### PR DESCRIPTION
## What This PR Does

This PR fixes Quarkus function builds on non-amd64 architectures (s390x, ppc64le, arm64) by switching to a multi-arch builder image.

## Background

Issue #3781 reported that Quarkus builds were failing on s390x and ppc64le clusters with silent `exec format error`. The root cause was that the default Quarkus builder image (`ghcr.io/knative/builder-jammy-tiny:v2`) only supports amd64 architecture.

When a user tried to build a Quarkus function on a non-amd64 cluster, the build would fail because the builder image couldn't run on that architecture. The error was silent and confusing for users.

## What I Changed

I swapped the Quarkus default builder from the amd64-only image to a multi-arch image that supports all major architectures:

**Before:**
```go
"quarkus": DefaultTinyBuilder, // ghcr.io/knative/builder-jammy-tiny:v2 (amd64 only)
```

**After:**
```go
"quarkus": DefaultQuarkusBuilder, // paketobuildpacks/builder-ubi8-base (multi-arch)
```

The new `paketobuildpacks/builder-ubi8-base` image supports:
- amd64 (Intel/AMD 64-bit)
- s390x (IBM System z)
- ppc64le (IBM POWER)
- arm64 (ARM 64-bit)

## Implementation Details

**File: `pkg/buildpacks/builder.go`**
- Added a new constant `DefaultQuarkusBuilder = "paketobuildpacks/builder-ubi8-base"`
- Changed `DefaultBuilderImages["quarkus"]` to use this new builder instead of `DefaultTinyBuilder`

**File: `pkg/buildpacks/builder_test.go`**
- Added `TestBuild_QuarkusBuilderMultiArch` test to verify Quarkus uses the multi-arch builder
- Test ensures we don't accidentally revert to the amd64-only builder

## Security

The `paketobuildpacks/builder-ubi8-base` image is already in the trusted builder image prefixes list (`docker.io/paketobuildpacks/`), so no additional security configuration is needed.

## Testing

I've added a unit test that verifies the correct builder is selected for Quarkus functions. All existing buildpacks tests continue to pass.

**Test Results:**
```
=== RUN   TestBuild_QuarkusBuilderMultiArch
--- PASS: TestBuild_QuarkusBuilderMultiArch (0.15s)
PASS
ok      knative.dev/func/pkg/buildpacks 1.795s
```

## Hardware Access Note

I don't currently have access to s390x or ppc64le hardware for end-to-end testing. The unit tests verify that the correct multi-arch builder is selected. If someone with access to these architectures can test the actual build process, that would be great for validation.

**Test command:**
```bash
func create -l quarkus test-quarkus
cd test-quarkus
func build
func deploy
```

## What This Fixes

- Quarkus functions can now be built on s390x clusters
- Quarkus functions can now be built on ppc64le clusters  
- Quarkus functions continue to work on amd64 clusters
- Quarkus functions can now be built on arm64 clusters
- Users won't see confusing `exec format error` messages anymore

Fixes #3781
