### PR TITLE
e2e: add lifecycle structure + tests for existing python + go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ test-integration: ## Run integration tests using an available cluster.
 .PHONY: test-e2e
 test-e2e: func-instrumented-bin ## Basic E2E tests (includes core, metadata and remote tests)
 	# Runtime and other options can be configured using the FUNC_E2E_* environment variables. see e2e_test.go
-	go test -tags e2e -timeout 60m ./e2e -v -run "TestCore_|TestMetadata_|TestRemote_"
+	go test -tags e2e -timeout 60m ./e2e -v -run "TestCore_|TestMetadata_|TestRemote_|TestLifecycle_"
 	go tool covdata textfmt -i=$${FUNC_E2E_GOCOVERDIR:-.coverage} -o coverage.txt
 
 .PHONY: test-e2e-podman
@@ -307,6 +307,12 @@ test-e2e-podman: func-instrumented-bin ## Run E2E Podman-specific tests
 test-e2e-matrix: func-instrumented-bin ## Basic E2E tests (includes core, metadata and remote tests)
 	# Runtime and other options can be configured using the FUNC_E2E_* environment variables. see e2e_test.go
 	FUNC_E2E_MATRIX=true go test -tags e2e -timeout 120m ./e2e -v -run TestMatrix_
+	go tool covdata textfmt -i=$${FUNC_E2E_GOCOVERDIR:-.coverage} -o coverage.txt
+
+.PHONY: test-e2e-lifecycle
+test-e2e-lifecycle: func-instrumented-bin ## Run lifecycle hook E2E tests (Start, Stop, Ready, Alive)
+	# Runtime and other options can be configured using the FUNC_E2E_* environment variables. see e2e_test.go
+	go test -tags e2e -timeout 60m ./e2e -v -run TestLifecycle_
 	go tool covdata textfmt -i=$${FUNC_E2E_GOCOVERDIR:-.coverage} -o coverage.txt
 
 .PHONY: test-e2e-config-ci

--- a/e2e/e2e_lifecycle_test.go
+++ b/e2e/e2e_lifecycle_test.go
@@ -3,12 +3,15 @@
 package e2e
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // describe how to set up a Function for a specific runtimes testing lifecycle hooks
@@ -41,6 +44,7 @@ var lifecycleRuntimes = map[string]*lifecycleRuntime{
 }
 
 // loads testdata/lifecycle/{runtime}/{hook}{extension}
+// lifecycleSource reads the testdata source file for the given runtime and hook.
 func lifecycleSource(t *testing.T, runtime, hook string, rt *lifecycleRuntime) []byte {
 	t.Helper()
 	path := filepath.Join(Testdata, "lifecycle", runtime, hook+rt.srcExt)
@@ -76,4 +80,165 @@ func extractValue(body, key string) string {
 		}
 	}
 	return ""
