### PR TITLE
fix(mcp): add readonly guard to buildHandler

### DIFF
--- a/pkg/mcp/tools_build.go
+++ b/pkg/mcp/tools_build.go
@@ -21,7 +21,7 @@ var buildTool = &mcp.Tool{
 
 func (s *Server) buildHandler(ctx context.Context, r *mcp.CallToolRequest, input BuildInput) (result *mcp.CallToolResult, output BuildOutput, err error) {
 	if s.readonly.Load() {
-		err = fmt.Errorf("the server is currently in readonly mode.  Please set FUNC_ENABLE_MCP_WRITE and restart the client")
+		err = fmt.Errorf("the server is currently in read-only mode; to enable write operations, set FUNC_ENABLE_MCP_WRITE in the server environment and restart the server")
 		return
 	}
 

--- a/pkg/mcp/tools_build.go
+++ b/pkg/mcp/tools_build.go
@@ -20,6 +20,11 @@ var buildTool = &mcp.Tool{
 }
 
 func (s *Server) buildHandler(ctx context.Context, r *mcp.CallToolRequest, input BuildInput) (result *mcp.CallToolResult, output BuildOutput, err error) {
+	if s.readonly.Load() {
+		err = fmt.Errorf("the server is currently in readonly mode.  Please set FUNC_ENABLE_MCP_WRITE and restart the client")
+		return
+	}
+
 	out, err := s.executor.Execute(ctx, "build", input.Args()...)
 	if err != nil {
 		err = fmt.Errorf("%w\n%s", err, string(out))


### PR DESCRIPTION
## Problem

`buildHandler` invokes `func build`, which can write updated image metadata back to `func.yaml` (e.g. `build.image`). The tool is correctly annotated with `ReadOnlyHint: false`, but it was missing the `s.readonly.Load()` check that prevents mutating operations when the MCP server starts in readonly mode.

## Changes

- `pkg/mcp/tools_build.go`: add `s.readonly.Load()` guard at the top of `buildHandler`, consistent with the existing pattern in `deleteHandler` and `deployHandler`.