### PR TITLE
fix: return error for malformed --extension flag values

### DIFF
--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -186,7 +186,7 @@ func runInvoke(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 
 	// Message to send the running function built from parameters gathered
 	// from the user (or defaults)
-	exts, err := cfg.extensionsMap()
+	exts, err := cfg.parseExtensions()
 	if err != nil {
 		return err
 	}
@@ -319,11 +319,11 @@ func newInvokeConfig() (cfg invokeConfig, err error) {
 	return
 }
 
-func (c invokeConfig) extensionsMap() (map[string]string, error) {
+func (c invokeConfig) parseExtensions() (map[string]string, error) {
 	result := make(map[string]string)
 	for _, ext := range c.Extensions {
 		parts := strings.SplitN(ext, "=", 2)
-		if len(parts) != 2 {
+		if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" {
 			return nil, fmt.Errorf("invalid --extension %q: must be in key=value format", ext)
 		}
 		result[parts[0]] = parts[1]

--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -186,6 +186,10 @@ func runInvoke(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 
 	// Message to send the running function built from parameters gathered
 	// from the user (or defaults)
+	exts, err := cfg.extensionsMap()
+	if err != nil {
+		return err
+	}
 	m := fn.InvokeMessage{
 		ID:          cfg.ID,
 		Source:      cfg.Source,
@@ -194,7 +198,7 @@ func runInvoke(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 		RequestType: strings.ToUpper(cfg.RequestType),
 		Data:        cfg.Data,
 		Format:      cfg.Format,
-		Extensions:  cfg.extensionsMap(),
+		Extensions:  exts,
 	}
 
 	// If --file was specified, use its content for message data
@@ -315,15 +319,16 @@ func newInvokeConfig() (cfg invokeConfig, err error) {
 	return
 }
 
-func (c invokeConfig) extensionsMap() map[string]string {
-	extensionsMap := make(map[string]string)
+func (c invokeConfig) extensionsMap() (map[string]string, error) {
+	result := make(map[string]string)
 	for _, ext := range c.Extensions {
 		parts := strings.SplitN(ext, "=", 2)
-		if len(parts) == 2 {
-			extensionsMap[parts[0]] = parts[1]
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid --extension %q: must be in key=value format", ext)
 		}
+		result[parts[0]] = parts[1]
 	}
-	return extensionsMap
+	return result, nil
 }
 
 func (c invokeConfig) prompt() (invokeConfig, error) {

--- a/cmd/invoke_test.go
+++ b/cmd/invoke_test.go
@@ -83,7 +83,7 @@ func TestInvoke(t *testing.T) {
 // parsed correctly, including values that themselves contain '='.
 func TestInvokeExtensionsMapValid(t *testing.T) {
 	c := invokeConfig{Extensions: []string{"key=value", "foo=bar=baz"}}
-	m, err := c.extensionsMap()
+	m, err := c.parseExtensions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -95,12 +95,23 @@ func TestInvokeExtensionsMapValid(t *testing.T) {
 	}
 }
 
-// TestInvokeExtensionsMapMalformed ensures that an extension entry missing '='
-// returns an error rather than being silently dropped.
+// TestInvokeExtensionsMapMalformed ensures that extension entries missing '='
+// or with an empty key return an error rather than being silently dropped.
 func TestInvokeExtensionsMapMalformed(t *testing.T) {
-	c := invokeConfig{Extensions: []string{"valid=ok", "badformat"}}
-	_, err := c.extensionsMap()
-	if err == nil {
-		t.Fatal("expected error for malformed extension entry, got nil")
+	cases := []struct {
+		name string
+		exts []string
+	}{
+		{"missing equals", []string{"valid=ok", "badformat"}},
+		{"empty key", []string{"valid=ok", "=nokey"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := invokeConfig{Extensions: tc.exts}
+			_, err := c.parseExtensions()
+			if err == nil {
+				t.Fatalf("expected error for %v, got nil", tc.exts)
+			}
+		})
 	}
 }

--- a/cmd/invoke_test.go
+++ b/cmd/invoke_test.go
@@ -78,3 +78,29 @@ func TestInvoke(t *testing.T) {
 		t.Fatal("function was not invoked")
 	}
 }
+
+// TestInvokeExtensionsMapValid ensures well-formed key=value extensions are
+// parsed correctly, including values that themselves contain '='.
+func TestInvokeExtensionsMapValid(t *testing.T) {
+	c := invokeConfig{Extensions: []string{"key=value", "foo=bar=baz"}}
+	m, err := c.extensionsMap()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["key"] != "value" {
+		t.Fatalf("expected key=value, got %q", m["key"])
+	}
+	if m["foo"] != "bar=baz" {
+		t.Fatalf("expected foo=bar=baz, got %q", m["foo"])
+	}
+}
+
+// TestInvokeExtensionsMapMalformed ensures that an extension entry missing '='
+// returns an error rather than being silently dropped.
+func TestInvokeExtensionsMapMalformed(t *testing.T) {
+	c := invokeConfig{Extensions: []string{"valid=ok", "badformat"}}
+	_, err := c.extensionsMap()
+	if err == nil {
+		t.Fatal("expected error for malformed extension entry, got nil")
+	}
+}


### PR DESCRIPTION
## Problem

`extensionsMap()` in `cmd/invoke.go` silently dropped any `--extension` value that did not contain `=`. The invocation proceeded with fewer extensions than the user specified, with no feedback — particularly confusing when debugging CloudEvent routing.

## Changes

**`cmd/invoke.go`**
- Changed `extensionsMap()` signature from `map[string]string` to `(map[string]string, error)`.
- Returns a descriptive error for any entry missing `=` (e.g. `invalid --extension "badformat": must be in key=value format`).
- Renamed the shadowing local variable `extensionsMap` → `result` for clarity.
- Updated the call site to propagate the error before constructing `InvokeMessage`.

**`cmd/invoke_test.go`**
- `TestInvokeExtensionsMapValid`: verifies correct parsing including values that themselves contain `=` (e.g. base64 strings like `foo=bar=baz`).
- `TestInvokeExtensionsMapMalformed`: verifies that a missing `=` produces an error rather than a silent drop.

## Testing

```
go test ./cmd/... -run TestInvokeExtensionsMap
```