### PR TITLE
e2e cleanup: RemoteUpdate, TriggerSync simplified, fix test prefix to run in general e2e suite

### DIFF
--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -208,6 +208,7 @@ jobs:
       FUNC_CLUSTER_RETRIES: 5
       FUNC_E2E_CLEAN: false # cluster only used once
       FUNC_E2E_VERBOSE: true
+      FUNC_CLUSTER_KEDA: "false" # these tests don't use KEDA; skip it to free cluster CPU (PR #3914 'Insufficient cpu')
     steps:
       - uses: actions/checkout@v4
       - uses: knative/actions/setup-go@main

--- a/e2e/e2e_instanced_test.go
+++ b/e2e/e2e_instanced_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -74,9 +75,24 @@ func sendRequest(t *testing.T, url string) string {
 	return string(body)
 }
 
-// TestInstanced_GoHTTP deploys a Go HTTP function using the instanced
+// requestCount issues one GET and parses the integer N from a "request:N" body.
+func requestCount(t *testing.T, url string) int {
+	t.Helper()
+	body := sendRequest(t, url)
+	_, num, ok := strings.Cut(body, "request:")
+	if !ok {
+		t.Fatalf("unexpected response (missing \"request:\" prefix): %q", body)
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(num))
+	if err != nil {
+		t.Fatalf("could not parse counter from response %q: %v", body, err)
+	}
+	return n
+}
+
+// TestCore_InstancedGoHTTP deploys a Go HTTP function using the instanced
 // signature and verifies that constructor state persists across requests.
