### PR TITLE
fix(cmd): replace panic with error return in write() and remove phantom xml format

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -89,8 +89,7 @@ func runDescribe(cmd *cobra.Command, args []string, newClient ClientFactory) (er
 		}
 	}
 
-	write(os.Stdout, info(details), cfg.Output)
-	return
+	return write(os.Stdout, info(details), cfg.Output)
 }
 
 // CLI Configuration (parameters)

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -24,25 +24,21 @@ type Formatter interface {
 	URL(io.Writer) error
 }
 
-// write to the output the output of the formatter's appropriate serilization function.
-// the command to exit with value 2.
-func write(out io.Writer, s Formatter, formatName string) {
-	var err error
+// write the output using the formatter's appropriate serialization function,
+// returning any errors to the caller for graceful handling.
+func write(out io.Writer, s Formatter, formatName string) error {
 	switch Format(formatName) {
 	case Human:
-		err = s.Human(out)
+		return s.Human(out)
 	case Plain:
-		err = s.Plain(out)
+		return s.Plain(out)
 	case JSON:
-		err = s.JSON(out)
+		return s.JSON(out)
 	case YAML:
-		err = s.YAML(out)
+		return s.YAML(out)
 	case URL:
-		err = s.URL(out)
+		return s.URL(out)
 	default:
-		err = fmt.Errorf("format not recognized: %v", formatName)
-	}
-	if err != nil {
-		panic(err)
+		return fmt.Errorf("format not recognized: %v", formatName)
 	}
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -68,7 +68,7 @@ Lists deployed functions.
 	// Flags
 	cmd.Flags().BoolP("all-namespaces", "A", false, "List functions in all namespaces. If set, the --namespace flag is ignored.")
 	cmd.Flags().StringP("namespace", "n", defaultNamespace(fn.Function{}, false), "The namespace for which to list functions. ($FUNC_NAMESPACE)")
-	cmd.Flags().StringP("output", "o", "human", "Output format (human|plain|json|xml|yaml) ($FUNC_OUTPUT)")
+	cmd.Flags().StringP("output", "o", "human", "Output format (human|plain|json|yaml) ($FUNC_OUTPUT)")
 	addVerboseFlag(cmd, cfg.Verbose)
 
 	if err := cmd.RegisterFlagCompletionFunc("output", CompleteOutputFormatList); err != nil {
@@ -119,9 +119,7 @@ To see functions here:
 		return
 	}
 
-	write(os.Stdout, listItems(items), cfg.Output)
-
-	return
+	return write(os.Stdout, listItems(items), cfg.Output)
 }
 
 // CLI Configuration (parameters)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -95,8 +95,7 @@ func runVersion(cmd *cobra.Command, v Version) error {
 	}
 	v.MiddlewareVersions = latestMW
 
-	write(cmd.OutOrStdout(), v, output)
-	return nil
+	return write(cmd.OutOrStdout(), v, output)
 }
 
 // Version information populated on build.

--- a/docs/reference/func_list.md
+++ b/docs/reference/func_list.md
@@ -34,7 +34,7 @@ func list --all-namespaces --output json
   -A, --all-namespaces     List functions in all namespaces. If set, the --namespace flag is ignored.
   -h, --help               help for list
   -n, --namespace string   The namespace for which to list functions. ($FUNC_NAMESPACE) (default "default")
-  -o, --output string      Output format (human|plain|json|xml|yaml) ($FUNC_OUTPUT) (default "human")
+  -o, --output string      Output format (human|plain|json|yaml) ($FUNC_OUTPUT) (default "human")
   -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
 ```
 


### PR DESCRIPTION
Fixes https://github.com/knative/func/issues/3844

## Changes

The `write()` function in `cmd/format.go` used `panic(err)` when encountering an unrecognized output format or serialization error. This crashes the CLI process instead of showing a graceful error message.

Additionally, `list.go` advertised `xml` as a valid output format in its `--output` flag help text, but XML was never implemented. Passing `--output xml` would trigger the panic.

### What this PR does:

1. **`cmd/format.go`**: Change `write()` to return `error` instead of panicking
2. **`cmd/list.go`**, **`cmd/describe.go`**, **`cmd/version.go`**: Update all three callers to propagate the returned error
3. **`cmd/list.go`**: Remove `xml` from the `--output` flag help text

### Testing

The change is minimal and type-safe - the function signature change from `func write(...)` to `func write(...) error` forces all callers to handle the error. Previously-panicking code paths now return errors through cobra's standard error handling.

/kind bug