### PR TITLE
fix(cmd): remove unreachable dead code in --extension validation

### DIFF
--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -175,9 +175,6 @@ func runInvoke(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 		if effectiveFormat != "cloudevent" {
 			return fmt.Errorf("--extension (-e) is only valid with cloudevents")
 		}
-		if effectiveFormat != "" && effectiveFormat != "cloudevent" {
-			return fmt.Errorf("--extension flag is only valid with cloudevent format")
-		}
 	}
 
 	// Client instance from env vars, flags, args and user prompts (if --confirm)


### PR DESCRIPTION
## Problem

In `cmd/invoke.go`, the `--extension` validation block contains two consecutive
`if` checks, but the second is permanently unreachable:

```go
if effectiveFormat != "cloudevent" {          // returns here if true
    return fmt.Errorf("--extension (-e) is only valid with cloudevents")
}
if effectiveFormat != "" && effectiveFormat != "cloudevent" { // DEAD — never reached
    return fmt.Errorf("--extension flag is only valid with cloudevent format")
}
```

If the first condition is true the function has already returned. By the time
execution reaches the second `if`, `effectiveFormat` is guaranteed to equal
`"cloudevent"`, so the second condition is always `false`. The duplicate error
message is also inconsistently worded.

## Fix

Remove the unreachable block. The single check at line 175 is sufficient and
already carries the correct error message.

## Testing

`go test ./cmd/...`