### PR TITLE
fix(cmd): reorder invoke validation to check Initialized before Validate

### DIFF
--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -412,6 +412,26 @@ Or use --path to delete from anywhere:
 
 For more options, run 'func delete --help'`, e.Err)
 
+	case "invoke":
+		return fmt.Sprintf(`%v
+
+No function found in provided path (current directory or via --path).
+You need to be inside a function directory to invoke it (or use --path).
+
+Try this:
+  func create --language go myfunction    Create a new function
+  cd myfunction                          Go into the function directory
+  func invoke                            Invoke the function
+
+Or if you have an existing function:
+  cd path/to/your/function              Go to your function directory
+  func invoke                           Invoke the function
+
+Or use --path to invoke from anywhere:
+  func invoke --path /path/to/function
+
+For more options, run 'func invoke --help'`, e.Err)
+
 	default:
 		return e.Err.Error()
 	}

--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -150,8 +150,10 @@ func runInvoke(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 	if err != nil {
 		return
 	}
+	if !f.Initialized() {
+		return NewErrNotInitializedFromPath(f.Root, "invoke")
+	}
 	if err = f.Validate(); err != nil {
-		fmt.Printf("error validating function at '%v'. %v\n", f.Root, err)
 		return err
 	}
 
@@ -160,10 +162,6 @@ func runInvoke(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 			"Warning: invoking as %q, but function declares type %q in func.yaml.\n"+
 				"   This may fail unless you rebuild or update func.yaml with `invoke: %s`.\n\n",
 			cfg.Format, f.Invoke, cfg.Format)
-	}
-
-	if !f.Initialized() {
-		return fmt.Errorf("no function found in current directory.\nYou need to be inside a function directory to invoke it.\n\nTry this:\n  func create --language go myfunction    Create a new function\n  cd myfunction                          Go into the function directory\n  func invoke                            Now you can invoke it\n\nOr if you have an existing function:\n  cd path/to/your/function              Go to your function directory\n  func invoke                           Invoke the function")
 	}
 
 	// If extensions were provided, ensure the format is cloudevent, otherwise return an error.

--- a/cmd/invoke_test.go
+++ b/cmd/invoke_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -113,5 +114,27 @@ func TestInvokeExtensionsMapMalformed(t *testing.T) {
 				t.Fatalf("expected error for %v, got nil", tc.exts)
 			}
 		})
+	}
+}
+
+// TestInvoke_NotInitialized ensures that invoking when there is no
+// function in the given directory fails with the appropriate error.
+func TestInvoke_NotInitialized(t *testing.T) {
+	_ = FromTempDirectory(t)
+
+	cmd := NewInvokeCmd(NewClient)
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+
+	if err == nil {
+		t.Fatal("invoking a nonexistent function should error")
+	}
+
+	var errNotInit *ErrNotInitialized
+	if !errors.As(err, &errNotInit) {
+		t.Fatalf("expected ErrNotInitialized, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "No function found in provided path") {
+		t.Fatalf("Unexpected error text returned: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/knative/func/issues/3848

## Changes

In `runInvoke()`, `f.Validate()` was called before checking `f.Initialized()`. Every other command (`run`, `deploy`, `delete`, `describe`, `subscribe`) checks `Initialized()` immediately after `NewFunction()`. The `invoke` command was the only one that validated first.

This caused users running `func invoke` in a non-function directory to see a confusing validation error (e.g., `func.yaml contains errors`) instead of the helpful "no function found" message.

Additionally, the `Validate` error was printed via `fmt.Printf` AND returned to cobra, causing double error output.

### What this PR does:

1. Move `!f.Initialized()` check before `f.Validate()` — matching every other command
2. Remove `fmt.Printf` double error output on validation failure
3. Preserve the format mismatch warning in its logical position (after validation)

### Testing

The reordering ensures the `!f.Initialized()` guard runs first, returning the user-friendly error message. The `f.Validate()` call only runs on initialized functions where it can produce meaningful diagnostics.

/kind bug