+}
+
+// TestLifecycle_Hooks verifies the Start, Ready, and Alive hooks using a single
+// merged function per runtime. The function implements all three hooks
+// simultaneously, and the test verifies them in sequence:
+//  1. Start — fires during cold start, captures config env var
+//  2. Ready — returns false for 15s warm-up, then true
+//  3. Alive — defaults true, toggled false via /set-unhealthy, pod restarts
+func TestLifecycle_Hooks(t *testing.T) {
+	for _, name := range allRuntimes {
+		rt, enabled := lifecycleRuntimes[name]
+		t.Run(name, func(t *testing.T) {
+			if !enabled {
+				t.Skipf("lifecycle hooks not enabled for %s", name)
+			}
+
+			funcName := fmt.Sprintf("func-e2e-test-lifecycle-hooks-%s", name)
+			root := fromCleanEnv(t, funcName)
+
+			args := append([]string{"init", "-l=" + name}, rt.initArgs...)
+			if err := newCmd(t, args...).Run(); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := newCmd(t, "config", "envs", "add",
+				"--name=TEST_CONFIG_VALUE", "--value=e2e-lifecycle-hooks").Run(); err != nil {
+				t.Fatal(err)
+			}
+
+			src := lifecycleSource(t, name, "hooks", rt)
+			if err := os.WriteFile(filepath.Join(root, rt.srcPath), src, 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			deployArgs := []string{"deploy"}
+			if rt.builder != "" {
+				deployArgs = append(deployArgs, "--builder", rt.builder)
+			}
+			if err := newCmd(t, deployArgs...).Run(); err != nil {
+				t.Fatal(err)
+			}
+			defer clean(t, funcName, Namespace)
+			if rt.builder != "" {
+				defer cleanImages(t, funcName)
+			}
+
+			url := ksvcUrl(funcName)
+
+			// Phase 1: Start hook — verify it fired and received config
+			t.Run("start", func(t *testing.T) {
+				if !waitFor(t, url,
+					withContentMatch("START_OK:e2e-lifecycle-hooks"),
+					withWaitTimeout(5*time.Minute)) {
+					t.Fatal("Start hook did not fire or did not receive config")
+				}
+			})
+
+			// Phase 2: Ready hook — verify readiness endpoint
+			t.Run("ready", func(t *testing.T) {
+				if !waitFor(t, url,
+					withContentMatch("READY=true"),
+					withWaitTimeout(5*time.Minute)) {
+					t.Fatal("Ready hook: function never became ready")
+				}
+
+				body := getBody(t, url+"/health/readiness")
+				if !strings.Contains(strings.ToUpper(body), "READY") {
+					t.Fatalf("readiness endpoint returned unexpected body: %s", body)
+				}
+			})
+
+			// Phase 3: Alive hook — toggle unhealthy, verify pod restart via nonce
+			t.Run("alive", func(t *testing.T) {
+				body := getBody(t, url)
+				nonce1 := extractValue(body, "NONCE")
+				if nonce1 == "" {
+					t.Fatalf("no NONCE in response: %s", body)
+				}
+				t.Logf("initial nonce: %s", nonce1)
+
+				unhealthyBody := getBody(t, url+"/set-unhealthy")
+				t.Logf("set-unhealthy response: %s", unhealthyBody)
+
+				if !waitFor(t, url,
+					withContentMatch("ALIVE=true"),
+					withWaitTimeout(3*time.Minute)) {
+					t.Fatal("function did not recover after liveness failure")
+				}
+
+				body = getBody(t, url)
+				nonce2 := extractValue(body, "NONCE")
+				if nonce2 == "" {
+					t.Fatalf("no NONCE in response after restart: %s", body)
+				}
+				t.Logf("post-restart nonce: %s", nonce2)
+
+				if nonce1 == nonce2 {
+					t.Fatal("nonce unchanged — pod was not restarted by liveness probe failure")
+				}
+			})
+		})
+	}
+}
+
+func TestLifecycle_Stop(t *testing.T) {
+	for _, name := range allRuntimes {
+		rt, enabled := lifecycleRuntimes[name]
+		t.Run(name, func(t *testing.T) {
+			if !enabled {
+				t.Skipf("lifecycle hooks not enabled for %s", name)
+			}
+
+			recName := fmt.Sprintf("func-e2e-lifecycle-stop-rec-%s", name)
+			rec := deployRecorder(t, recName)
+
+			funcName := fmt.Sprintf("func-e2e-test-lifecycle-stop-%s", name)
+			root := fromCleanEnv(t, funcName)
+
+			args := append([]string{"init", "-l=" + name}, rt.initArgs...)
+			if err := newCmd(t, args...).Run(); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := newCmd(t, "config", "envs", "add",
+				"--name=RECORDER_URL", "--value="+rec.internalURL).Run(); err != nil {
+				t.Fatal(err)
+			}
+
+			src := lifecycleSource(t, name, "stop", rt)
+			if err := os.WriteFile(filepath.Join(root, rt.srcPath), src, 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			deployArgs := []string{"deploy"}
+			if rt.builder != "" {
+				deployArgs = append(deployArgs, "--builder", rt.builder)
+			}
+			if err := newCmd(t, deployArgs...).Run(); err != nil {
+				t.Fatal(err)
+			}
+			if rt.builder != "" {
+				defer cleanImages(t, funcName)
+			}
+
+			if !waitFor(t, ksvcUrl(funcName), withWaitTimeout(5*time.Minute)) {
+				t.Fatal("notifier function did not deploy correctly")
+			}
+
+			if err := newCmd(t, "delete", funcName, "--namespace", Namespace).Run(); err != nil {
+				t.Logf("error deleting notifier: %v", err)
+			}
+
+			stopID := fmt.Sprintf("stop-%s", name)
+			ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+			defer cancel()
+			if !rec.awaitReceived(ctx, t, stopID) {
+				t.Fatalf("recorder did not receive stop event %q within 60s", stopID)
+			}
+			t.Logf("Stop hook confirmed: recorder received %q", stopID)
+		})
+	}
 }

--- a/e2e/e2e_lifecycle_test.go
+++ b/e2e/e2e_lifecycle_test.go
@@ -1,0 +1,79 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// describe how to set up a Function for a specific runtimes testing lifecycle hooks
+type lifecycleRuntime struct {
+	builder string // "host", "pack", "s2i"
+	// TODO: expand matrix for each deployer
+	// deployer string   // "knative","raw","keda"
+	srcPath  string   // where to write source in func dir (e.g. "function.go")
+	srcExt   string   // extension for testdata lookup (".go", ".py")
+	initArgs []string // extra args for func init
+}
+
+var allRuntimes = []string{
+	"go", "python", "node", "typescript", "rust", "quarkus", "springboot",
+}
+
+var lifecycleRuntimes = map[string]*lifecycleRuntime{
+	"go": {
+		builder:  "host",
+		srcPath:  "function.go",
+		srcExt:   ".go",
+		initArgs: []string{},
+	},
+	"python": {
+		builder:  "host",
+		srcPath:  filepath.Join("function", "func.py"),
+		srcExt:   ".py",
+		initArgs: []string{},
+	},
+}
+
+// loads testdata/lifecycle/{runtime}/{hook}{extension}
+func lifecycleSource(t *testing.T, runtime, hook string, rt *lifecycleRuntime) []byte {
+	t.Helper()
+	path := filepath.Join(Testdata, "lifecycle", runtime, hook+rt.srcExt)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("lifecycleSource: reading %s: %v", path, err)
+	}
+	return data
+}
+
+// getBody performs a single HTTP GET and returns the response body as a string.
+func getBody(t *testing.T, url string) string {
+	t.Helper()
+	resp, err := http.Get(url) //nolint:noctx
+	if err != nil {
+		t.Fatalf("getBody: GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("getBody: reading body from %s: %v", url, err)
+	}
+	return string(body)
+}
+
+// extractValue parses KEY=value pairs from a space-separated response body and
+// returns the value for the given key, or "" if the key is not present.
+// Example: extractValue("ALIVE=true NONCE=12345", "NONCE") == "12345"
+func extractValue(body, key string) string {
+	for _, field := range strings.Fields(body) {
+		if k, v, ok := strings.Cut(field, "="); ok && k == key {
+			return v
+		}
+	}
+	return ""
+}

--- a/e2e/testdata/lifecycle/go/hooks.go
+++ b/e2e/testdata/lifecycle/go/hooks.go
@@ -1,0 +1,69 @@
+package function
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type Function struct {
+	mu          sync.Mutex
+	startCalled bool
+	configValue string
+	ready       bool
+	alive       bool
+	nonce       string
+}
+
+func New() *Function {
+	f := &Function{
+		alive: true,
+		nonce: fmt.Sprintf("%d", time.Now().UnixNano()),
+	}
+	go func() {
+		time.Sleep(15 * time.Second)
+		f.mu.Lock()
+		f.ready = true
+		f.mu.Unlock()
+	}()
+	return f
+}
+
+func (f *Function) Start(_ context.Context, cfg map[string]string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.startCalled = true
+	f.configValue = cfg["TEST_CONFIG_VALUE"]
+	return nil
+}
+
+func (f *Function) Ready(_ context.Context) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.ready, nil
+}
+
+func (f *Function) Alive(_ context.Context) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.alive, nil
+}
+
+func (f *Function) Handle(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/set-unhealthy" {
+		f.mu.Lock()
+		f.alive = false
+		f.mu.Unlock()
+		fmt.Fprintln(w, "UNHEALTHY")
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.startCalled {
+		fmt.Fprintf(w, "START_OK:%s READY=%t ALIVE=%t NONCE=%s", f.configValue, f.ready, f.alive, f.nonce)
+	} else {
+		fmt.Fprintf(w, "START_NOT_CALLED READY=%t ALIVE=%t NONCE=%s", f.ready, f.alive, f.nonce)
+	}
+}

