### PR TITLE
fixup: wrap list error + improve code readability

### DIFF
--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -707,3 +707,31 @@ Installation guide: https://knative.dev/docs/serving/#installation`, e.Err)
 func (e *ErrListClusterConnection) Unwrap() error {
 	return e.Err
 }
+
+// -------------------------------------------------------------------------- //
+
+type ErrListConflictingNamespaceFlags struct {
+	Err error
+}
+
+func NewErrListConflictingNamespaceFlags() error {
+	return &ErrListConflictingNamespaceFlags{
+		Err: errors.New("both --namespace and --all-namespaces specified"),
+	}
+}
+
+func (e *ErrListConflictingNamespaceFlags) Error() string {
+	return fmt.Sprintf(`%v
+
+These flags are mutually exclusive:
+  --namespace        List functions in a specific namespace
+  --all-namespaces   List functions across all namespaces
+
+Use one or the other:
+  func list --namespace my-ns
+  func list --all-namespaces`, e.Err)
+}
+
+func (e *ErrListConflictingNamespaceFlags) Unwrap() error {
+	return e.Err
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -93,29 +92,7 @@ func runList(cmd *cobra.Command, _ []string, newClient ClientFactory) (err error
 	}
 
 	if len(items) == 0 {
-		if cfg.Namespace != "" {
-			fmt.Printf(`no functions found in namespace '%v'
-
-'func list' shows functions that have been deployed to your cluster.
-
-To see functions here:
-  func create --language go myfunction    Create a function
-  func deploy --registry <registry>       Deploy to cluster
-  func list                               See it listed
-
-Or check other namespaces:
-  func list --all-namespaces             List functions in all namespaces
-`, cfg.Namespace)
-		} else {
-			fmt.Println(`no functions found
-
-'func list' shows functions that have been deployed to your cluster.
-
-To see functions here:
-  func create --language go myfunction    Create a function
-  func deploy --registry <registry>       Deploy to cluster
-  func list                               See it listed`)
-		}
+		printNoFunctionsFound(cmd, cfg.Namespace)
 		return
 	}
 
@@ -145,12 +122,36 @@ func newListConfig(cmd *cobra.Command) (cfg listConfig, err error) {
 		cfg.Namespace = ""
 	}
 
-	// specifying both -A and --namespace is logically inconsistent
 	if cmd.Flags().Changed("namespace") && viper.GetBool("all-namespaces") {
-		err = errors.New("both --namespace and --all-namespaces specified")
+		err = NewErrListConflictingNamespaceFlags()
 	}
 
 	return
+}
+
+func printNoFunctionsFound(cmd *cobra.Command, namespace string) {
+	msg := "no functions found"
+	if namespace != "" {
+		msg = fmt.Sprintf("no functions found in namespace '%v'", namespace)
+	}
+
+	msg += `
+
+'func list' shows functions that have been deployed to your cluster.
+
+To see functions here:
+  func create --language go myfunction    Create a function
+  func deploy --registry <registry>       Deploy to cluster
+  func list                               See it listed`
+
+	if namespace != "" {
+		msg += `
+
+Or check other namespaces:
+  func list --all-namespaces             List functions in all namespaces`
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), msg)
 }
 
 // Output Formatting (serializers)


### PR DESCRIPTION
- improve readability of the `func list` cmd
- create wrapped error as other cmds