### PR TITLE
fix(k8s): prevent goroutine leak and deadlock in pod watcher

### DIFF
--- a/pkg/k8s/persistent_volumes.go
+++ b/pkg/k8s/persistent_volumes.go
@@ -188,18 +188,34 @@ func runWithVolumeMounted(ctx context.Context, podImage string, podCommand []str
 		return fmt.Errorf("cannot set up the watcher: %w", err)
 	}
 	defer watcher.Stop()
+
 	termCh := make(chan corev1.ContainerStateTerminated, 1)
+	errCh := make(chan error, 1)
+
 	go func() {
-		for event := range watcher.ResultChan() {
-			p, ok := event.Object.(*corev1.Pod)
-			if !ok {
-				continue
-			}
-			if len(p.Status.ContainerStatuses) > 0 {
-				termState := event.Object.(*corev1.Pod).Status.ContainerStatuses[0].State.Terminated
-				if termState != nil {
-					termCh <- *termState
-					break
+		defer close(termCh)
+		defer close(errCh)
+		for {
+			select {
+			case <-localCtx.Done():
+				return
+			case event, ok := <-watcher.ResultChan():
+				if !ok {
+					errCh <- errors.New("kubernetes pod watch channel closed unexpectedly")
+					return
+				}
+
+				p, ok := event.Object.(*corev1.Pod)
+				if !ok {
+					continue
+				}
+
+				if len(p.Status.ContainerStatuses) > 0 {
+					termState := p.Status.ContainerStatuses[0].State.Terminated
+					if termState != nil {
+						termCh <- *termState
+						return
+					}
 				}
 			}
 		}
@@ -211,7 +227,15 @@ func runWithVolumeMounted(ctx context.Context, podImage string, podCommand []str
 		return fmt.Errorf("cannot attach stdio to the pod: %w", err)
 	}
 
-	termState := <-termCh
+	var termState corev1.ContainerStateTerminated
+	select {
+	case termState = <-termCh:
+	case err := <-errCh:
+		return fmt.Errorf("pod execution failed during watch: %w", err)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
 	if termState.ExitCode != 0 {
 		cmdOut := strings.Trim(outBuff.String(), "\n")
 		err = fmt.Errorf("the command failed: exitcode=%d, out=%q", termState.ExitCode, cmdOut)

--- a/pkg/k8s/persistent_volumes.go
+++ b/pkg/k8s/persistent_volumes.go
@@ -1,4 +1,4 @@
- package k8s
+package k8s
 
 import (
 	"bytes"
@@ -227,9 +227,13 @@ func runWithVolumeMounted(ctx context.Context, podImage string, podCommand []str
 		return fmt.Errorf("cannot attach stdio to the pod: %w", err)
 	}
 
-	var termState corev1.ContainerStateTerminated
+	var (
+		termState corev1.ContainerStateTerminated
+		ok        bool
+	)
+
 	select {
-	case termState, ok := <-termCh:
+	case termState, ok = <-termCh:
 		if !ok {
 			return errors.New("pod watcher exited without a termination state")
 		}

--- a/pkg/k8s/persistent_volumes.go
+++ b/pkg/k8s/persistent_volumes.go
@@ -192,34 +192,33 @@ func runWithVolumeMounted(ctx context.Context, podImage string, podCommand []str
 	termCh := make(chan corev1.ContainerStateTerminated, 1)
 	errCh := make(chan error, 1)
 
-	go func() {
-		defer close(termCh)
-		defer close(errCh)
-		for {
-			select {
-			case <-localCtx.Done():
-				return
-			case event, ok := <-watcher.ResultChan():
-				if !ok {
-					errCh <- errors.New("kubernetes pod watch channel closed unexpectedly")
-					return
-				}
+    go func() {
+	    for {
+		    select {
+		    case <-localCtx.Done():
+			    return
 
-				p, ok := event.Object.(*corev1.Pod)
-				if !ok {
-					continue
-				}
+		    case event, ok := <-watcher.ResultChan():
+			    if !ok {
+				    errCh <- errors.New("kubernetes pod watch channel closed unexpectedly")
+				    return
+			    }
 
-				if len(p.Status.ContainerStatuses) > 0 {
-					termState := p.Status.ContainerStatuses[0].State.Terminated
-					if termState != nil {
-						termCh <- *termState
-						return
-					}
-				}
-			}
-		}
-	}()
+			    p, ok := event.Object.(*corev1.Pod)
+			    if !ok {
+				    continue
+			    }
+
+			    if len(p.Status.ContainerStatuses) > 0 {
+				    termState := p.Status.ContainerStatuses[0].State.Terminated
+				    if termState != nil {
+					    termCh <- *termState
+					    return
+				    }
+			    }
+		    }
+	    }
+    }()
 
 	var outBuff tsBuff
 	err = attach(ctx, client.CoreV1().RESTClient(), restConf, podName, namespace, podInput, &outBuff, &outBuff)
@@ -227,32 +226,20 @@ func runWithVolumeMounted(ctx context.Context, podImage string, podCommand []str
 		return fmt.Errorf("cannot attach stdio to the pod: %w", err)
 	}
 
-	var (
-		termState corev1.ContainerStateTerminated
-		ok        bool
-	)
+	var termState corev1.ContainerStateTerminated
 
-	select {
-	case termState, ok = <-termCh:
-		if !ok {
-			return errors.New("pod watcher exited without a termination state")
-		}
-	case err, ok := <-errCh:
-		if !ok || err == nil {
-			return errors.New("pod execution failed during watch")
-		}
-		return fmt.Errorf("pod execution failed during watch: %w", err)
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+    select {
+    case termState = <-termCh:
 
-	if termState.ExitCode != 0 {
-		cmdOut := strings.Trim(outBuff.String(), "\n")
-		err = fmt.Errorf("the command failed: exitcode=%d, out=%q", termState.ExitCode, cmdOut)
-	}
+    case watchErr := <-errCh:
+	    if watchErr == nil {
+		    return errors.New("pod execution failed during watch")
+	    }
+	    return fmt.Errorf("pod execution failed during watch: %w", watchErr)
 
-	return err
-}
+    case <-ctx.Done():
+	    return ctx.Err()
+    }
 
 // thread safe buffer for logging
 type tsBuff struct {

--- a/pkg/k8s/persistent_volumes.go
+++ b/pkg/k8s/persistent_volumes.go
@@ -192,33 +192,33 @@ func runWithVolumeMounted(ctx context.Context, podImage string, podCommand []str
 	termCh := make(chan corev1.ContainerStateTerminated, 1)
 	errCh := make(chan error, 1)
 
-    go func() {
-	    for {
-		    select {
-		    case <-localCtx.Done():
-			    return
+	go func() {
+		for {
+			select {
+			case <-localCtx.Done():
+				return
 
-		    case event, ok := <-watcher.ResultChan():
-			    if !ok {
-				    errCh <- errors.New("kubernetes pod watch channel closed unexpectedly")
-				    return
-			    }
+			case event, ok := <-watcher.ResultChan():
+				if !ok {
+					errCh <- errors.New("kubernetes pod watch channel closed unexpectedly")
+					return
+				}
 
-			    p, ok := event.Object.(*corev1.Pod)
-			    if !ok {
-				    continue
-			    }
+				p, ok := event.Object.(*corev1.Pod)
+				if !ok {
+					continue
+				}
 
-			    if len(p.Status.ContainerStatuses) > 0 {
-				    termState := p.Status.ContainerStatuses[0].State.Terminated
-				    if termState != nil {
-					    termCh <- *termState
-					    return
-				    }
-			    }
-		    }
-	    }
-    }()
+				if len(p.Status.ContainerStatuses) > 0 {
+					termState := p.Status.ContainerStatuses[0].State.Terminated
+					if termState != nil {
+						termCh <- *termState
+						return
+					}
+				}
+			}
+		}
+	}()
 
 	var outBuff tsBuff
 	err = attach(ctx, client.CoreV1().RESTClient(), restConf, podName, namespace, podInput, &outBuff, &outBuff)
@@ -228,18 +228,26 @@ func runWithVolumeMounted(ctx context.Context, podImage string, podCommand []str
 
 	var termState corev1.ContainerStateTerminated
 
-    select {
-    case termState = <-termCh:
+	select {
+	case termState = <-termCh:
 
-    case watchErr := <-errCh:
-	    if watchErr == nil {
-		    return errors.New("pod execution failed during watch")
-	    }
-	    return fmt.Errorf("pod execution failed during watch: %w", watchErr)
+	case watchErr := <-errCh:
+		if watchErr == nil {
+			return errors.New("pod execution failed during watch")
+		}
+		return fmt.Errorf("pod execution failed during watch: %w", watchErr)
 
-    case <-ctx.Done():
-	    return ctx.Err()
-    }
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	if termState.ExitCode != 0 {
+		cmdOut := strings.Trim(outBuff.String(), "\n")
+		err = fmt.Errorf("the command failed: exitcode=%d, out=%q", termState.ExitCode, cmdOut)
+	}
+
+	return err
+}
 
 // thread safe buffer for logging
 type tsBuff struct {

--- a/pkg/k8s/persistent_volumes.go
+++ b/pkg/k8s/persistent_volumes.go
@@ -1,4 +1,4 @@
-package k8s
+ package k8s
 
 import (
 	"bytes"
@@ -229,8 +229,14 @@ func runWithVolumeMounted(ctx context.Context, podImage string, podCommand []str
 
 	var termState corev1.ContainerStateTerminated
 	select {
-	case termState = <-termCh:
-	case err := <-errCh:
+	case termState, ok := <-termCh:
+		if !ok {
+			return errors.New("pod watcher exited without a termination state")
+		}
+	case err, ok := <-errCh:
+		if !ok || err == nil {
+			return errors.New("pod execution failed during watch")
+		}
 		return fmt.Errorf("pod execution failed during watch: %w", err)
 	case <-ctx.Done():
 		return ctx.Err()


### PR DESCRIPTION
# Changes

- :bug: Fixed a critical goroutine leak inside `runWithVolumeMounted` by making the pod watcher loop context-aware (`<-localCtx.Done()`).
- :bug: Prevented potential deadlocks/infinite hangs by introducing an `errCh` to handle abrupt or unexpected watch channel closures from the Kubernetes API server.
- :broom: Cleaned up a double type assertion on `event.Object` to eliminate any sudden runtime panic risks when unexpected object states are encountered.

/kind bug

 

**Release Note**

```release-note
Fixed a potential goroutine leak and deadlock scenario in the Kubernetes pod watcher inside `pkg/k8s`.