### PR TITLE
pipelines: never upload .func to the cluster in direct remote deploy

### DIFF
--- a/pkg/pipelines/tekton/pipelines_provider.go
+++ b/pkg/pipelines/tekton/pipelines_provider.go
@@ -281,14 +281,17 @@ func (pp *PipelinesProvider) Run(ctx context.Context, f fn.Function) (string, fn
 
 // Creates tar stream with the function sources as they were in "./source" directory.
 func sourcesAsTarStream(f fn.Function) *io.PipeReader {
-	ignored := func(p string) bool { return strings.HasPrefix(p, ".git") }
-	if gi, err := gitignore.CompileIgnoreFile(filepath.Join(f.Root, ".gitignore")); err == nil {
-		ignored = func(p string) bool {
-			if strings.HasPrefix(p, ".git") {
-				return true
-			}
-			return gi.MatchesPath(p)
+	// Apply the same ignore policy as local builds: fn.IsIgnored always excludes
+	// the DefaultIgnored plus the user's .funcignore patterns. This guarantees local
+	// runtime data under .func — scaffolding (regenerated on-cluster by the
+	// func-scaffold step)
+	userPatterns := fn.ParseFuncIgnore(f.Root)
+	gi, giErr := gitignore.CompileIgnoreFile(filepath.Join(f.Root, ".gitignore"))
+	ignored := func(p string) bool {
+		if fn.IsIgnored(p, userPatterns) {
+			return true
 		}
+		return giErr == nil && gi.MatchesPath(p)
 	}
 
 	pr, pw := io.Pipe()
@@ -327,6 +330,9 @@ func sourcesAsTarStream(f fn.Function) *io.PipeReader {
 			}
 
 			if ignored(relp) {
+				if fi.IsDir() {
+					return filepath.SkipDir
+				}
 				return nil
 			}
 

--- a/pkg/pipelines/tekton/pipelines_provider_test.go
+++ b/pkg/pipelines/tekton/pipelines_provider_test.go
@@ -81,6 +81,54 @@ func TestSourcesAsTarStream(t *testing.T) {
 	}
 }
 
+// TestSourcesAsTarStream_ExcludesFuncDir ensures the local runtime directory
+// (.func) is never uploaded to the cluster — most importantly the credential
+// file .func/local.yaml — even when the function has NO .gitignore. The
+// exclusion must come from the authoritative DefaultIgnored policy, not from a
+// .gitignore happening to list it. Scaffolding under .func/build is regenerated
+// on-cluster by the func-scaffold step, so it is not needed in the upload.
+func TestSourcesAsTarStream_ExcludesFuncDir(t *testing.T) {
+	root := t.TempDir()
+	// deliberately NO .gitignore is written
+	mustWrite := func(rel, content string) {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("app.js", "module.exports = () => {}\n") // a normal source file
+	mustWrite(".func/local.yaml", "auth:\n- cluster-url: https://secret\n  user:\n    token: SECRET\n")
+	mustWrite(".func/build/service/main.py", "# scaffolding\n")
+	mustWrite(".func/built-image", "example.com/img@sha256:deadbeef\n")
+
+	rc := sourcesAsTarStream(fn.Function{Root: root})
+	t.Cleanup(func() { _ = rc.Close() })
+
+	var appFound bool
+	tr := tar.NewReader(rc)
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatal(err)
+		}
+		if strings.HasPrefix(hdr.Name, "source/.func") {
+			t.Errorf(".func entry leaked into the upload stream: %q", hdr.Name)
+		}
+		if hdr.Name == "source/app.js" {
+			appFound = true
+		}
+	}
+	if !appFound {
+		t.Error("the app.js source file is missing from the stream")
+	}
+}
+
 func Test_createPipelinePersistentVolumeClaim(t *testing.T) {
 	type mockType func(ctx context.Context, name, namespaceOverride string, labels map[string]string, annotations map[string]string, accessMode corev1.PersistentVolumeAccessMode, resourceRequest resource.Quantity, storageClass string) (err error)
 


### PR DESCRIPTION
- Direct remote (on-cluster) builds tar the function source and upload it to a PVC. Honor the same ignoring system that local builds already implement -> Using the default ignored + `.funcignore` + `.gitignore`. 

- Scaffolding under `.func/build` is regenerated on-cluster by the func-scaffold step, so nothing needed is lost

