### PR TITLE
Duplicate env and volume validation

### DIFF
--- a/pkg/functions/function_envs.go
+++ b/pkg/functions/function_envs.go
@@ -185,6 +185,8 @@ func ValidateBuildEnvs(envs []Env) (errors []string) {
 			errors = append(errors, fmt.Sprintf("env entry #%d is not properly set", i))
 		} else if env.Value == nil {
 			errors = append(errors, fmt.Sprintf("env entry #%d is missing value field, only name '%s' is set", i, *env.Name))
+		} else if env.Name == nil {
+			errors = append(errors, fmt.Sprintf("env entry #%d is missing name field, only value '%s' is set", i, *env.Value))
 		} else {
 
 			if err := utils.ValidateEnvVarName(*env.Name); err != nil {

--- a/pkg/functions/function_envs.go
+++ b/pkg/functions/function_envs.go
@@ -119,7 +119,16 @@ func (e Env) KeyValuePair() string {
 //     value: {{ configMap:configMapName:key }}   	# ENV from a key in configMap
 //   - value: {{ configMap:configMapName }}          	# all key-pair values from configMap are set as ENV
 func ValidateEnvs(envs []Env) (errors []string) {
+	seenNames := make(map[string]int)
 	for i, env := range envs {
+		if env.Name != nil {
+			name := *env.Name
+			if firstIdx, seen := seenNames[name]; seen {
+				errors = append(errors, fmt.Sprintf("env entry #%d has duplicate name %q (first defined at entry #%d)", i, name, firstIdx))
+			} else {
+				seenNames[name] = i
+			}
+		}
 		if env.Name == nil && env.Value == nil {
 			errors = append(errors, fmt.Sprintf("env entry #%d is not properly set", i))
 		} else if env.Value == nil {
@@ -162,7 +171,16 @@ func ValidateEnvs(envs []Env) (errors []string) {
 //   - name: EXAMPLE2                 				# ENV from the local ENV var
 //     value: {{ env:MY_ENV }}
 func ValidateBuildEnvs(envs []Env) (errors []string) {
+	seenNames := make(map[string]int)
 	for i, env := range envs {
+		if env.Name != nil {
+			name := *env.Name
+			if firstIdx, seen := seenNames[name]; seen {
+				errors = append(errors, fmt.Sprintf("env entry #%d has duplicate name %q (first defined at entry #%d)", i, name, firstIdx))
+			} else {
+				seenNames[name] = i
+			}
+		}
 		if env.Name == nil && env.Value == nil {
 			errors = append(errors, fmt.Sprintf("env entry #%d is not properly set", i))
 		} else if env.Value == nil {

--- a/pkg/functions/function_envs_unit_test.go
+++ b/pkg/functions/function_envs_unit_test.go
@@ -158,12 +158,21 @@ func Test_validateBuildEnvs(t *testing.T) {
 			},
 			1,
 		},
+		{
+			"incorrect entry - missing name",
+			[]Env{
+				{
+					Value: &value,
+				},
+			},
+			1,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ValidateEnvs(tt.envs); len(got) != tt.errs {
-				t.Errorf("validateEnvs() = %v\n got %d errors but want %d", got, len(got), tt.errs)
+			if got := ValidateBuildEnvs(tt.envs); len(got) != tt.errs {
+				t.Errorf("ValidateBuildEnvs() = %v\n got %d errors but want %d", got, len(got), tt.errs)
 			}
 		})
 	}

--- a/pkg/functions/function_envs_unit_test.go
+++ b/pkg/functions/function_envs_unit_test.go
@@ -9,6 +9,8 @@ func Test_validateBuildEnvs(t *testing.T) {
 
 	name := "name"
 	name2 := "name2"
+	name3 := "name3"
+	name4 := "name4"
 	value := "value"
 	value2 := "value2"
 
@@ -110,11 +112,11 @@ func Test_validateBuildEnvs(t *testing.T) {
 					Value: &valueLocalEnv,
 				},
 				{
-					Name:  &name,
+					Name:  &name2,
 					Value: &valueLocalEnv2,
 				},
 				{
-					Name:  &name,
+					Name:  &name3,
 					Value: &valueLocalEnv3,
 				},
 			},
@@ -128,19 +130,33 @@ func Test_validateBuildEnvs(t *testing.T) {
 					Value: &valueLocalEnv,
 				},
 				{
-					Name:  &name,
+					Name:  &name2,
 					Value: &valueLocalEnvIncorrect,
 				},
 				{
-					Name:  &name,
+					Name:  &name3,
 					Value: &valueLocalEnvIncorrect2,
 				},
 				{
-					Name:  &name,
+					Name:  &name4,
 					Value: &valueLocalEnvIncorrect3,
 				},
 			},
 			3,
+		},
+		{
+			"incorrect entry - duplicate env names",
+			[]Env{
+				{
+					Name:  &name,
+					Value: &value,
+				},
+				{
+					Name:  &name,
+					Value: &value2,
+				},
+			},
+			1,
 		},
 	}
 
@@ -157,6 +173,13 @@ func Test_validateEnvs(t *testing.T) {
 
 	name := "name"
 	name2 := "name2"
+	name3 := "name3"
+	name4 := "name4"
+	name5 := "name5"
+	name6 := "name6"
+	name7 := "name7"
+	name8 := "name8"
+	name9 := "name9"
 	value := "value"
 	value2 := "value2"
 
@@ -293,11 +316,11 @@ func Test_validateEnvs(t *testing.T) {
 					Value: &valueLocalEnv,
 				},
 				{
-					Name:  &name,
+					Name:  &name2,
 					Value: &valueLocalEnv2,
 				},
 				{
-					Name:  &name,
+					Name:  &name3,
 					Value: &valueLocalEnv3,
 				},
 			},
@@ -311,15 +334,15 @@ func Test_validateEnvs(t *testing.T) {
 					Value: &valueLocalEnv,
 				},
 				{
-					Name:  &name,
+					Name:  &name2,
 					Value: &valueLocalEnvIncorrect,
 				},
 				{
-					Name:  &name,
+					Name:  &name3,
 					Value: &valueLocalEnvIncorrect2,
 				},
 				{
-					Name:  &name,
+					Name:  &name4,
 					Value: &valueLocalEnvIncorrect3,
 				},
 			},
@@ -353,31 +376,31 @@ func Test_validateEnvs(t *testing.T) {
 					Value: &valueConfigMapKey,
 				},
 				{
-					Name:  &name,
+					Name:  &name2,
 					Value: &valueConfigMapKey2,
 				},
 				{
-					Name:  &name,
+					Name:  &name3,
 					Value: &valueConfigMapKey3,
 				},
 				{
-					Name:  &name,
+					Name:  &name4,
 					Value: &valueConfigMapKey4,
 				},
 				{
-					Name:  &name,
+					Name:  &name5,
 					Value: &valueConfigMapKey5,
 				},
 				{
-					Name:  &name,
+					Name:  &name6,
 					Value: &valueConfigMapKey6,
 				},
 				{
-					Name:  &name,
+					Name:  &name7,
 					Value: &valueConfigMapKey7,
 				},
 				{
-					Name:  &name,
+					Name:  &name8,
 					Value: &valueConfigMapKey8,
 				},
 			},
@@ -391,31 +414,31 @@ func Test_validateEnvs(t *testing.T) {
 					Value: &valueSecretKey,
 				},
 				{
-					Name:  &name,
+					Name:  &name2,
 					Value: &valueSecretKey2,
 				},
 				{
-					Name:  &name,
+					Name:  &name3,
 					Value: &valueSecretKey3,
 				},
 				{
-					Name:  &name,
+					Name:  &name4,
 					Value: &valueSecretKey4,
 				},
 				{
-					Name:  &name,
+					Name:  &name5,
 					Value: &valueSecretKey5,
 				},
 				{
-					Name:  &name,
+					Name:  &name6,
 					Value: &valueSecretKey6,
 				},
 				{
-					Name:  &name,
+					Name:  &name7,
 					Value: &valueSecretKey7,
 				},
 				{
-					Name:  &name,
+					Name:  &name8,
 					Value: &valueSecretKey8,
 				},
 			},
@@ -429,7 +452,7 @@ func Test_validateEnvs(t *testing.T) {
 					Value: &valueSecretKey,
 				},
 				{
-					Name:  &name,
+					Name:  &name2,
 					Value: &valueConfigMapKey,
 				},
 			},
@@ -453,15 +476,15 @@ func Test_validateEnvs(t *testing.T) {
 					Value: &valueSecretKey,
 				},
 				{
-					Name:  &name,
+					Name:  &name2,
 					Value: &valueSecretKeyIncorrect,
 				},
 				{
-					Name:  &name,
+					Name:  &name3,
 					Value: &valueSecretKeyIncorrect2,
 				},
 				{
-					Name:  &name,
+					Name:  &name4,
 					Value: &valueSecretKeyIncorrect3,
 				},
 			},
