### PR TITLE
fix(cmd): reject malformed subscribe filters

### DIFF
--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -58,26 +58,23 @@ func runSubscribe(cmd *cobra.Command) (err error) {
 		return fmt.Errorf("no function found in current directory.\nYou need to be inside a function directory to subscribe to events.\n\nTry this:\n  func create --language go myfunction    Create a new function\n  cd myfunction                          Go into the function directory\n  func subscribe --filter type=example   Subscribe to events\n\nOr if you have an existing function:\n  cd path/to/your/function              Go to your function directory\n  func subscribe --filter type=example  Subscribe to events")
 	}
 
-	// add subscription	to function
-	f.Deploy.Subscriptions = updateOrAddSubscription(f.Deploy.Subscriptions, cfg)
+	if f.Deploy.Subscriptions, err = updateOrAddSubscription(f.Deploy.Subscriptions, cfg); err != nil {
+		return err
+	}
 
-	// pump it
 	return f.Write()
 }
 
-func extractFilterMap(filters []string) map[string]string {
+func extractFilterMap(filters []string) (map[string]string, error) {
 	subscriptionFilters := make(map[string]string)
 	for _, filter := range filters {
-		kv := strings.Split(filter, "=")
-		if len(kv) != 2 {
-			fmt.Println("Invalid pair:", filter)
-			continue
+		key, value, found := strings.Cut(filter, "=")
+		if !found || strings.TrimSpace(key) == "" {
+			return nil, fmt.Errorf("invalid --filter %q: must be in key=value format", filter)
 		}
-		key := kv[0]
-		value := kv[1]
 		subscriptionFilters[key] = value
 	}
-	return subscriptionFilters
+	return subscriptionFilters, nil
 }
 
 type subscibeConfig struct {
@@ -85,10 +82,12 @@ type subscibeConfig struct {
 	Source string
 }
 
-func updateOrAddSubscription(subscriptions []fn.KnativeSubscription, cfg subscibeConfig) []fn.KnativeSubscription {
+func updateOrAddSubscription(subscriptions []fn.KnativeSubscription, cfg subscibeConfig) ([]fn.KnativeSubscription, error) {
 	found := false
-	newFilters := extractFilterMap(cfg.Filter)
-
+	newFilters, err := extractFilterMap(cfg.Filter)
+	if err != nil {
+		return nil, err
+	}
 	// Iterate over subscriptions to find if one with the same source already exists
 	for i, subscription := range subscriptions {
 		if subscription.Source == cfg.Source {
@@ -114,7 +113,7 @@ func updateOrAddSubscription(subscriptions []fn.KnativeSubscription, cfg subscib
 			Filters: newFilters,
 		})
 	}
-	return subscriptions
+	return subscriptions, nil
 }
 
 func newSubscribeConfig(cmd *cobra.Command) (c subscibeConfig) {

--- a/cmd/subscribe_test.go
+++ b/cmd/subscribe_test.go
@@ -286,3 +286,54 @@ func TestSubscribeWithDuplicated(t *testing.T) {
 	}
 
 }
+
+func TestSubscribeRejectsMalformedFilter(t *testing.T) {
+	root := FromTempDirectory(t)
+
+	_, err := fn.New().Init(fn.Function{Runtime: "go", Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewSubscribeCmd()
+	cmd.SetArgs([]string{"--filter", "badfilter"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected malformed filter error")
+	}
+
+	f, err := fn.NewFunction(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Deploy.Subscriptions) != 0 {
+		t.Fatalf("expected no subscription to be written, got %d", len(f.Deploy.Subscriptions))
+	}
+}
+
+func TestSubscribeAllowsFilterValuesContainingEquals(t *testing.T) {
+	root := FromTempDirectory(t)
+
+	_, err := fn.New().Init(fn.Function{Runtime: "go", Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewSubscribeCmd()
+	cmd.SetArgs([]string{"--filter", "foo=bar=baz"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := fn.NewFunction(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Deploy.Subscriptions) != 1 {
+		t.Fatalf("expected one subscription, got %d", len(f.Deploy.Subscriptions))
+	}
+	if f.Deploy.Subscriptions[0].Filters["foo"] != "bar=baz" {
+		t.Fatalf("expected filter value 'bar=baz', got %q", f.Deploy.Subscriptions[0].Filters["foo"])
+	}
+}


### PR DESCRIPTION
Fixes #3941

## Why

`func subscribe --filter` currently prints malformed filter values and continues, which can write a subscription without the intended filter.

## What changed

- return an error for malformed `--filter` values
- preserve valid filter values containing `=`
- add regression tests for both paths

## Testing

- `gofmt -w cmd/subscribe.go cmd/subscribe_test.go`
- `git diff --check`
- Added regression tests in `cmd/subscribe_test.go`

Note: focused `go test ./cmd -run 'TestSubscribe(RejectsMalformedFilter|AllowsFilterValuesContainingEquals)' -count=1 -v` was attempted locally on Windows but timed out before package output. CI should run the tests normally.
