### PR TITLE
fix: use %g instead of %f for autoscaling annotation values

### DIFF
--- a/pkg/knative/deployer.go
+++ b/pkg/knative/deployer.go
@@ -589,13 +589,13 @@ func setServiceOptions(template *servingv1.RevisionTemplateSpec, options fn.Opti
 		}
 
 		if options.Scale.Target != nil {
-			toUpdate[autoscaling.TargetAnnotationKey] = fmt.Sprintf("%f", *options.Scale.Target)
+			toUpdate[autoscaling.TargetAnnotationKey] = fmt.Sprintf("%g", *options.Scale.Target)
 		} else {
 			toRemove = append(toRemove, autoscaling.TargetAnnotationKey)
 		}
 
 		if options.Scale.Utilization != nil {
-			toUpdate[autoscaling.TargetUtilizationPercentageKey] = fmt.Sprintf("%f", *options.Scale.Utilization)
+			toUpdate[autoscaling.TargetUtilizationPercentageKey] = fmt.Sprintf("%g", *options.Scale.Utilization)
 		} else {
 			toRemove = append(toRemove, autoscaling.TargetUtilizationPercentageKey)
 		}

--- a/pkg/knative/deployer_test.go
+++ b/pkg/knative/deployer_test.go
@@ -29,6 +29,7 @@ import (
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	fn "knative.dev/func/pkg/functions"
 	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/apis/autoscaling"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -448,6 +449,35 @@ func TestGenerateNewService_ResourceSetsPopulated(t *testing.T) {
 	}
 	if !referencedConfigMaps.Has(configMapName) {
 		t.Errorf("expected referencedConfigMaps to contain %q after generateNewService, got: %v", configMapName, referencedConfigMaps)
+	}
+}
+
+func TestSetServiceOptions_ScaleAnnotationFormat(t *testing.T) {
+	target := 100.0
+	utilization := 70.0
+	template := &servingv1.RevisionTemplateSpec{
+		Spec: servingv1.RevisionSpec{
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{}},
+			},
+		},
+	}
+	options := fn.Options{
+		Scale: &fn.ScaleOptions{
+			Target:      &target,
+			Utilization: &utilization,
+		},
+	}
+
+	if err := setServiceOptions(template, options); err != nil {
+		t.Fatalf("setServiceOptions returned unexpected error: %v", err)
+	}
+
+	if got := template.Annotations[autoscaling.TargetAnnotationKey]; got != "100" {
+		t.Errorf("expected target annotation to be %q, got %q", "100", got)
+	}
+	if got := template.Annotations[autoscaling.TargetUtilizationPercentageKey]; got != "70" {
+		t.Errorf("expected utilization annotation to be %q, got %q", "70", got)
 	}
 }
 


### PR DESCRIPTION
## Description
`setServiceOptions` in `pkg/knative/deployer.go` uses `fmt.Sprintf("%f", ...)` to format autoscaling `Target` and `Utilization` annotation values. Go's `%f` verb produces 6 trailing decimal places by default (e.g., `"100.000000"`), which is not the expected format for Knative autoscaling annotations.

Changed `%f` to `%g` which strips trailing zeros (`100.0` becomes `"100"`, `70.5` becomes `"70.5"`).

### Changes
- `pkg/knative/deployer.go`, lines 592 and 598: `%f` replaced with `%g`
- `pkg/knative/deployer_test.go`: added `TestSetServiceOptions_ScaleAnnotationFormat` regression test

### Verification
- `go vet ./pkg/knative`: clean
- `go test ./pkg/knative/ -count=1`: all 20 tests pass
- `go test ./pkg/knative/ -run TestSetServiceOptions_ScaleAnnotationFormat -count=1`: pass

Fixes #3901
