### PR TITLE
Add strict Tekton schema validation for Pipeline and PipelineRun templates

### DIFF
--- a/pkg/pipelines/tekton/templates_test.go
+++ b/pkg/pipelines/tekton/templates_test.go
@@ -328,6 +328,80 @@ func Test_createAndApplyPipelineRunTemplate(t *testing.T) {
 	}
 }
 
+// strictTektonDecoder returns a strict deserializer that rejects unknown fields
+// in Tekton v1 resources (Pipeline, PipelineRun, etc.).
+func strictTektonDecoder(t *testing.T) runtime.Decoder {
+	t.Helper()
+	myScheme := runtime.NewScheme()
+	if err := tektonv1.AddToScheme(myScheme); err != nil {
+		t.Fatal(err)
+	}
+	codecs := serializer.NewCodecFactory(myScheme, serializer.EnableStrict)
+	return codecs.UniversalDeserializer()
+}
+
+// renderTemplate renders a Go text/template with the given data and returns the result.
+func renderTemplate(t *testing.T, name, tmplStr string, data any) []byte {
+	t.Helper()
+	tmpl, err := template.New(name).Parse(tmplStr)
+	if err != nil {
+		t.Fatalf("failed to parse template: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestPipelineTemplatesValidate renders each Pipeline template with real
+// inline task specs and decodes it into a typed tektonv1.Pipeline using a
+// strict deserializer that rejects unknown fields.
+func TestPipelineTemplatesValidate(t *testing.T) {
+	buildpacksTaskRef, err := getTaskSpec(getBuildpackTask())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2iTaskRef, err := getTaskSpec(getS2ITask())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := templateData{
+		FunctionName:          "myfunc",
+		Annotations:           map[string]string{"test": "val"},
+		Labels:                map[string]string{"test": "val"},
+		PipelineName:          "myfunc-pipeline",
+		TlsVerify:             "true",
+		Registry:              "docker.io/alice",
+		FuncBuildpacksTaskRef: buildpacksTaskRef,
+		FuncS2iTaskRef:        s2iTaskRef,
+	}
+
+	tests := []struct {
+		name    string
+		tmplStr string
+	}{
+		{"packPipelineTemplate", packPipelineTemplate},
+		{"s2iPipelineTemplate", s2iPipelineTemplate},
+	}
+
+	decode := strictTektonDecoder(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rendered := renderTemplate(t, tt.name, tt.tmplStr, data)
+			obj, _, err := decode.Decode(rendered, nil, nil)
+			if err != nil {
+				t.Fatalf("failed to decode Pipeline: %v", err)
+			}
+			if _, ok := obj.(*tektonv1.Pipeline); !ok {
+				t.Fatalf("expected *Pipeline, got %T", obj)
+			}
+		})
+	}
+}
+
 // TestPipelineRunTemplatesValidate renders each PipelineRun template with dummy
 // data and decodes it into a typed tektonv1.PipelineRun using a strict
 // deserializer. This catches unknown/misplaced fields (e.g. spec.podTemplate
@@ -367,25 +441,12 @@ func TestPipelineRunTemplatesValidate(t *testing.T) {
 		{"s2iRunTemplatePAC", s2iRunTemplatePAC},
 	}
 
-	myScheme := runtime.NewScheme()
-	if err := tektonv1.AddToScheme(myScheme); err != nil {
-		t.Fatal(err)
-	}
-	codecs := serializer.NewCodecFactory(myScheme, serializer.EnableStrict)
-	decode := codecs.UniversalDeserializer().Decode
+	decode := strictTektonDecoder(t)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmpl, err := template.New(tt.name).Parse(tt.tmplStr)
-			if err != nil {
-				t.Fatalf("failed to parse template: %v", err)
-			}
-			var buf bytes.Buffer
-			if err := tmpl.Execute(&buf, data); err != nil {
-				t.Fatalf("failed to execute template: %v", err)
-			}
-
-			obj, _, err := decode(buf.Bytes(), nil, nil)
+			rendered := renderTemplate(t, tt.name, tt.tmplStr, data)
+			obj, _, err := decode.Decode(rendered, nil, nil)
 			if err != nil {
 				t.Fatalf("failed to decode PipelineRun: %v", err)
 			}

--- a/pkg/pipelines/tekton/templates_test.go
+++ b/pkg/pipelines/tekton/templates_test.go
@@ -402,7 +402,7 @@ func TestPipelineTemplatesValidate(t *testing.T) {
 	}
 }
 
-// TestPipelineRunTemplatesValidate renders each PipelineRun template with dummy
+// TestPipelineRunTemplatesValidate renders each PipelineRun template with sample
 // data and decodes it into a typed tektonv1.PipelineRun using a strict
 // deserializer. This catches unknown/misplaced fields (e.g. spec.podTemplate
 // instead of spec.taskRunTemplate.podTemplate) that string-based tests miss.

