### PR TITLE
fix(ci): make git describe robust against shallow checkouts

### DIFF
--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -38,6 +38,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: knative/actions/setup-go@main
 
       - name: Check and Lint
@@ -72,6 +74,8 @@ jobs:
         run: git config --global core.autocrlf false
 
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: knative/actions/setup-go@main
 
       - name: Run Unit Tests
@@ -109,6 +113,8 @@ jobs:
         run: git config --global core.autocrlf false
 
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: knative/actions/setup-go@main
 
         # Toolchains
@@ -150,6 +156,8 @@ jobs:
       KUBECONFIG: ${{github.workspace}}/hack/bin/kubeconfig.yaml
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: knative/actions/setup-go@main
       - uses: endersonmenezes/free-disk-space@v3
         with:
@@ -211,6 +219,8 @@ jobs:
       FUNC_CLUSTER_KEDA: "false" # these tests don't use KEDA; skip it to free cluster CPU (PR #3914 'Insufficient cpu')
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: knative/actions/setup-go@main
       - uses: endersonmenezes/free-disk-space@v3
         with:
@@ -272,6 +282,8 @@ jobs:
       FUNC_E2E_VERBOSE: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: knative/actions/setup-go@main
 
       - uses: endersonmenezes/free-disk-space@v3
@@ -341,6 +353,8 @@ jobs:
       FUNC_E2E_MATRIX_RUNTIMES: ${{ matrix.runtime }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: knative/actions/setup-go@main
       - uses: endersonmenezes/free-disk-space@v3
         with:
@@ -419,6 +433,8 @@ jobs:
       FUNC_E2E_VERBOSE: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: knative/actions/setup-go@main
       - uses: endersonmenezes/free-disk-space@v3
         with:
@@ -476,6 +492,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: knative/actions/setup-go@main
       - name: Build Platform Binaries
         run: make cross-platform
@@ -522,6 +540,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: knative/actions/setup-go@main
       - uses: docker/setup-qemu-action@v3
       - name: Login to GitHub Container Registry
@@ -565,6 +585,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: knative/actions/setup-go@main
       - uses: imjasonh/setup-ko@v0.6
       - run: ko build --platform=linux/ppc64le,linux/s390x,linux/amd64,linux/arm64 -B ./cmd/func

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ BIN_GOIMPORTS     ?= "$(PWD)/bin/goimports"
 HASH         := $(shell git rev-parse --short HEAD 2>/dev/null)
 VTAG         := $(shell git tag --points-at HEAD | head -1)
 VTAG         := $(shell [ -z $(VTAG) ] && echo $(ETAG) || echo $(VTAG))
-VERS         ?= $(shell git describe --tags --match 'v*')
-KVER         ?= $(shell git describe --tags --match 'knative-*')
+VERS         ?= $(shell git describe --tags --match 'v*' 2>/dev/null || echo "v0.0.0")
+KVER         ?= $(shell git describe --tags --match 'knative-*' 2>/dev/null || echo "knative-v0.0.0")
 
 LDFLAGS      := -X knative.dev/func/pkg/version.Vers=$(VERS) -X knative.dev/func/pkg/version.Kver=$(KVER) -X knative.dev/func/pkg/version.Hash=$(HASH)
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -37,8 +37,8 @@ function build_release() {
       go_module_version="v0.$(( $(minor_version "$TAG") + 27 )).$(patch_version "$TAG")"
     fi
   else
-    knative_version="$(git describe --tags --match 'knative-*')"
-    go_module_version="$(git describe --tags --match 'v*')"
+    knative_version="$(git describe --tags --match 'knative-*' 2>/dev/null || git rev-parse --short HEAD)"
+    go_module_version="$(git describe --tags --match 'v*' 2>/dev/null || git rev-parse --short HEAD)"
   fi
   VERS="${go_module_version}" KVER="${knative_version}" make cross-platform
 


### PR DESCRIPTION
# Changes

- :bug: Make `git describe` resilient to shallow checkouts so the version string is never empty

While working on #3913 I noticed the `E2E - Core, Metadata, and Remote` check kept failing on a change that was completely unrelated to it (just an extension map iteration cleanup). Digging into the logs of the failing run (job 83049870138), the actual cause turned out to be in CI itself, not the PR.

`actions/checkout` does a shallow clone by default and doesn't fetch tags. Because of that, `git describe --tags --match 'v*'` exits with status 128 and the version ends up empty. That empty version flows into the image tags, so the e2e tests later fail looking up an image that was never built under the expected name — which is why `TestCore_PythonUserDepsRemote` reports "image not found".

This PR fixes the root cause rather than the symptom:

- Set `fetch-depth: 0` on all `actions/checkout@v4` steps so tags are actually available when `git describe` runs.
- Add a safe fallback in `Makefile` and `hack/release.sh` so the version degrades to a commit SHA (or a placeholder) instead of being empty if no matching tag is found.

This should unblock e2e on PRs like #3913 that don't touch CI but were failing because of it.

/kind bug

Relates to #3913

**Release Note**
```release-note
NONE
```

**Docs**
```docs
NONE
```