@@ -563,15 +586,15 @@ func Test_validateEnvs(t *testing.T) {
 					Value: &value2,
 				},
 				{
-					Name:  &name,
+					Name:  &name3,
 					Value: &valueLocalEnv,
 				},
 				{
-					Name:  &name,
+					Name:  &name4,
 					Value: &valueLocalEnv2,
 				},
 				{
-					Name:  &name,
+					Name:  &name5,
 					Value: &valueLocalEnv3,
 				},
 				{
@@ -587,23 +610,37 @@ func Test_validateEnvs(t *testing.T) {
 					Value: &valueConfigMap,
 				},
 				{
-					Name:  &name,
+					Name:  &name6,
 					Value: &valueSecretKey,
 				},
 				{
-					Name:  &name,
+					Name:  &name7,
 					Value: &valueSecretKey2,
 				},
 				{
-					Name:  &name,
+					Name:  &name8,
 					Value: &valueSecretKey3,
 				},
 				{
-					Name:  &name,
+					Name:  &name9,
 					Value: &valueConfigMapKey,
 				},
 			},
 			0,
+		},
+		{
+			"incorrect entry - duplicate env names",
+			[]Env{
+				{
+					Name:  &name,
+					Value: &value,
+				},
+				{
+					Name:  &name,
+					Value: &value2,
+				},
+			},
+			1,
 		},
 	}
 