--- a/pkg/pipelines/tekton/templates_test.go
+++ b/pkg/pipelines/tekton/templates_test.go
@@ -1,11 +1,16 @@
 package tekton
 
 import (
+	"bytes"
 	"path/filepath"
 	"testing"
+	"text/template"
 
 	"github.com/manifestival/manifestival"
 	"github.com/manifestival/manifestival/fake"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 
 	"knative.dev/func/pkg/builders"
 	fn "knative.dev/func/pkg/functions"
@@ -318,6 +323,74 @@ func Test_createAndApplyPipelineRunTemplate(t *testing.T) {
 
 			if err := createAndApplyPipelineRunTemplate(f, tt.namespace, tt.labels); (err != nil) != tt.wantErr {
 				t.Errorf("createAndApplyPipelineRunTemplate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestPipelineRunTemplatesValidate renders each PipelineRun template with dummy
+// data and decodes it into a typed tektonv1.PipelineRun using a strict
+// deserializer. This catches unknown/misplaced fields (e.g. spec.podTemplate
+// instead of spec.taskRunTemplate.podTemplate) that string-based tests miss.
+func TestPipelineRunTemplatesValidate(t *testing.T) {
+	data := templateData{
+		FunctionName:  "myfunc",
+		Annotations:   map[string]string{"test": "val"},
+		Labels:        map[string]string{"test": "val"},
+		ContextDir:    ".",
+		FunctionImage: "docker.io/alice/myfunc",
+		Registry:      "docker.io/alice",
+		BuilderImage:  "gcr.io/paketo-buildpacks/builder:base",
+		BuildEnvs:     []string{"="},
+
+		PipelineName:    "myfunc-pipeline",
+		PipelineRunName: "myfunc-pipeline-run-",
+		PvcName:         "myfunc-pvc",
+		SecretName:      "myfunc-secret",
+
+		PipelinesTargetBranch: "main",
+		PipelineYamlURL:       ".tekton/pipeline-pac.yaml",
+		S2iImageScriptsUrl:    "image:///usr/libexec/s2i",
+		TlsVerify:             "true",
+		RepoUrl:               "https://example.com/repo",
+		Revision:              "main",
+		Commit:                "abc123",
+	}
+
+	tests := []struct {
+		name    string
+		tmplStr string
+	}{
+		{"packRunTemplate", packRunTemplate},
+		{"packRunTemplatePAC", packRunTemplatePAC},
+		{"s2iRunTemplate", s2iRunTemplate},
+		{"s2iRunTemplatePAC", s2iRunTemplatePAC},
+	}
+
+	myScheme := runtime.NewScheme()
+	if err := tektonv1.AddToScheme(myScheme); err != nil {
+		t.Fatal(err)
+	}
+	codecs := serializer.NewCodecFactory(myScheme, serializer.EnableStrict)
+	decode := codecs.UniversalDeserializer().Decode
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl, err := template.New(tt.name).Parse(tt.tmplStr)
+			if err != nil {
+				t.Fatalf("failed to parse template: %v", err)
+			}
+			var buf bytes.Buffer
+			if err := tmpl.Execute(&buf, data); err != nil {
+				t.Fatalf("failed to execute template: %v", err)
+			}
+
+			obj, _, err := decode(buf.Bytes(), nil, nil)
+			if err != nil {
+				t.Fatalf("failed to decode PipelineRun: %v", err)
+			}
+			if _, ok := obj.(*tektonv1.PipelineRun); !ok {
+				t.Fatalf("expected *PipelineRun, got %T", obj)
 			}
 		})
 	}


### PR DESCRIPTION

### Summary

- Add `TestPipelineTemplatesValidate` and `TestPipelineRunTemplatesValidate` which render all Tekton YAML templates and decode them into typed `tektonv1.Pipeline` / `tektonv1.PipelineRun` structs using a **strict deserializer** that rejects unknown fields
- Replace the string-based `Test_PipelineRunHasPodTemplateSecurityContext` (from #3665) with these schema-level validations

### Motivation

PR #3665 added `spec.podTemplate` to PipelineRun templates, but this field is only valid in the Tekton `v1beta1` API. In `v1`, it must be nested under `spec.taskRunTemplate.podTemplate`. The existing tests used `strings.Contains` on rendered YAML, which cannot catch misplaced fields — the string was present in the file, but Kubernetes silently ignored it (`Warning: unknown field "spec.podTemplate"`).

These new tests would have caught that bug at CI time by failing with a strict decode error on the unknown field.

### What changed

- **`TestPipelineTemplatesValidate`**: renders `packPipelineTemplate` and `s2iPipelineTemplate` with real inline task specs, strict-decodes into `tektonv1.Pipeline`
- **`TestPipelineRunTemplatesValidate`**: renders all 4 PipelineRun templates (pack/s2i × standard/PAC), strict-decodes into `tektonv1.PipelineRun`
- Shared helpers `strictTektonDecoder` and `renderTemplate` extracted to reduce duplication
- Removed `Test_PipelineRunHasPodTemplateSecurityContext` and its unused imports (`os`, `strings`)

### Test plan

- [x] `go test ./pkg/pipelines/tekton/ -run TestPipelineTemplatesValidate` passes
- [x] `go test ./pkg/pipelines/tekton/ -run TestPipelineRunTemplatesValidate` passes
- [x] All existing tests in the package continue to pass
