### PR TITLE
Fix goroutine leak in SSH DialContext

### DIFF
--- a/pkg/ssh/ssh_dialer.go
+++ b/pkg/ssh/ssh_dialer.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/docker/cli/cli/connhelper"
@@ -126,18 +127,36 @@ func (n contextDialerFn) DialContext(ctx context.Context, network, address strin
 	return n(ctx, network, address)
 }
 
+// connWithDone wraps a net.Conn and signals a channel when Close() is called,
+// allowing the context-cancellation goroutine to exit cleanly.
+type connWithDone struct {
+	net.Conn
+	done chan struct{}
+	once sync.Once
+}
+
+func (c *connWithDone) Close() error {
+	c.once.Do(func() { close(c.done) })
+	return c.Conn.Close()
+}
+
 func (d *dialer) DialContext(ctx context.Context, n, a string) (net.Conn, error) {
 	conn, err := d.Dial(d.network, d.addr)
 	if err != nil {
 		return nil, err
 	}
+	wrapped := &connWithDone{Conn: conn, done: make(chan struct{})}
 	go func() {
 		if ctx != nil {
-			<-ctx.Done()
-			conn.Close()
+			select {
+			case <-ctx.Done():
+				conn.Close()
+			case <-wrapped.done:
+				// Connection was closed by the caller; exit cleanly.
+			}
 		}
 	}()
-	return conn, nil
+	return wrapped, nil
 }
 
 func (d *dialer) Dial(n, a string) (net.Conn, error) {

--- a/pkg/ssh/ssh_dialer.go
+++ b/pkg/ssh/ssh_dialer.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/docker/cli/cli/connhelper"
@@ -127,36 +126,8 @@ func (n contextDialerFn) DialContext(ctx context.Context, network, address strin
 	return n(ctx, network, address)
 }
 
-// connWithDone wraps a net.Conn and signals a channel when Close() is called,
-// allowing the context-cancellation goroutine to exit cleanly.
-type connWithDone struct {
-	net.Conn
-	done chan struct{}
-	once sync.Once
-}
-
-func (c *connWithDone) Close() error {
-	c.once.Do(func() { close(c.done) })
-	return c.Conn.Close()
-}
-
 func (d *dialer) DialContext(ctx context.Context, n, a string) (net.Conn, error) {
-	conn, err := d.Dial(d.network, d.addr)
-	if err != nil {
-		return nil, err
-	}
-	wrapped := &connWithDone{Conn: conn, done: make(chan struct{})}
-	go func() {
-		if ctx != nil {
-			select {
-			case <-ctx.Done():
-				conn.Close()
-			case <-wrapped.done:
-				// Connection was closed by the caller; exit cleanly.
-			}
-		}
-	}()
-	return wrapped, nil
+	return d.sshClient.DialContext(ctx, d.network, d.addr)
 }
 
 func (d *dialer) Dial(n, a string) (net.Conn, error) {


### PR DESCRIPTION
# Changes

Fixes #3881

### Why is this needed?

The previous `DialContext` implementation spawned a background goroutine that watched `ctx.Done()` and force-closed the connection when the context expired. This had two problems:

1. **Goroutine leak**: If the caller closed the connection manually while the context was still alive (e.g., `context.Background()`), the goroutine blocked forever on `<-ctx.Done()`, leaking 1 goroutine per connection.

2. **Violated `net.Dialer.DialContext` semantics**: Per the [Go docs](https://pkg.go.dev/net#Dialer.DialContext): *"Once successfully connected, any expiration of the context will not affect the connection."* The old code did the opposite it killed established connections when the context expired. The k8s dialer in this same repo already documents this contract correctly ([`pkg/k8s/dialer.go` L80-84](https://github.com/knative/func/blob/main/pkg/k8s/dialer.go#L80-L84)).

### The fix

The `golang.org/x/crypto/ssh` library already provides [`Client.DialContext`](https://pkg.go.dev/golang.org/x/crypto/ssh#Client.DialContext) which handles context-cancellable dialing correctly:
- Context cancellation during the dial phase → returns error
- Context expiration after connection is established → does not affect the connection

So the fix simply delegates to `d.sshClient.DialContext(ctx, d.network, d.addr)` instead of calling `d.Dial()` + spawning a broken monitoring goroutine. The `connWithDone` wrapper and `sync` import are removed as dead code.

### Testing performed

- `go test ./pkg/ssh/...` passes.
- The change is a net deletion of 30 lines removing incorrect behavior, not adding new logic.

```release-note
Fixed a goroutine leak and incorrect context handling in the SSH dialer. DialContext now correctly delegates to ssh.Client.DialContext, respecting standard Go context semantics.
```
```docs
NONE
```