--- a/pkg/functions/function_volumes.go
+++ b/pkg/functions/function_volumes.go
@@ -81,8 +81,17 @@ func (v Volume) String() string {
 //   - emptyDir: {}                                         # mount EmptyDir as Volume
 //     path: /etc/configMap-volume
 func validateVolumes(volumes []Volume) (errors []string) {
-
+	seenPaths := make(map[string]int)
 	for i, vol := range volumes {
+		if vol.Path != nil {
+			path := *vol.Path
+			if firstIdx, seen := seenPaths[path]; seen {
+				errors = append(errors, fmt.Sprintf("volume entry #%d has duplicate path %q (first defined at entry #%d)", i, path, firstIdx))
+			} else {
+				seenPaths[path] = i
+			}
+		}
+
 		numVolumes := 0
 		if vol.Secret != nil {
 			numVolumes++

--- a/pkg/functions/function_volumes.go
+++ b/pkg/functions/function_volumes.go
@@ -1,6 +1,9 @@
 package functions
 
-import "fmt"
+import (
+	"fmt"
+	"path"
+)
 
 type Volume struct {
 	Secret                *string                `yaml:"secret,omitempty" jsonschema:"oneof_required=secret"`
@@ -84,11 +87,11 @@ func validateVolumes(volumes []Volume) (errors []string) {
 	seenPaths := make(map[string]int)
 	for i, vol := range volumes {
 		if vol.Path != nil {
-			path := *vol.Path
-			if firstIdx, seen := seenPaths[path]; seen {
-				errors = append(errors, fmt.Sprintf("volume entry #%d has duplicate path %q (first defined at entry #%d)", i, path, firstIdx))
+			cleanedPath := path.Clean(*vol.Path)
+			if firstIdx, seen := seenPaths[cleanedPath]; seen {
+				errors = append(errors, fmt.Sprintf("volume entry #%d has duplicate path %q (first defined at entry #%d)", i, *vol.Path, firstIdx))
 			} else {
-				seenPaths[path] = i
+				seenPaths[cleanedPath] = i
 			}
 		}
 

--- a/pkg/functions/function_volumes_unit_test.go
+++ b/pkg/functions/function_volumes_unit_test.go
@@ -173,6 +173,20 @@ func Test_validateVolumes(t *testing.T) {
 			},
 			2,
 		},
+		{
+			"incorrect entry - duplicate volume paths",
+			[]Volume{
+				{
+					Secret: &secret,
+					Path:   &path,
+				},
+				{
+					Secret: &secret2,
+					Path:   &path,
+				},
+			},
+			1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/functions/function_volumes_unit_test.go
+++ b/pkg/functions/function_volumes_unit_test.go
@@ -10,6 +10,8 @@ func Test_validateVolumes(t *testing.T) {
 	path2 := "path2"
 	path3 := "path3"
 	path4 := "path4"
+	pathSlash := "/path/"
+	pathNoSlash := "/path"
 	secret := "secret"
 	secret2 := "secret2"
 	cm := "configMap"
@@ -183,6 +185,34 @@ func Test_validateVolumes(t *testing.T) {
 				{
 					Secret: &secret2,
 					Path:   &path,
+				},
+			},
+			1,
+		},
+		{
+			"incorrect entry - duplicate volume paths with trailing slash",
+			[]Volume{
+				{
+					Secret: &secret,
+					Path:   &pathSlash,
+				},
+				{
+					Secret: &secret2,
+					Path:   &pathNoSlash,
+				},
+			},
+			1,
+		},
+		{
+			"incorrect entry - duplicate volume paths both with trailing slash",
+			[]Volume{
+				{
+					Secret: &secret,
+					Path:   &pathSlash,
+				},
+				{
+					Secret: &secret2,
+					Path:   &pathSlash,
 				},
 			},
 			1,


### PR DESCRIPTION
### Changes
Validation Logic
- Modified `ValidateEnvs` and `ValidateBuildEnvs` to track encountered variable names using a set/map.
- Returns a detailed error if duplicate names are detected, showing the index of the duplicate and the index of the first definition.

Volume Mount Paths

- Modified `validateVolumes` to track encountered volume paths.
- Returns a detailed error if multiple volumes are mounted to the exact same path.

Unit Tests

- Fixed legacy test cases that reused name pointer references across slice items to use unique variable names.
- Added new test cases verifying that duplicate environment variable name and volume mount paths are successfully rejected.

Closes : #3877 
