### PR TITLE
Let KEDA functions scale to zero

### DIFF
--- a/pkg/keda/deployer.go
+++ b/pkg/keda/deployer.go
@@ -147,7 +147,7 @@ func (d *Deployer) httpScaledObject(f fn.Function, namespace string, deployment 
 
 	annotations := deployer.GenerateCommonAnnotations(f, d.decorator, false /*we don't care about dapr for the HttpScaledObject*/, KedaDeployerName)
 
-	minScale := int32(1)
+	minScale := int32(0)
 	maxScale := int32(10)
 	if scaleOptions := f.Deploy.Options.Scale; scaleOptions != nil {
 		if scaleOptions.Min != nil {

--- a/pkg/keda/deployer_test.go
+++ b/pkg/keda/deployer_test.go
@@ -1,0 +1,77 @@
+package keda
+
+import (
+	"testing"
+
+	httpv1alpha1 "github.com/kedacore/http-add-on/operator/apis/http/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	fn "knative.dev/func/pkg/functions"
+)
+
+func TestHTTPScaledObjectDefaultsMinReplicasToZero(t *testing.T) {
+	httpScaledObject := newTestHTTPScaledObject(t, fn.Function{})
+
+	if httpScaledObject.Spec.Replicas == nil || httpScaledObject.Spec.Replicas.Min == nil {
+		t.Fatal("expected replicas.min to be set")
+	}
+
+	if got := *httpScaledObject.Spec.Replicas.Min; got != 0 {
+		t.Fatalf("expected replicas.min to default to 0, got %d", got)
+	}
+}
+
+func TestHTTPScaledObjectUsesConfiguredMinReplicas(t *testing.T) {
+	minScale := int64(1)
+	httpScaledObject := newTestHTTPScaledObject(t, fn.Function{
+		Deploy: fn.DeploySpec{
+			Options: fn.Options{
+				Scale: &fn.ScaleOptions{
+					Min: &minScale,
+				},
+			},
+		},
+	})
+
+	if httpScaledObject.Spec.Replicas == nil || httpScaledObject.Spec.Replicas.Min == nil {
+		t.Fatal("expected replicas.min to be set")
+	}
+
+	if got := *httpScaledObject.Spec.Replicas.Min; got != int32(minScale) {
+		t.Fatalf("expected replicas.min to use configured value %d, got %d", minScale, got)
+	}
+}
+
+func newTestHTTPScaledObject(t *testing.T, f fn.Function) *httpv1alpha1.HTTPScaledObject {
+	t.Helper()
+
+	f.Name = "test-function"
+	f.Runtime = "go"
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-function",
+			UID:  types.UID("test-uid"),
+		},
+	}
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-function",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Port: 8080},
+			},
+		},
+	}
+
+	httpScaledObject, err := NewDeployer().httpScaledObject(f, "default", deployment, service, []string{"test-function.default.svc"})
+	if err != nil {
+		t.Fatalf("httpScaledObject() error = %v", err)
+	}
+
+	return httpScaledObject
+}


### PR DESCRIPTION
Title: Let KEDA functions scale to zero by default

## Why

The KEDA deployer currently defaults `minReplicaCount` to `1` when generating the `HTTPScaledObject`. That keeps at least one function pod running even when there is no traffic, so functions cannot scale to zero by default.

KEDA's HTTP add-on supports waking the function back up through the interceptor, and users who want to avoid cold-start latency can still set `scale.min: 1` explicitly.

Fixes #3924.

## What changed

- Default the KEDA deployer's generated `replicas.min` value to `0`.
- Keep honoring an explicit `deploy.options.scale.min` value.
- Add regression coverage for both the default and configured minimum replica behavior.

## Testing

- `go test -count=1 ./pkg/keda`