### PR TITLE
cmd: apply function context to invoke/logs flag defaults

### DIFF
--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -118,6 +118,12 @@ EXAMPLES
 		fmt.Fprintf(cmd.OutOrStdout(), "error loading config at '%v'. %v\n", config.File(), err)
 	}
 
+	// Function Context
+	f, _ := fn.NewFunction(effectivePath())
+	if f.Initialized() {
+		cfg = cfg.Apply(f)
+	}
+
 	// Flags
 	cmd.Flags().StringP("format", "f", "", "Format of message to send, 'http' or 'cloudevent(s)'.  Default is to choose automatically. ($FUNC_FORMAT)")
 	cmd.Flags().StringP("target", "t", "", "Function instance to invoke.  Can be 'local', 'remote' or a URL.  Defaults to auto-discovery if not provided. ($FUNC_TARGET)")

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -52,6 +52,12 @@ specified with --path. Abstracts away the underlying service name and pod detail
 		fmt.Fprintf(cmd.OutOrStdout(), "error loading config at '%v'. %v\n", config.File(), err)
 	}
 
+	// Function Context
+	f, _ := fn.NewFunction(effectivePath())
+	if f.Initialized() {
+		cfg = cfg.Apply(f)
+	}
+
 	// Flags
 	cmd.Flags().StringP("name", "", "", "Name of the function to get logs from ($FUNC_NAME)")
 	cmd.Flags().StringP("namespace", "n", defaultNamespace(fn.Function{}, false), "The namespace of the function ($FUNC_NAMESPACE)")


### PR DESCRIPTION
Bring `NewInvokeCmd` and `NewLogsCmd` in line with the `cfg.Apply(f)` idiom already used by deploy and build -> fold the current function's state into the global config before registering flags, so `func.yaml` values become flag defaults. 
