### PR TITLE
fix: use taskRunTemplate for podTemplate in Tekton v1 PipelineRuns

### DIFF
--- a/pkg/pipelines/tekton/templates_pack.go
+++ b/pkg/pipelines/tekton/templates_pack.go
@@ -125,11 +125,12 @@ spec:
       value: "{{.Commit}}"
   pipelineRef:
    name: {{.PipelineName}}
-  podTemplate:
-    securityContext:
-      runAsUser: 1001
-      runAsGroup: 0
-      fsGroup: 1002
+  taskRunTemplate:
+    podTemplate:
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 0
+        fsGroup: 1002
   workspaces:
     - name: source-workspace
       persistentVolumeClaim:
@@ -190,11 +191,12 @@ spec:
         {{end}}
   pipelineRef:
    name: {{.PipelineName}}
-  podTemplate:
-    securityContext:
-      runAsUser: 1001
-      runAsGroup: 0
-      fsGroup: 1002
+  taskRunTemplate:
+    podTemplate:
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 0
+        fsGroup: 1002
   workspaces:
     - name: source-workspace
       persistentVolumeClaim:

--- a/pkg/pipelines/tekton/templates_s2i.go
+++ b/pkg/pipelines/tekton/templates_s2i.go
@@ -136,11 +136,12 @@ spec:
       value: "{{.Commit}}"
   pipelineRef:
    name: {{.PipelineName}}
-  podTemplate:
-    securityContext:
-      runAsUser: 1001
-      runAsGroup: 0
-      fsGroup: 1002
+  taskRunTemplate:
+    podTemplate:
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 0
+        fsGroup: 1002
   workspaces:
     - name: source-workspace
       persistentVolumeClaim:
@@ -208,11 +209,12 @@ spec:
       value: {{.TlsVerify}}
   pipelineRef:
    name: {{.PipelineName}}
-  podTemplate:
-    securityContext:
-      runAsUser: 1001
-      runAsGroup: 0
-      fsGroup: 1002
+  taskRunTemplate:
+    podTemplate:
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 0
+        fsGroup: 1002
   workspaces:
     - name: source-workspace
       persistentVolumeClaim:

--- a/pkg/pipelines/tekton/templates_test.go
+++ b/pkg/pipelines/tekton/templates_test.go
@@ -376,9 +376,14 @@ func Test_PipelineRunHasPodTemplateSecurityContext(t *testing.T) {
 
 			contentStr := string(content)
 
-			// Verify podTemplate is present
+			// Verify taskRunTemplate is present (Tekton v1 API requirement)
+			if !strings.Contains(contentStr, "taskRunTemplate:") {
+				t.Error("taskRunTemplate not found in generated PipelineRun")
+			}
+
+			// Verify podTemplate is nested under taskRunTemplate
 			if !strings.Contains(contentStr, "podTemplate:") {
-				t.Error("podTemplate not found in generated PipelineRun")
+				t.Error("podTemplate not found in taskRunTemplate")
 			}
 
 			// Verify securityContext is present


### PR DESCRIPTION
Hey team,

I'm fixing an issue with PR #3665 that @matejvasek pointed out - the security context isn't actually being applied on KinD or OCP clusters.

What's wrong:

PR #3665 added podTemplate with securityContext to fix FSGroup permission issues on s390x/ppc64le. But it put podTemplate directly under spec, which is the old v1beta1 syntax. Since our templates use apiVersion: tekton.dev/v1, Kubernetes just ignores that field completely.

The fix:

In Tekton v1, podTemplate needs to be nested under taskRunTemplate. I've moved it to the right place in all four PipelineRun templates (Pack and S2I, both regular and PAC versions).

Before:

spec:
  podTemplate:
    securityContext:
      fsGroup: 1002

After:

spec:
  taskRunTemplate:
    podTemplate:
      securityContext:
        fsGroup: 1002

This matches the official Tekton v1 docs: https://tekton.dev/docs/pipelines/pipelineruns/#specifying-a-pod-template

Testing:

All tests pass
make check is clean
Test now verifies taskRunTemplate is present
This should fix the issue where the security context wasn't being applied.