### PR TITLE
refactor(invoke): simplify extension map iteration

### DIFF
--- a/pkg/functions/invoke.go
+++ b/pkg/functions/invoke.go
@@ -169,8 +169,8 @@ func sendEvent(ctx context.Context, route string, m InvokeMessage, t http.RoundT
 	event.SetID(m.ID)
 	event.SetSource(m.Source)
 	event.SetType(m.Type)
-	for extension := range m.Extensions {
-		event.SetExtension(extension, m.Extensions[extension])
+	for k, v := range m.Extensions {
+		event.SetExtension(k, v)
 	}
 	err = event.SetData(m.ContentType, (m.Data))
 	if err != nil {


### PR DESCRIPTION
Use `for k, v := range` instead of indexed map lookup when setting CloudEvent extensions.

# Changes

- Simplify CloudEvent extension iteration using `for k, v := range` instead of looking up each value by key

/kind cleanup

Relates to #3346

**Release Note**

```release-note

```

**Docs**

```docs

```