### PR TITLE
fix: use 0644 permissions for runtime data files in .func/

### DIFF
--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -574,7 +574,7 @@ func (f Function) Stamp(oo ...stampOption) (err error) {
 	}
 
 	// Write out the hash
-	if err = os.WriteFile(filepath.Join(f.Root, RunDataDir, BuiltHash), []byte(hash), os.ModePerm); err != nil {
+	if err = os.WriteFile(filepath.Join(f.Root, RunDataDir, BuiltHash), []byte(hash), 0644); err != nil {
 		return
 	}
 
@@ -830,7 +830,7 @@ func (f Function) WriteRuntimeBuiltImage(verbose bool) error {
 		fmt.Printf("Writing built image: '%s' at path: '%s'\n", f.Build.Image, path)
 	}
 
-	return os.WriteFile(path, []byte(f.Build.Image), os.ModePerm)
+	return os.WriteFile(path, []byte(f.Build.Image), 0644)
 }
 
 // getLastBuiltImage reads .func/built-image and returns its value or empty string


### PR DESCRIPTION
## Problem

`.func/built-image` and `.func/built-hash` were written using `os.ModePerm`
(`0777`), which sets the execute bit on plain data files and is inconsistent
with the rest of the codebase.

The `pkg/config` package already writes `~/.func/config.yaml` with explicit
`0600` permissions and has a dedicated test enforcing this. The runtime data
directory had no such discipline.

## Changes

- `pkg/functions/function.go:577` — `BuiltHash` file now written with `0644`
- `pkg/functions/function.go:833` — `BuiltImage` file now written with `0644`

`client.go:1277` (`MkdirAll` for the `.func/` directory) is intentionally
unchanged — using `os.ModePerm` with `MkdirAll` is standard Go practice for
directories; the umask produces the correct `0755` result.

## Why 0644 and not 0600

These files contain build metadata (image references, content hashes), not
credentials. They do not need to be private to the owner. `0644` gives the
owner read/write and others read-only, with no execute bits — appropriate for
data files.

## Testing

- `make test` passes with no changes to existing tests