### PR TITLE
fix: guard against empty Build.Image in ImageNameWithDigest

### DIFF
--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -862,6 +862,9 @@ func (f Function) ImageNameWithDigest(newDigest string) string {
 		return f.Build.Image
 	}
 	image := f.Build.Image
+	if image == "" {
+		return ""
+	}
 
 	// overwrite current digest
 	shaIndex := strings.Index(image, "@sha256:")

--- a/pkg/functions/function_unit_test.go
+++ b/pkg/functions/function_unit_test.go
@@ -115,6 +115,11 @@ func TestFunction_ImageWithDigest(t *testing.T) {
 			fields: fields{Image: "image-registry.openshift-image-registry.svc.cluster.local:50000/default/bar@sha256:42", ImageDigest: ""},
 			want:   "image-registry.openshift-image-registry.svc.cluster.local:50000/default/bar@sha256:42",
 		},
+		{
+			name:   "Empty image with digest",
+			fields: fields{Image: "", ImageDigest: "sha256:42"},
+			want:   "",
+		},
 	}
 	//TODO: gauron99 - this is gonna need to be changed (probably) because:
 	// 1: imageDigest now doesn't have a dedicated structure member (resolved?)


### PR DESCRIPTION
## Description
`ImageNameWithDigest` in `pkg/functions/function.go` does not validate that `Build.Image` is non-empty before processing. When called with a non-empty `newDigest` but an empty image name, it produces the malformed OCI reference `@sha256:...` (missing the image name prefix), causing confusing downstream `name.ParseReference` errors.

Added early return for empty image.

### Changes
- `pkg/functions/function.go`, line 866: added `if image == "" { return "" }` guard

### Reproduction
```go
f := fn.Function{Build: fn.BuildSpec{Image: ""}}
result := f.ImageNameWithDigest("sha256:abc123")
// Before fix: "@sha256:abc123" (invalid OCI reference)
// After fix:  "" (safe empty string)
```

### Verification
- `go vet ./pkg/functions`: clean
- `go test ./pkg/functions/ -run TestFunction_ImageWithDigest -count=1`: all 5 tests pass

Fixes #3902