-func TestInstanced_GoHTTP(t *testing.T) {
+func TestCore_InstancedGoHTTP(t *testing.T) {
 	name := "func-e2e-instanced-go-http"
 	root := fromCleanEnv(t, name)
 
@@ -94,19 +110,23 @@ func TestInstanced_GoHTTP(t *testing.T) {
 		clean(t, name, Namespace)
 	}()
 
-	if !waitFor(t, ksvcUrl(name), withContentMatch("request:1")) {
-		t.Fatal("instanced Go HTTP function did not return request:1")
+	// Wait for readiness by matching the "request:" PREFIX
+	if !waitFor(t, ksvcUrl(name), withContentMatch("request:")) {
+		t.Fatal("instanced HTTP function did not become ready")
 	}
 
-	body := sendRequest(t, ksvcUrl(name))
-	if !strings.Contains(body, "request:2") {
-		t.Fatalf("expected request:2 on second call, got: %s", body)
+	// Dont check for exact match because we poll function first to check if
+	// its live + some health checks send requests too, this is simpler
+	first := requestCount(t, ksvcUrl(name))
+	second := requestCount(t, ksvcUrl(name))
+	if second <= first {
+		t.Fatalf("instanced counter did not increase across requests (state should persist): first=%d second=%d", first, second)
 	}
 }
 
-// TestInstanced_PythonHTTP deploys a Python HTTP function using the instanced
+// TestCore_InstancedPythonHTTP deploys a Python HTTP function using the instanced
 // signature and verifies constructor state persists across requests.
-func TestInstanced_PythonHTTP(t *testing.T) {
+func TestCore_InstancedPythonHTTP(t *testing.T) {
 	name := "func-e2e-instanced-py-http"
 	root := fromCleanEnv(t, name)
 
@@ -124,12 +144,13 @@ func TestInstanced_PythonHTTP(t *testing.T) {
 		clean(t, name, Namespace)
 	}()
 
-	if !waitFor(t, ksvcUrl(name), withContentMatch("request:1")) {
-		t.Fatal("instanced Python HTTP function did not return request:1")
+	if !waitFor(t, ksvcUrl(name), withContentMatch("request:")) {
+		t.Fatal("instanced HTTP function did not become ready")
 	}
 
-	body := sendRequest(t, ksvcUrl(name))
-	if !strings.Contains(body, "request:2") {
-		t.Fatalf("expected request:2 on second call, got: %s", body)
+	first := requestCount(t, ksvcUrl(name))
+	second := requestCount(t, ksvcUrl(name))
+	if second <= first {
+		t.Fatalf("instanced counter did not increase across requests (state should persist): first=%d second=%d", first, second)
 	}
 }

--- a/e2e/e2e_remote_test.go
+++ b/e2e/e2e_remote_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
+	"time"
 )
 
 // ---------------------------------------------------------------------------
@@ -184,5 +186,57 @@ func TestRemote_Deploy_InClusterRegistry(t *testing.T) {
 
 	if !waitFor(t, ksvcUrl(name)) {
 		t.Fatal("function did not deploy correctly")
+	}
+}
+
+// TestRemote_Update ensures that redeploying via the remote/Tekton path after
+// changing the function's source code actually serves the new code. This is the
+// remote analogue of TestCore_Update / TestCore_PythonUpdate, which only cover
+// the local build+deploy path.
+//
+//	func deploy --remote --builder=pack
+func TestRemote_Update(t *testing.T) {
+	name := "func-e2e-test-remote-update"
+	root := fromCleanEnv(t, name)
+
+	// create
+	if err := newCmd(t, "init", "-l=go").Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	// initial remote build + deploy
+	if err := newCmd(t, "deploy", "--remote", "--builder=pack", fmt.Sprintf("--registry=%s", Registry)).Run(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		clean(t, name, Namespace)
+	}()
+	if !waitFor(t, ksvcUrl(name), withWaitTimeout(5*time.Minute)) {
+		t.Fatal("function did not deploy correctly")
+	}
+
+	// update: rewrite the handler to return a new response body
+	update := `
+	package function
+	import "fmt"
+	import "net/http"
+	type Function struct{}
+	func New() *Function { return &Function{} }
+	func (f *Function) Handle(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, "UPDATED")
+	}
+	`
+	if err := os.WriteFile(filepath.Join(root, "function.go"), []byte(update), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// redeploy via the remote path
+	if err := newCmd(t, "deploy", "--remote", "--builder=pack", fmt.Sprintf("--registry=%s", Registry)).Run(); err != nil {
+		t.Fatal(err)
+	}
+	if !waitFor(t, ksvcUrl(name),
+		withContentMatch("UPDATED"),
+		withWaitTimeout(5*time.Minute)) {
+		t.Fatal("function did not update correctly via remote redeploy")
 	}
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -949,6 +950,64 @@ func logClusterCPU(t *testing.T) {
 			break
 		}
 	}
+	// Break the total down into pod count + the biggest CPU requesters, so we can
+	// see WHAT holds the CPU and whether pods/replicas accumulate across the run.
+	logTopPodsCPU(t)
+}
+
+// logTopPodsCPU logs the number of non-terminal pods (only those count toward
+// scheduling) and the top CPU requesters (namespace/name -> millicores). This
+// reveals which workloads make up the committed CPU and what grows over a run.
+func logTopPodsCPU(t *testing.T) {
+	t.Helper()
+	cmd := exec.Command("kubectl", "get", "pods", "-A",
+		"--field-selector=status.phase!=Succeeded,status.phase!=Failed",
+		"-o", `jsonpath={range .items[*]}{.metadata.namespace}/{.metadata.name}{range .spec.containers[*]}{" "}{.resources.requests.cpu}{end}{"\n"}{end}`)
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+Kubeconfig)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return
+	}
+	type pod struct {
+		name  string
+		milli int
+	}
+	var pods []pod
+	total := 0
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		f := strings.Fields(line)
+		if len(f) == 0 {
+			continue
+		}
+		sum := 0
+		for _, v := range f[1:] {
+			sum += parseMilliCPU(v)
+		}
+		pods = append(pods, pod{f[0], sum})
+		total += sum
+	}
+	sort.Slice(pods, func(i, j int) bool { return pods[i].milli > pods[j].milli })
+	t.Logf("[cluster-cpu] %d non-terminal pods, %dm requested (sum)", len(pods), total)
+	for i, p := range pods {
+		if i >= 10 || p.milli == 0 {
+			break
+		}
+		t.Logf("[cluster-cpu]   %4dm  %s", p.milli, p.name)
+	}
+}
+
+// parseMilliCPU parses a Kubernetes CPU quantity ("100m", "1", "0.5") to millicores.
+func parseMilliCPU(s string) int {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	if strings.HasSuffix(s, "m") {
+		n, _ := strconv.Atoi(strings.TrimSuffix(s, "m"))
+		return n
+	}
+	f, _ := strconv.ParseFloat(s, 64)
+	return int(f * 1000)
 }
 
 // cleanImages removes container images and volumes created for a function during testing.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -915,11 +915,39 @@ func containsInstance(t *testing.T, list []fn.ListItem, name, namespace string) 
 // clean up by deleting the named function (via defers)
 func clean(t *testing.T, name, ns string) {
 	t.Helper()
+	// Log committed CPU before cleanup (this test's pods are still up), so the
+	// suite output carries a timeline of cluster load and we can see whether it
+	// creeps toward the node's allocatable and triggers "Insufficient cpu".
+	logClusterCPU(t)
 	if !Clean {
 		return
 	}
 	if err := newCmd(t, "delete", name, "--namespace", ns).Run(); err != nil {
 		t.Logf("Error deleting function. %v", err)
+	}
+}
+
+// logClusterCPU logs the cluster's committed CPU *requests* vs the node's
+// allocatable — the figure the scheduler uses for its "Insufficient cpu"
+// decision (not actual utilization). Best-effort; never fails a test.
+func logClusterCPU(t *testing.T) {
+	t.Helper()
+	cmd := exec.Command("kubectl", "describe", "node")
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+Kubeconfig)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return
+	}
+	inAlloc := false
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.Contains(line, "Allocated resources:") {
+			inAlloc = true
+			continue
+		}
+		if inAlloc && strings.HasPrefix(strings.TrimSpace(line), "cpu") {
+			t.Logf("[cluster-cpu] %s", strings.TrimSpace(line)) // e.g. "cpu  1500m (75%)  2 (100%)"
+			break
+		}
 	}
 }
 

