### PR TITLE
fix: autoscaling annotation format and empty image guard

### DIFF
--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -862,6 +862,9 @@ func (f Function) ImageNameWithDigest(newDigest string) string {
 		return f.Build.Image
 	}
 	image := f.Build.Image
+	if image == "" {
+		return ""
+	}
 
 	// overwrite current digest
 	shaIndex := strings.Index(image, "@sha256:")

--- a/pkg/knative/deployer.go
+++ b/pkg/knative/deployer.go
@@ -589,13 +589,13 @@ func setServiceOptions(template *servingv1.RevisionTemplateSpec, options fn.Opti
 		}
 
 		if options.Scale.Target != nil {
-			toUpdate[autoscaling.TargetAnnotationKey] = fmt.Sprintf("%f", *options.Scale.Target)
+			toUpdate[autoscaling.TargetAnnotationKey] = fmt.Sprintf("%g", *options.Scale.Target)
 		} else {
 			toRemove = append(toRemove, autoscaling.TargetAnnotationKey)
 		}
 
 		if options.Scale.Utilization != nil {
-			toUpdate[autoscaling.TargetUtilizationPercentageKey] = fmt.Sprintf("%f", *options.Scale.Utilization)
+			toUpdate[autoscaling.TargetUtilizationPercentageKey] = fmt.Sprintf("%g", *options.Scale.Utilization)
 		} else {
 			toRemove = append(toRemove, autoscaling.TargetUtilizationPercentageKey)
 		}

--- a/pkg/knative/deployer_test.go
+++ b/pkg/knative/deployer_test.go
@@ -29,6 +29,7 @@ import (
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	fn "knative.dev/func/pkg/functions"
 	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/apis/autoscaling"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -448,6 +449,35 @@ func TestGenerateNewService_ResourceSetsPopulated(t *testing.T) {
 	}
 	if !referencedConfigMaps.Has(configMapName) {
 		t.Errorf("expected referencedConfigMaps to contain %q after generateNewService, got: %v", configMapName, referencedConfigMaps)
+	}
+}
+
+func TestSetServiceOptions_ScaleAnnotationFormat(t *testing.T) {
+	target := 100.0
+	utilization := 70.0
+	template := &servingv1.RevisionTemplateSpec{
+		Spec: servingv1.RevisionSpec{
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{}},
+			},
+		},
+	}
+	options := fn.Options{
+		Scale: &fn.ScaleOptions{
+			Target:      &target,
+			Utilization: &utilization,
+		},
+	}
+
+	if err := setServiceOptions(template, options); err != nil {
+		t.Fatalf("setServiceOptions returned unexpected error: %v", err)
+	}
+
+	if got := template.Annotations[autoscaling.TargetAnnotationKey]; got != "100" {
+		t.Errorf("expected target annotation to be %q, got %q", "100", got)
+	}
+	if got := template.Annotations[autoscaling.TargetUtilizationPercentageKey]; got != "70" {
+		t.Errorf("expected utilization annotation to be %q, got %q", "70", got)
 	}
 }
 


### PR DESCRIPTION
## Description
Two bug fixes:

### 1. Autoscaling annotations formatted with `%f` produce invalid values
`setServiceOptions` in `pkg/knative/deployer.go` uses `fmt.Sprintf("%f", ...)` to format scale `Target` and `Utilization` annotations, producing strings like `"100.000000"` instead of `"100"`. Changed `%f` to `%g` which strips trailing zeros.

**Files changed:** `pkg/knative/deployer.go` (lines 592, 598)

### 2. `ImageNameWithDigest` produces invalid OCI reference when `Build.Image` is empty
No guard against empty `Build.Image` in `ImageNameWithDigest`. When called with non-empty digest but empty image, produces invalid `@sha256:...` reference. Added early return for empty image.

**Files changed:** `pkg/functions/function.go` (line 864)

### Regression test
Added `TestSetServiceOptions_ScaleAnnotationFormat` that verifies scale annotations contain clean values (`"100"` not `"100.000000"`).

**Files changed:** `pkg/knative/deployer_test.go`

### Verification
- `go vet ./pkg/knative ./pkg/functions` - clean
- `go test ./pkg/knative/ -count=1` - all 20 tests pass
- `go test ./pkg/functions/ -run TestFunction_ImageWithDigest -count=1` - all 5 tests pass