--- a/e2e/testdata/lifecycle/go/stop.go
+++ b/e2e/testdata/lifecycle/go/stop.go
@@ -1,0 +1,30 @@
+package function
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+)
+
+type Function struct {
+	recorderURL string
+}
+
+func New() *Function {
+	return &Function{recorderURL: os.Getenv("RECORDER_URL")}
+}
+
+func (f *Function) Stop(_ context.Context) error {
+	if f.recorderURL != "" {
+		resp, err := http.Post(f.recorderURL+"/record?id=stop-go", "text/plain", nil)
+		if err == nil {
+			resp.Body.Close()
+		}
+	}
+	return nil
+}
+
+func (f *Function) Handle(w http.ResponseWriter, _ *http.Request) {
+	fmt.Fprint(w, "OK")
+}

--- a/e2e/testdata/lifecycle/python/hooks.py
+++ b/e2e/testdata/lifecycle/python/hooks.py
@@ -1,0 +1,50 @@
+import threading
+import time
+
+
+def new():
+    return Function()
+
+
+class Function:
+    def __init__(self):
+        self.start_called = False
+        self.config_value = ""
+        self._ready = False
+        self._alive = True
+        self._nonce = str(time.time_ns())
+        threading.Timer(15.0, self._become_ready).start()
+
+    def _become_ready(self):
+        self._ready = True
+
+    def start(self, cfg):
+        self.start_called = True
+        self.config_value = cfg.get("TEST_CONFIG_VALUE", "")
+
+    def ready(self):
+        return self._ready, "ready" if self._ready else "warming up"
+
+    def alive(self):
+        return self._alive, "alive" if self._alive else "unhealthy"
+
+    async def handle(self, scope, receive, send):
+        path = scope.get("path", "/")
+
+        if path == "/set-unhealthy":
+            self._alive = False
+            body = b"UNHEALTHY"
+        elif self.start_called:
+            body = f"START_OK:{self.config_value} READY={str(self._ready).lower()} ALIVE={str(self._alive).lower()} NONCE={self._nonce}".encode()
+        else:
+            body = f"START_NOT_CALLED READY={str(self._ready).lower()} ALIVE={str(self._alive).lower()} NONCE={self._nonce}".encode()
+
+        await send({
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [[b"content-type", b"text/plain"]],
+        })
+        await send({
+            "type": "http.response.body",
+            "body": body,
+        })

--- a/e2e/testdata/lifecycle/python/stop.py
+++ b/e2e/testdata/lifecycle/python/stop.py
@@ -1,0 +1,33 @@
+import os
+import urllib.request
+
+
+def new():
+    return Function()
+
+
+class Function:
+    def __init__(self):
+        self._recorder_url = os.environ.get("RECORDER_URL", "")
+
+    def stop(self):
+        if self._recorder_url:
+            req = urllib.request.Request(
+                self._recorder_url + "/record?id=stop-python",
+                method="POST",
+            )
+            try:
+                urllib.request.urlopen(req, timeout=5)
+            except Exception:
+                pass
+
+    async def handle(self, scope, receive, send):
+        await send({
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [[b"content-type", b"text/plain"]],
+        })
+        await send({
+            "type": "http.response.body",
+            "body": b"OK",
+        })


### PR DESCRIPTION
e2e lifecycle tests
- start,ready,alive hooks in one function
- stop separate to deliberately test stop hook works on `func delete`