--- a/e2e/e2e_trigger_sync_test.go
+++ b/e2e/e2e_trigger_sync_test.go
@@ -14,279 +14,163 @@ import (
 	fn "knative.dev/func/pkg/functions"
 )
 
-// TestMetadata_TriggerSyncStaleTriggerCleanup verifies that stale triggers are deleted
-// when subscriptions are removed from func.yaml
-func TestMetadata_TriggerSyncStaleTriggerCleanup(t *testing.T) {
+// TestMetadata_TriggerSync tests the raw-deployer trigger synchronization
+// behavior. Containing sub-tests for few different scenarios - we change the
+// subscriptions via func.yaml change (via setSubscriptions).
+// Each sub-test resets the subscription at start.
+// Sub-tests that create manual (unmanaged) triggers register cleanup on their
+// own sub-test t.
+func TestMetadata_TriggerSync(t *testing.T) {
 	brokerName := "default"
 	createBrokerWithCheck(t, Namespace, brokerName)
 
-	functionName := "func-e2e-test-trigger-sync-cleanup"
+	functionName := "func-e2e-test-trigger-sync"
 	root := fromCleanEnv(t, functionName)
 
-	// Create function
+	// Create the function (and thus its image) ONCE; all sub-tests share it.
 	if err := newCmd(t, "init", "-l=go", "-t=http").Run(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Add first subscription
-	if err := newCmd(t, "subscribe",
-		"--source", "default",
-		"--filter", "type=order.created").Run(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Add second subscription by editing func.yaml
-	f, err := fn.NewFunction(root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Add another subscription manually
-	f.Deploy.Subscriptions = append(f.Deploy.Subscriptions, fn.KnativeSubscription{
-		Source: "default",
-		Filters: map[string]string{
-			"type": "order.updated",
-		},
-	})
-	if err := f.Write(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Deploy with raw deployer
-	if err := newCmd(t, "deploy", "--deployer", "raw").Run(); err != nil {
 		t.Fatal(err)
 	}
 	defer clean(t, functionName, Namespace)
 
-	waitForDeployment(t, Namespace, functionName)
+	subCreated := fn.KnativeSubscription{Source: "default", Filters: map[string]string{"type": "order.created"}}
+	subUpdated := fn.KnativeSubscription{Source: "default", Filters: map[string]string{"type": "order.updated"}}
+	subShipped := fn.KnativeSubscription{Source: "default", Filters: map[string]string{"type": "order.shipped"}}
 
-	// Verify 2 triggers were created
-	triggers := listTriggersForFunction(t, Namespace, functionName)
-	if len(triggers) != 2 {
-		t.Fatalf("Expected 2 triggers after initial deploy, got %d: %v", len(triggers), triggers)
-	}
-	t.Logf("Initial deploy created 2 triggers: %v", triggers)
-
-	// Verify triggers have managed-by annotation
-	for _, trigger := range triggers {
-		if !hasManagedByAnnotation(t, Namespace, trigger) {
-			t.Errorf("Trigger %s missing managed-by annotation", trigger)
+	// setSubscriptions resets func.yaml subscriptions to a known state and
+	// redeploys with the raw deployer. Resetting at the start of every sub-test
+	// keeps the scenarios order-independent.
+	setSubscriptions := func(t *testing.T, subs ...fn.KnativeSubscription) {
+		t.Helper()
+		f, err := fn.NewFunction(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		f.Deploy.Subscriptions = subs
+		if err := f.Write(); err != nil {
+			t.Fatal(err)
+		}
+		if err := newCmd(t, "deploy", "--deployer", "raw").Run(); err != nil {
+			t.Fatal(err)
 		}
 	}
-	t.Log("All triggers have managed-by annotation")
 
-	// Remove one subscription by editing func.yaml
-	f, err = fn.NewFunction(root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Keep only the first subscription
-	f.Deploy.Subscriptions = f.Deploy.Subscriptions[:1]
-	if err := f.Write(); err != nil {
-		t.Fatal(err)
-	}
+	// stale triggers are deleted when subscriptions are removed
+	t.Run("Stale-cleanup", func(t *testing.T) {
+		setSubscriptions(t, subCreated, subUpdated)
+		waitForDeployment(t, Namespace, functionName)
 
-	// Redeploy
-	if err := newCmd(t, "deploy", "--deployer", "raw").Run(); err != nil {
-		t.Fatal(err)
-	}
+		// Verify 2 triggers were created
+		triggers := listTriggersForFunction(t, Namespace, functionName)
+		if len(triggers) != 2 {
+			t.Fatalf("Expected 2 triggers after initial deploy, got %d: %v", len(triggers), triggers)
+		}
+		t.Logf("Initial deploy created 2 triggers: %v", triggers)
 
-	time.Sleep(5 * time.Second)
+		// Verify triggers have managed-by annotation
+		for _, trigger := range triggers {
+			if !hasManagedByAnnotation(t, Namespace, trigger) {
+				t.Errorf("Trigger %s missing managed-by annotation", trigger)
+			}
+		}
+		t.Log("All triggers have managed-by annotation")
 
-	// Verify only 1 trigger remains
-	triggersAfter := listTriggersForFunction(t, Namespace, functionName)
-	if len(triggersAfter) != 1 {
-		t.Fatalf("Expected 1 trigger after removing subscription, got %d: %v", len(triggersAfter), triggersAfter)
-	}
-	t.Logf("Stale trigger deleted, 1 trigger remains: %v", triggersAfter)
-}
+		// Remove one subscription (keep only the first) and redeploy
+		setSubscriptions(t, subCreated)
+		time.Sleep(5 * time.Second)
 
-// TestMetadata_TriggerSyncManualTriggerPreservation verifies that manually created
-// triggers (without managed-by annotation) are NOT deleted during sync
-func TestMetadata_TriggerSyncManualTriggerPreservation(t *testing.T) {
-	brokerName := "default"
-	createBrokerWithCheck(t, Namespace, brokerName)
-
-	functionName := "func-e2e-test-trigger-sync-manual"
-	_ = fromCleanEnv(t, functionName)
-
-	// Create function
-	if err := newCmd(t, "init", "-l=go", "-t=http").Run(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Add one subscription
-	if err := newCmd(t, "subscribe",
-		"--source", "default",
-		"--filter", "type=order.created").Run(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Deploy with raw deployer
-	if err := newCmd(t, "deploy", "--deployer", "raw").Run(); err != nil {
-		t.Fatal(err)
-	}
-	defer clean(t, functionName, Namespace)
-
-	waitForDeployment(t, Namespace, functionName)
-
-	// Create a manual trigger (without managed-by annotation)
-	manualTriggerName := fmt.Sprintf("%s-manual-trigger", functionName)
-	createManualTrigger(t, Namespace, manualTriggerName, functionName, brokerName)
-
-	// Verify we have 2 triggers (1 managed + 1 manual)
-	allTriggers := listAllTriggers(t, Namespace)
-	managedTriggers := listTriggersForFunction(t, Namespace, functionName)
-	if len(managedTriggers) != 1 {
-		t.Fatalf("Expected 1 managed trigger, got %d", len(managedTriggers))
-	}
-	if len(allTriggers) < 2 {
-		t.Fatalf("Expected at least 2 total triggers (managed + manual), got %d", len(allTriggers))
-	}
-	t.Logf("Created manual trigger: %s", manualTriggerName)
-
-	// Redeploy (no changes to subscriptions)
-	if err := newCmd(t, "deploy", "--deployer", "raw").Run(); err != nil {
-		t.Fatal(err)
-	}
-
-	time.Sleep(5 * time.Second)
-
-	// Verify manual trigger still exists
-	if !triggerExists(t, Namespace, manualTriggerName) {
-		t.Fatal("Manual trigger was deleted during sync - should have been preserved!")
-	}
-	t.Log("Manual trigger preserved after redeploy")
-
-	// Verify managed trigger still exists
-	managedTriggersAfter := listTriggersForFunction(t, Namespace, functionName)
-	if len(managedTriggersAfter) != 1 {
-		t.Fatalf("Expected 1 managed trigger after redeploy, got %d", len(managedTriggersAfter))
-	}
-	t.Log("Managed trigger still exists")
-}
-
-// TestMetadata_TriggerSyncAddSubscription verifies that new triggers are created
-// when subscriptions are added
-func TestMetadata_TriggerSyncAddSubscription(t *testing.T) {
-	brokerName := "default"
-	createBrokerWithCheck(t, Namespace, brokerName)
-
-	functionName := "func-e2e-test-trigger-sync-add"
-	root := fromCleanEnv(t, functionName)
-
-	// Create function
-	if err := newCmd(t, "init", "-l=go", "-t=http").Run(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Add one subscription
-	if err := newCmd(t, "subscribe",
-		"--source", "default",
-		"--filter", "type=order.created").Run(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Deploy with raw deployer
-	if err := newCmd(t, "deploy", "--deployer", "raw").Run(); err != nil {
-		t.Fatal(err)
-	}
-	defer clean(t, functionName, Namespace)
-
-	waitForDeployment(t, Namespace, functionName)
-
-	// Verify 1 trigger created
-	triggers := listTriggersForFunction(t, Namespace, functionName)
-	if len(triggers) != 1 {
-		t.Fatalf("Expected 1 trigger, got %d", len(triggers))
-	}
-	t.Logf("Initial deploy created 1 trigger: %v", triggers)
-
-	// Add another subscription by editing func.yaml
-	f, err := fn.NewFunction(root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	f.Deploy.Subscriptions = append(f.Deploy.Subscriptions, fn.KnativeSubscription{
-		Source: "default",
-		Filters: map[string]string{
-			"type": "order.shipped",
-		},
+		// Verify only 1 trigger remains
+		triggersAfter := listTriggersForFunction(t, Namespace, functionName)
+		if len(triggersAfter) != 1 {
+			t.Fatalf("Expected 1 trigger after removing subscription, got %d: %v", len(triggersAfter), triggersAfter)
+		}
+		t.Logf("Stale trigger deleted, 1 trigger remains: %v", triggersAfter)
 	})
-	if err := f.Write(); err != nil {
-		t.Fatal(err)
-	}
 
-	// Redeploy
-	if err := newCmd(t, "deploy", "--deployer", "raw").Run(); err != nil {
-		t.Fatal(err)
-	}
+	// Manual-trigger-preservation: manually created triggers (without the
+	// managed-by annotation) are NOT deleted during sync.
+	t.Run("Manual-trigger-preservation", func(t *testing.T) {
+		setSubscriptions(t, subCreated)
+		waitForDeployment(t, Namespace, functionName)
 
-	time.Sleep(5 * time.Second)
+		// Create a manual trigger (without managed-by annotation)
+		manualTriggerName := fmt.Sprintf("%s-manual-trigger", functionName)
+		createManualTrigger(t, Namespace, manualTriggerName, functionName, brokerName)
 
-	// Verify 2 triggers now exist
-	triggersAfter := listTriggersForFunction(t, Namespace, functionName)
-	if len(triggersAfter) != 2 {
-		t.Fatalf("Expected 2 triggers after adding subscription, got %d: %v", len(triggersAfter), triggersAfter)
-	}
-	t.Logf("New trigger created, 2 triggers total: %v", triggersAfter)
-}
+		// Verify we have 1 managed trigger and at least 2 total (managed + manual)
+		allTriggers := listAllTriggers(t, Namespace)
+		managedTriggers := listTriggersForFunction(t, Namespace, functionName)
+		if len(managedTriggers) != 1 {
+			t.Fatalf("Expected 1 managed trigger, got %d", len(managedTriggers))
+		}
+		if len(allTriggers) < 2 {
+			t.Fatalf("Expected at least 2 total triggers (managed + manual), got %d", len(allTriggers))
+		}
+		t.Logf("Created manual trigger: %s", manualTriggerName)
 
-// TestMetadata_TriggerSyncIdempotency verifies that repeated deploys with the same
-// subscriptions don't create duplicate triggers
-func TestMetadata_TriggerSyncIdempotency(t *testing.T) {
-	brokerName := "default"
-	createBrokerWithCheck(t, Namespace, brokerName)
+		// Redeploy (no changes to subscriptions)
+		if err := newCmd(t, "deploy", "--deployer", "raw").Run(); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(5 * time.Second)
 
-	functionName := "func-e2e-test-trigger-sync-idempotent"
-	root := fromCleanEnv(t, functionName)
+		// Verify manual trigger still exists
+		if !triggerExists(t, Namespace, manualTriggerName) {
+			t.Fatal("Manual trigger was deleted during sync - should have been preserved!")
+		}
+		t.Log("Manual trigger preserved after redeploy")
 
-	// Create function
-	if err := newCmd(t, "init", "-l=go", "-t=http").Run(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Add first subscription
-	if err := newCmd(t, "subscribe",
-		"--source", "default",
-		"--filter", "type=order.created").Run(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Add second subscription by editing func.yaml
-	f, err := fn.NewFunction(root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	f.Deploy.Subscriptions = append(f.Deploy.Subscriptions, fn.KnativeSubscription{
-		Source: "default",
-		Filters: map[string]string{
-			"type": "order.updated",
-		},
+		// Verify managed trigger still exists
+		managedTriggersAfter := listTriggersForFunction(t, Namespace, functionName)
+		if len(managedTriggersAfter) != 1 {
+			t.Fatalf("Expected 1 managed trigger after redeploy, got %d", len(managedTriggersAfter))
+		}
+		t.Log("Managed trigger still exists")
 	})
-	if err := f.Write(); err != nil {
-		t.Fatal(err)
-	}
 
-	// Deploy with raw deployer
-	if err := newCmd(t, "deploy", "--deployer", "raw").Run(); err != nil {
-		t.Fatal(err)
-	}
-	defer clean(t, functionName, Namespace)
+	// Add-subscription: new triggers are created when subscriptions are added.
+	t.Run("Add-subscription", func(t *testing.T) {
+		setSubscriptions(t, subCreated)
+		waitForDeployment(t, Namespace, functionName)
 
-	waitForDeployment(t, Namespace, functionName)
+		// Verify 1 trigger created
+		triggers := listTriggersForFunction(t, Namespace, functionName)
+		if len(triggers) != 1 {
+			t.Fatalf("Expected 1 trigger, got %d", len(triggers))
+		}
+		t.Logf("Initial deploy created 1 trigger: %v", triggers)
 
-	// Verify 2 triggers created
-	triggers := listTriggersForFunction(t, Namespace, functionName)
-	if len(triggers) != 2 {
-		t.Fatalf("Expected 2 triggers, got %d", len(triggers))
-	}
-	initialTriggers := make([]string, len(triggers))
-	copy(initialTriggers, triggers)
-	t.Logf("Initial triggers: %v", initialTriggers)
+		// Add another subscription and redeploy
+		setSubscriptions(t, subCreated, subShipped)
+		time.Sleep(5 * time.Second)
 
-	// Redeploy multiple times
-	for i := 1; i <= 3; i++ {
-		t.Logf("Redeploy #%d", i)
+		// Verify 2 triggers now exist
+		triggersAfter := listTriggersForFunction(t, Namespace, functionName)
+		if len(triggersAfter) != 2 {
+			t.Fatalf("Expected 2 triggers after adding subscription, got %d: %v", len(triggersAfter), triggersAfter)
+		}
+		t.Logf("New trigger created, 2 triggers total: %v", triggersAfter)
+	})
+
+	// Idempotency: repeated deploys with the same subscriptions don't create
+	// duplicate triggers and don't change trigger names.
+	t.Run("Idempotency", func(t *testing.T) {
+		setSubscriptions(t, subCreated, subUpdated)
+		waitForDeployment(t, Namespace, functionName)
+
+		// Verify 2 triggers created
+		triggers := listTriggersForFunction(t, Namespace, functionName)
+		if len(triggers) != 2 {
+			t.Fatalf("Expected 2 triggers, got %d", len(triggers))
+		}
+		initialTriggers := make([]string, len(triggers))
+		copy(initialTriggers, triggers)
+		t.Logf("Initial triggers: %v", initialTriggers)
+
+		// One redeploy is sufficient to exercise the create-then-no-op
+		// (AlreadyExists-tolerated) cluster path; trigger-name determinism is
+		// already exhaustively unit-tested (pkg/k8s/deployer_test.go:157-333),
+		// so the previous ×3 loop is reduced to ×1.
 		if err := newCmd(t, "deploy", "--deployer", "raw").Run(); err != nil {
 			t.Fatal(err)
 		}
@@ -294,101 +178,50 @@ func TestMetadata_TriggerSyncIdempotency(t *testing.T) {
 
 		triggersAfter := listTriggersForFunction(t, Namespace, functionName)
 		if len(triggersAfter) != 2 {
-			t.Fatalf("Redeploy #%d: Expected 2 triggers, got %d: %v", i, len(triggersAfter), triggersAfter)
+			t.Fatalf("Redeploy: Expected 2 triggers, got %d: %v", len(triggersAfter), triggersAfter)
 		}
 
 		// Verify trigger names haven't changed
 		if !equalStringSlices(initialTriggers, triggersAfter) {
-			t.Fatalf("Redeploy #%d: Trigger names changed! Initial: %v, After: %v", i, initialTriggers, triggersAfter)
+			t.Fatalf("Redeploy: Trigger names changed! Initial: %v, After: %v", initialTriggers, triggersAfter)
 		}
-	}
-	t.Log("Idempotency verified: 3 redeploys produced same triggers")
-}
-
-// TestMetadata_TriggerSyncRemoveAllSubscriptions verifies that all managed triggers
-// are deleted when all subscriptions are removed
-func TestMetadata_TriggerSyncRemoveAllSubscriptions(t *testing.T) {
-	brokerName := "default"
-	createBrokerWithCheck(t, Namespace, brokerName)
-
-	functionName := "func-e2e-test-trigger-sync-remove-all"
-	root := fromCleanEnv(t, functionName)
-
-	// Create function
-	if err := newCmd(t, "init", "-l=go", "-t=http").Run(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Add first subscription
-	if err := newCmd(t, "subscribe",
-		"--source", "default",
-		"--filter", "type=order.created").Run(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Add second subscription by editing func.yaml
-	f, err := fn.NewFunction(root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	f.Deploy.Subscriptions = append(f.Deploy.Subscriptions, fn.KnativeSubscription{
-		Source: "default",
-		Filters: map[string]string{
-			"type": "order.updated",
-		},
+		t.Log("Idempotency verified: redeploy produced same triggers")
 	})
-	if err := f.Write(); err != nil {
-		t.Fatal(err)
-	}
 
-	// Deploy with raw deployer
-	if err := newCmd(t, "deploy", "--deployer", "raw").Run(); err != nil {
-		t.Fatal(err)
-	}
-	defer clean(t, functionName, Namespace)
+	// Remove-all: all managed triggers are deleted when all subscriptions are
+	// removed, while a manual trigger is preserved.
+	t.Run("Remove-all", func(t *testing.T) {
+		setSubscriptions(t, subCreated, subUpdated)
+		waitForDeployment(t, Namespace, functionName)
 
-	waitForDeployment(t, Namespace, functionName)
+		// Verify 2 triggers created
+		triggers := listTriggersForFunction(t, Namespace, functionName)
+		if len(triggers) != 2 {
+			t.Fatalf("Expected 2 triggers, got %d", len(triggers))
+		}
+		t.Logf("Initial triggers: %v", triggers)
 
-	// Verify 2 triggers created
-	triggers := listTriggersForFunction(t, Namespace, functionName)
-	if len(triggers) != 2 {
-		t.Fatalf("Expected 2 triggers, got %d", len(triggers))
-	}
-	t.Logf("Initial triggers: %v", triggers)
+		// Create a manual trigger for comparison
+		manualTriggerName := fmt.Sprintf("%s-manual", functionName)
+		createManualTrigger(t, Namespace, manualTriggerName, functionName, brokerName)
 
-	// Create a manual trigger for comparison
-	manualTriggerName := fmt.Sprintf("%s-manual", functionName)
-	createManualTrigger(t, Namespace, manualTriggerName, functionName, brokerName)
+		// Remove all subscriptions and redeploy
+		setSubscriptions(t)
+		time.Sleep(5 * time.Second)
 
-	// Remove all subscriptions by editing func.yaml directly
-	f, err = fn.NewFunction(root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	f.Deploy.Subscriptions = []fn.KnativeSubscription{}
-	if err := f.Write(); err != nil {
-		t.Fatal(err)
-	}
+		// Verify no managed triggers remain
+		managedTriggersAfter := listTriggersForFunction(t, Namespace, functionName)
+		if len(managedTriggersAfter) != 0 {
+			t.Fatalf("Expected 0 managed triggers after removing all subscriptions, got %d: %v", len(managedTriggersAfter), managedTriggersAfter)
+		}
+		t.Log("All managed triggers deleted")
 
-	// Redeploy
-	if err := newCmd(t, "deploy", "--deployer", "raw").Run(); err != nil {
-		t.Fatal(err)
-	}
-
-	time.Sleep(5 * time.Second)
-
-	// Verify no managed triggers remain
-	managedTriggersAfter := listTriggersForFunction(t, Namespace, functionName)
-	if len(managedTriggersAfter) != 0 {
-		t.Fatalf("Expected 0 managed triggers after removing all subscriptions, got %d: %v", len(managedTriggersAfter), managedTriggersAfter)
-	}
-	t.Log("All managed triggers deleted")
-
-	// Verify manual trigger still exists
-	if !triggerExists(t, Namespace, manualTriggerName) {
-		t.Fatal("Manual trigger was deleted - should have been preserved!")
-	}
-	t.Log("Manual trigger preserved")
+		// Verify manual trigger still exists
+		if !triggerExists(t, Namespace, manualTriggerName) {
+			t.Fatal("Manual trigger was deleted - should have been preserved!")
+		}
+		t.Log("Manual trigger preserved")
+	})
 }
 
 // Helper functions

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -90,7 +90,12 @@ allocate_cluster() {
   ( set -o pipefail; registry 2>&1 | sed  -e 's/^/reg /') &
   ( set -o pipefail; dapr_runtime 2>&1 | sed  -e 's/^/dpr /')&
   ( set -o pipefail; (tekton && pac) 2>&1 | sed  -e 's/^/tkt /')&
-  ( set -o pipefail; (keda && keda_http_addon) 2>&1 | sed  -e 's/^/keda /')&
+  # KEDA is opt-out (default on). Skipped when FUNC_CLUSTER_KEDA=false to free
+  # CPU reservation for jobs that don't use it (e.g. Core/Metadata/Remote e2e).
+  # FUNC_CLUSTER_KEDA is the same env var bound by `func cluster create --keda`.
+  if [ "${FUNC_CLUSTER_KEDA:-true}" = "true" ]; then
+    ( set -o pipefail; (keda && keda_http_addon) 2>&1 | sed  -e 's/^/keda /')&
+  fi
   ( set -o pipefail; func_operator 2>&1 | sed  -e 's/^/fop /')&
 
   local job


### PR DESCRIPTION
- test `Remote_Update` mimics the local deploy -> update function -> re-deploy to make sure we cover that scenario for direct deploy as well
- test `TriggerSync` was simplified using 1 function and updating the subscriptions (fewer resources, faster, simpler test)
- Few days ago I added explicit instanced tests but forgot we use the explicit test Prefixes that are run as part of the general e2e suite, just a fix to make that part of `TestCore` -- what it does: two sequential requests, assert the second count is greater than the first to prove state persistance

Had to also add an optional keda removal for `C/M/R job` - e2e test (Core|Metadata|Remote) because we were hitting the CPU usage max 4000m that github CI provisions. removing keda (since its not used in any of the e2e C/M/D tests reduces that by 1000m :nice:) 