### PR TITLE
Migrate non-Knative Ingress resources to Gateway API HTTPRoute

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	knative.dev/pkg v0.0.0-20260622140654-39ebae2ee2dc
 	knative.dev/serving v0.49.1-0.20260624144117-dbce551f802c
 	sigs.k8s.io/controller-runtime v0.23.3
+	sigs.k8s.io/gateway-api v1.4.1
 )
 
 require (
@@ -319,7 +320,6 @@ require (
 	k8s.io/cli-runtime v0.34.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	knative.dev/networking v0.0.0-20260616021346-d4e13b76b133 // indirect
-	sigs.k8s.io/gateway-api v1.4.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.0 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.21.0 // indirect

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -255,15 +255,37 @@ networking() {
   echo "${blue}Installing Ingress Controller (Contour)${reset}"
   echo "Version: ${contour_version}"
 
+  echo "Installing Gateway API CRDs."
+  $KUBECTL apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${gateway_api_version}/standard-install.yaml"
+  $KUBECTL wait --for=condition=Established --all crd --timeout=5m
+
   echo "Installing a configured Contour."
   curl -sSL "https://github.com/knative/net-contour/releases/download/knative-${contour_version}/contour.yaml" \
     | $YQ '(select(.kind == "Deployment" and .metadata.name == "contour").spec.template.spec.containers[0].args[] | select(. == "--xds-address=0.0.0.0")) = "--xds-address=::"' \
     | $YQ '(select(.kind == "Deployment" and .metadata.name == "contour").spec.template.spec.containers[0].args)
-          += ["--envoy-service-http-address=::", "--envoy-service-https-address=::", "--stats-address=::"]' \
+          += ["--envoy-service-http-address=::", "--envoy-service-https-address=::", "--stats-address=::", "--gateway-ref=contour-external/contour-gateway"]' \
     | $KUBECTL apply -f -
 
   sleep 5
   $KUBECTL wait pod --for=condition=Ready -l '!job-name' -n contour-external --timeout=10m
+
+  echo "Creating shared Gateway."
+  $KUBECTL apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: contour-gateway
+  namespace: contour-external
+spec:
+  gatewayClassName: contour
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+EOF
 
   echo "Installing the Knative Contour controller."
   $KUBECTL apply -f "https://github.com/knative/net-contour/releases/download/knative-${contour_version}/net-contour.yaml"
@@ -314,24 +336,20 @@ eventing() {
   local -r broker_host="${FUNC_E2E_BROKER_HOST:-broker.localtest.me}"
   echo "Exposing broker at ${broker_host}"
   $KUBECTL apply -f - <<EOF
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
 metadata:
   name: broker-ingress
   namespace: knative-eventing
 spec:
-  ingressClassName: contour-external
+  parentRefs:
+    - name: contour-gateway
+      namespace: contour-external
+  hostnames: ["${broker_host}"]
   rules:
-    - host: ${broker_host}
-      http:
-        paths:
-          - backend:
-              service:
-                name: broker-ingress
-                port:
-                  number: 80
-            pathType: Prefix
-            path: /
+    - backendRefs:
+        - name: broker-ingress
+          port: 80
 EOF
 
   echo "${green}✅ Eventing${reset}"
@@ -382,24 +400,20 @@ spec:
   - port: 5000
     targetPort: 5000
 ---
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
 metadata:
   name: registry
   namespace: default
 spec:
-  ingressClassName: contour-external
+  parentRefs:
+    - name: contour-gateway
+      namespace: contour-external
+  hostnames: ["registry.localtest.me"]
   rules:
-  - host: registry.localtest.me
-    http:
-      paths:
-      - backend:
-          service:
-            name: registry
-            port:
-              number: 5000
-        pathType: Prefix
-        path: /
+    - backendRefs:
+        - name: registry
+          port: 5000
 EOF
 
   $KUBECTL apply -f - <<EOF
@@ -612,26 +626,22 @@ pac() {
   sleep 5
   $KUBECTL wait pod --for=condition=Ready -l '!job-name' -n pipelines-as-code --timeout=5m
 
-  # Install ingress for the PaC controller. This is used by VCS Webhooks.
+  # Install HTTPRoute for the PaC controller. This is used by VCS Webhooks.
   $KUBECTL apply -f - << EOF
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
 metadata:
   name: pipelines-as-code
   namespace: pipelines-as-code
 spec:
-  ingressClassName: contour-external
+  parentRefs:
+    - name: contour-gateway
+      namespace: contour-external
+  hostnames: ["${pac_ctr_host}"]
   rules:
-  - host: ${pac_ctr_host}
-    http:
-      paths:
-      - backend:
-          service:
-            name: pipelines-as-code-controller
-            port:
-              number: 8080
-        pathType: Prefix
-        path: /
+    - backendRefs:
+        - name: pipelines-as-code-controller
+          port: 8080
 EOF
   echo "the Pipeline as Code controller is available at: http://${pac_ctr_host}"
   echo "${green}✅ PAC${reset}"

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -256,21 +256,30 @@ networking() {
   echo "Version: ${contour_version}"
 
   echo "Installing Gateway API CRDs."
-  $KUBECTL apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${gateway_api_version}/standard-install.yaml"
+  $KUBECTL apply --server-side -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${gateway_api_version}/experimental-install.yaml"
   $KUBECTL wait --for=condition=Established --all crd --timeout=5m
 
   echo "Installing a configured Contour."
   curl -sSL "https://github.com/knative/net-contour/releases/download/knative-${contour_version}/contour.yaml" \
     | $YQ '(select(.kind == "Deployment" and .metadata.name == "contour").spec.template.spec.containers[0].args[] | select(. == "--xds-address=0.0.0.0")) = "--xds-address=::"' \
     | $YQ '(select(.kind == "Deployment" and .metadata.name == "contour").spec.template.spec.containers[0].args)
-          += ["--envoy-service-http-address=::", "--envoy-service-https-address=::", "--stats-address=::", "--gateway-ref=contour-external/contour-gateway"]' \
+          += ["--envoy-service-http-address=::", "--envoy-service-https-address=::", "--stats-address=::"]' \
+    | $YQ '(select(.kind == "ConfigMap" and .metadata.name == "contour" and .metadata.namespace == "contour-external").data."contour.yaml")
+          |= . + "\ngateway:\n  gatewayRef:\n    namespace: contour-external\n    name: contour-gateway\n"' \
     | $KUBECTL apply -f -
 
   sleep 5
   $KUBECTL wait pod --for=condition=Ready -l '!job-name' -n contour-external --timeout=10m
 
-  echo "Creating shared Gateway."
+  echo "Creating GatewayClass and shared Gateway."
   $KUBECTL apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: contour
+spec:
+  controllerName: projectcontour.io/contour
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -85,6 +85,12 @@ allocate_cluster() {
   echo "fop:  Func Operator"
   echo ""
 
+  # Install Gateway API CRDs first — they must exist before any HTTPRoute
+  # can be created, so this runs before the parallel block.
+  echo "${blue}Installing Gateway API CRDs${reset}"
+  $KUBECTL apply --server-side -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${gateway_api_version}/experimental-install.yaml"
+  $KUBECTL wait --for=condition=Established --all crd --timeout=5m
+
   ( set -o pipefail; (serving && dns && networking) 2>&1 | sed  -e 's/^/svr /')&
   ( set -o pipefail; (eventing && namespace) 2>&1 | sed  -e 's/^/evt /')&
   ( set -o pipefail; registry 2>&1 | sed  -e 's/^/reg /') &
@@ -254,10 +260,6 @@ EOF
 networking() {
   echo "${blue}Installing Ingress Controller (Contour)${reset}"
   echo "Version: ${contour_version}"
-
-  echo "Installing Gateway API CRDs."
-  $KUBECTL apply --server-side -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${gateway_api_version}/experimental-install.yaml"
-  $KUBECTL wait --for=condition=Established --all crd --timeout=5m
 
   echo "Installing a configured Contour."
   curl -sSL "https://github.com/knative/net-contour/releases/download/knative-${contour_version}/contour.yaml" \

--- a/hack/component-versions.json
+++ b/hack/component-versions.json
@@ -4,6 +4,9 @@
 		"owner": "knative-extensions",
 		"repo": "net-contour"
 	},
+	"GatewayAPI": {
+		"version": "v1.4.1"
+	},
 	"Eventing": {
 		"version": "v1.22.2",
 		"owner": "knative",

--- a/hack/component-versions.sh
+++ b/hack/component-versions.sh
@@ -11,6 +11,7 @@ set_versions() {
 	kind_node_version=v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
 
 	# find source-of-truth in component-versions.json to add/modify components
+	gateway_api_version="v1.4.1"
 	knative_serving_version="v1.22.1"
 	knative_eventing_version="v1.22.2"
 	contour_version="v1.22.2"

--- a/hack/git-server.sh
+++ b/hack/git-server.sh
@@ -28,11 +28,13 @@ git_server() {
   namespace="${namespace:-"default"}"
 
 
-  local ingress_class="contour-external"
+  local gateway_name="contour-gateway"
+  local gateway_namespace="contour-external"
   local cluster_domain="localtest.me"
   if kubectl api-versions | grep -q openshift.io; then
     cluster_domain="$(kubectl get ingresses.config/cluster -o jsonpath='{.spec.domain}')"
-    ingress_class="openshift-default"
+    gateway_name="openshift-default"
+    gateway_namespace="openshift-ingress"
   fi
 
 
@@ -69,24 +71,20 @@ spec:
       targetPort: http
   type: ClusterIP
 ---
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
 metadata:
   name: "${name}"
   namespace: "${namespace}"
 spec:
-  ingressClassName: "${ingress_class}"
+  parentRefs:
+    - name: "${gateway_name}"
+      namespace: "${gateway_namespace}"
+  hostnames: ["${func_git_host}"]
   rules:
-    - host: "${func_git_host}"
-      http:
-        paths:
-          - backend:
-              service:
-                name: "${name}"
-                port:
-                  number: 80
-            pathType: Prefix
-            path: /
+    - backendRefs:
+        - name: "${name}"
+          port: 80
 EOF
 
   echo "starting func-git service at: ${func_git_host}"

--- a/hack/gitlab.sh
+++ b/hack/gitlab.sh
@@ -181,24 +181,20 @@ spec:
       nodePort: 30022
   type: NodePort
 ---
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
 metadata:
   name: gitlab
   namespace: gitlab
 spec:
-  ingressClassName: contour-external
+  parentRefs:
+    - name: contour-gateway
+      namespace: contour-external
+  hostnames: ["${gitlab_host}"]
   rules:
-    - host: ${gitlab_host}
-      http:
-        paths:
-          - backend:
-              service:
-                name: gitlab-internal
-                port:
-                  number: 80
-            pathType: Prefix
-            path: /
+    - backendRefs:
+        - name: gitlab-internal
+          port: 80
 
 EOF
 

--- a/pkg/builders/builders_int_test.go
+++ b/pkg/builders/builders_int_test.go
@@ -489,11 +489,8 @@ func servePrivateGit(ctx context.Context, t *testing.T, certDir string) {
 	}
 
 	// Patch the shared Gateway to add an HTTPS listener for this test.
-	gw, err := gwClient.GatewayV1().Gateways(gwNamespace).Get(ctx, gwName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	gw.Spec.Listeners = append(gw.Spec.Listeners, gatewayv1.Listener{
+	// Filter out any stale listener with the same name first (idempotent).
+	httpsListener := gatewayv1.Listener{
 		Name:     gatewayv1.SectionName(listenerName),
 		Protocol: gatewayv1.HTTPSProtocolType,
 		Port:     443,
@@ -509,7 +506,12 @@ func servePrivateGit(ctx context.Context, t *testing.T, certDir string) {
 				From: ptr(gatewayv1.NamespacesFromAll),
 			},
 		},
-	})
+	}
+	gw, err := gwClient.GatewayV1().Gateways(gwNamespace).Get(ctx, gwName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.Spec.Listeners = replaceOrAppendListener(gw.Spec.Listeners, httpsListener)
 	_, err = gwClient.GatewayV1().Gateways(gwNamespace).Update(ctx, gw, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -517,6 +519,7 @@ func servePrivateGit(ctx context.Context, t *testing.T, certDir string) {
 	t.Cleanup(func() {
 		gw, err := gwClient.GatewayV1().Gateways(gwNamespace).Get(context.Background(), gwName, metav1.GetOptions{})
 		if err != nil {
+			t.Logf("warning: failed to get Gateway for listener cleanup: %v", err)
 			return
 		}
 		filtered := make([]gatewayv1.Listener, 0, len(gw.Spec.Listeners))
@@ -526,7 +529,9 @@ func servePrivateGit(ctx context.Context, t *testing.T, certDir string) {
 			}
 		}
 		gw.Spec.Listeners = filtered
-		_, _ = gwClient.GatewayV1().Gateways(gwNamespace).Update(context.Background(), gw, metav1.UpdateOptions{})
+		if _, err := gwClient.GatewayV1().Gateways(gwNamespace).Update(context.Background(), gw, metav1.UpdateOptions{}); err != nil {
+			t.Logf("warning: failed to remove HTTPS listener from Gateway: %v", err)
+		}
 	})
 
 	// Create HTTPRoute pointing at the git-private service.
@@ -535,8 +540,9 @@ func servePrivateGit(ctx context.Context, t *testing.T, certDir string) {
 		Spec: gatewayv1.HTTPRouteSpec{
 			CommonRouteSpec: gatewayv1.CommonRouteSpec{
 				ParentRefs: []gatewayv1.ParentReference{{
-					Name:      gatewayv1.ObjectName(gwName),
-					Namespace: ptr(gatewayv1.Namespace(gwNamespace)),
+					Name:        gatewayv1.ObjectName(gwName),
+					Namespace:   ptr(gatewayv1.Namespace(gwNamespace)),
+					SectionName: ptr(gatewayv1.SectionName(listenerName)),
 				}},
 			},
 			Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(host)},
@@ -556,6 +562,19 @@ func servePrivateGit(ctx context.Context, t *testing.T, certDir string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+// replaceOrAppendListener replaces an existing listener with the same name,
+// or appends the new listener if no match is found. This makes the Gateway
+// update idempotent — safe if a previous test cleanup left a stale listener.
+func replaceOrAppendListener(listeners []gatewayv1.Listener, l gatewayv1.Listener) []gatewayv1.Listener {
+	for i, existing := range listeners {
+		if existing.Name == l.Name {
+			listeners[i] = l
+			return listeners
+		}
+	}
+	return append(listeners, l)
 }
 
 func ptr[T any](val T) *T {

--- a/pkg/builders/builders_int_test.go
+++ b/pkg/builders/builders_int_test.go
@@ -26,9 +26,10 @@ import (
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/moby/moby/client"
 	coreV1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	"knative.dev/func/pkg/buildpacks"
 	fn "knative.dev/func/pkg/functions"
@@ -369,12 +370,26 @@ func buildPatchedBuilder(ctx context.Context, t *testing.T, tag, dockerfile, cer
 // The credentials are developer:nbusr123.
 func servePrivateGit(ctx context.Context, t *testing.T, certDir string) {
 	const (
-		name  = "git-private"
-		host  = "git-private.localtest.me"
-		image = "ghcr.io/matejvasek/git-private:latest"
+		name         = "git-private"
+		host         = "git-private.localtest.me"
+		image        = "ghcr.io/matejvasek/git-private:latest"
+		gwName       = "contour-gateway"
+		gwNamespace  = "contour-external"
+		listenerName = "https-git-private"
 	)
 
+	tlsSecretName := name + "-tls"
+
 	k8sClient, err := k8s.NewKubernetesClientset()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	restConfig, err := k8s.GetClientConfig().ClientConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gwClient, err := gatewayclient.NewForConfig(restConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,10 +416,11 @@ func servePrivateGit(ctx context.Context, t *testing.T, certDir string) {
 		t.Fatal(err)
 	}
 
-	secret := coreV1.Secret{
+	// Create TLS secret in the Gateway namespace so the HTTPS listener can reference it.
+	gwSecret := coreV1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: name,
+			Name:      tlsSecretName,
+			Namespace: gwNamespace,
 		},
 		Immutable: ptr(true),
 		Data: map[string][]byte{
@@ -413,11 +429,13 @@ func servePrivateGit(ctx context.Context, t *testing.T, certDir string) {
 		},
 		Type: coreV1.SecretTypeTLS,
 	}
-
-	_, err = k8sClient.CoreV1().Secrets(name).Create(ctx, &secret, metav1.CreateOptions{})
+	_, err = k8sClient.CoreV1().Secrets(gwNamespace).Create(ctx, &gwSecret, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		_ = k8sClient.CoreV1().Secrets(gwNamespace).Delete(context.Background(), tlsSecretName, metav1.DeleteOptions{})
+	})
 
 	pod := coreV1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -470,44 +488,71 @@ func servePrivateGit(ctx context.Context, t *testing.T, certDir string) {
 		t.Fatal(err)
 	}
 
-	ingress := v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: name,
+	// Patch the shared Gateway to add an HTTPS listener for this test.
+	gw, err := gwClient.GatewayV1().Gateways(gwNamespace).Get(ctx, gwName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw.Spec.Listeners = append(gw.Spec.Listeners, gatewayv1.Listener{
+		Name:     gatewayv1.SectionName(listenerName),
+		Protocol: gatewayv1.HTTPSProtocolType,
+		Port:     443,
+		Hostname: ptr(gatewayv1.Hostname(host)),
+		TLS: &gatewayv1.ListenerTLSConfig{
+			Mode: ptr(gatewayv1.TLSModeTerminate),
+			CertificateRefs: []gatewayv1.SecretObjectReference{
+				{Name: gatewayv1.ObjectName(tlsSecretName)},
+			},
 		},
-		Spec: v1.IngressSpec{
-			IngressClassName: ptr("contour-external"),
-			DefaultBackend:   nil,
-			TLS: []v1.IngressTLS{
-				{
-					Hosts:      []string{host},
-					SecretName: name,
-				},
+		AllowedRoutes: &gatewayv1.AllowedRoutes{
+			Namespaces: &gatewayv1.RouteNamespaces{
+				From: ptr(gatewayv1.NamespacesFromAll),
 			},
-			Rules: []v1.IngressRule{
-				{
-					Host: host,
-					IngressRuleValue: v1.IngressRuleValue{
-						HTTP: &v1.HTTPIngressRuleValue{Paths: []v1.HTTPIngressPath{
-							{
-								Path:     "/",
-								PathType: ptr(v1.PathTypePrefix),
-								Backend: v1.IngressBackend{
-									Service: &v1.IngressServiceBackend{
-										Name: name,
-										Port: v1.ServiceBackendPort{
-											Name: "http",
-										},
-									},
-								},
-							},
-						}},
+		},
+	})
+	_, err = gwClient.GatewayV1().Gateways(gwNamespace).Update(ctx, gw, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		gw, err := gwClient.GatewayV1().Gateways(gwNamespace).Get(context.Background(), gwName, metav1.GetOptions{})
+		if err != nil {
+			return
+		}
+		filtered := make([]gatewayv1.Listener, 0, len(gw.Spec.Listeners))
+		for _, l := range gw.Spec.Listeners {
+			if l.Name != gatewayv1.SectionName(listenerName) {
+				filtered = append(filtered, l)
+			}
+		}
+		gw.Spec.Listeners = filtered
+		_, _ = gwClient.GatewayV1().Gateways(gwNamespace).Update(context.Background(), gw, metav1.UpdateOptions{})
+	})
+
+	// Create HTTPRoute pointing at the git-private service.
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: name},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{
+					Name:      gatewayv1.ObjectName(gwName),
+					Namespace: ptr(gatewayv1.Namespace(gwNamespace)),
+				}},
+			},
+			Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(host)},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				BackendRefs: []gatewayv1.HTTPBackendRef{{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: gatewayv1.ObjectName(name),
+							Port: ptr(gatewayv1.PortNumber(80)),
+						},
 					},
-				},
-			},
+				}},
+			}},
 		},
 	}
-	_, err = k8sClient.NetworkingV1().Ingresses(name).Create(ctx, &ingress, metav1.CreateOptions{})
+	_, err = gwClient.GatewayV1().HTTPRoutes(name).Create(ctx, route, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cluster/create.go
+++ b/pkg/cluster/create.go
@@ -74,6 +74,12 @@ func allocateCluster(ctx context.Context, cfg ClusterConfig, out io.Writer) (err
 		return err
 	}
 
+	// Phase 1.5: Install Gateway API CRDs before the parallel block — all
+	// components that create HTTPRoute resources depend on these CRDs.
+	if err := installGatewayAPICRDs(ctx, cfg, out); err != nil {
+		return err
+	}
+
 	// Phase 2: Parallel component installation
 	status(out, "Beginning Cluster Configuration")
 	fmt.Fprintln(out, "Tasks will be executed in parallel.  Logs will be prefixed:")

--- a/pkg/cluster/eventing.go
+++ b/pkg/cluster/eventing.go
@@ -57,30 +57,26 @@ func installEventing(ctx context.Context, cfg ClusterConfig, out io.Writer) erro
 		return fmt.Errorf("waiting for mt-channel-broker: %w", err)
 	}
 
-	// Broker ingress
+	// Broker HTTPRoute
 	fmt.Fprintf(out, "Exposing broker at broker.%s\n", cfg.Domain)
-	brokerIngress := fmt.Sprintf(`apiVersion: networking.k8s.io/v1
-kind: Ingress
+	brokerRoute := fmt.Sprintf(`apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
 metadata:
   name: broker-ingress
   namespace: knative-eventing
 spec:
-  ingressClassName: contour-external
+  parentRefs:
+    - name: %s
+      namespace: %s
+  hostnames: ["broker.%s"]
   rules:
-    - host: broker.%s
-      http:
-        paths:
-          - backend:
-              service:
-                name: broker-ingress
-                port:
-                  number: 80
-            pathType: Prefix
-            path: /
-`, cfg.Domain)
+    - backendRefs:
+        - name: broker-ingress
+          port: 80
+`, gatewayName, gatewayNamespace, cfg.Domain)
 
-	if err := applyManifest(ctx, out, cfg, brokerIngress); err != nil {
-		return fmt.Errorf("applying broker ingress: %w", err)
+	if err := applyManifest(ctx, out, cfg, brokerRoute); err != nil {
+		return fmt.Errorf("applying broker HTTPRoute: %w", err)
 	}
 
 	success(out, "Eventing", time.Since(start))

--- a/pkg/cluster/serving.go
+++ b/pkg/cluster/serving.go
@@ -83,8 +83,8 @@ func installNetworking(ctx context.Context, cfg ClusterConfig, out io.Writer) er
 	fmt.Fprintf(out, "Version: %s\n", contourVersion)
 
 	fmt.Fprintln(out, "Installing Gateway API CRDs.")
-	gatewayAPICRDsURL := fmt.Sprintf("https://github.com/kubernetes-sigs/gateway-api/releases/download/%s/standard-install.yaml", gatewayAPIVersion)
-	if err := run(ctx, out, "", cfg.kubectl(), "apply", "-f", gatewayAPICRDsURL); err != nil {
+	gatewayAPICRDsURL := fmt.Sprintf("https://github.com/kubernetes-sigs/gateway-api/releases/download/%s/experimental-install.yaml", gatewayAPIVersion)
+	if err := run(ctx, out, "", cfg.kubectl(), "apply", "--server-side", "-f", gatewayAPICRDsURL); err != nil {
 		return fmt.Errorf("applying Gateway API CRDs: %w", err)
 	}
 	if err := run(ctx, out, "", cfg.kubectl(), "wait", "--for=condition=Established", "--all", "crd", "--timeout=5m"); err != nil {
@@ -115,7 +115,18 @@ func installNetworking(ctx context.Context, cfg ClusterConfig, out io.Writer) er
 		return fmt.Errorf("waiting for contour pods: %w", err)
 	}
 
-	fmt.Fprintln(out, "Creating shared Gateway.")
+	fmt.Fprintln(out, "Creating GatewayClass and shared Gateway.")
+	gatewayClass := `apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: contour
+spec:
+  controllerName: projectcontour.io/contour
+`
+	if err := applyManifest(ctx, out, cfg, gatewayClass); err != nil {
+		return fmt.Errorf("applying GatewayClass: %w", err)
+	}
+
 	gateway := fmt.Sprintf(`apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -195,7 +206,8 @@ spec:
 }
 
 // addContourIPv6Args modifies the Contour deployment YAML to add
-// --envoy-service-http-address=:: and --envoy-service-https-address=:: args.
+// --envoy-service-http-address=:: and --envoy-service-https-address=:: args,
+// and patches the Contour ConfigMap to enable Gateway API via gatewayRef.
 // This replaces the yq pipeline from the shell script. The input is split
 // on the multi-document separator and each non-empty chunk is decoded
 // individually, which avoids the k8s YAML decoder's quirk of returning a
@@ -219,11 +231,21 @@ func addContourIPv6Args(yamlContent string) (string, error) {
 				args := append(argsRaw,
 					"--envoy-service-http-address=::",
 					"--envoy-service-https-address=::",
-					fmt.Sprintf("--gateway-ref=%s/%s", gatewayNamespace, gatewayName),
 				)
 				container["args"] = toAnySlice(args)
 				containers[0] = container
 				_ = unstructured.SetNestedSlice(obj.Object, containers, "spec", "template", "spec", "containers")
+			}
+		}
+
+		// Patch the Contour ConfigMap to add gatewayRef configuration.
+		if obj.GetKind() == "ConfigMap" && obj.GetName() == "contour" && obj.GetNamespace() == gatewayNamespace {
+			data, _, _ := unstructured.NestedStringMap(obj.Object, "data")
+			if data != nil {
+				contourYAML := data["contour.yaml"]
+				contourYAML += fmt.Sprintf("\ngateway:\n  gatewayRef:\n    namespace: %s\n    name: %s\n", gatewayNamespace, gatewayName)
+				data["contour.yaml"] = contourYAML
+				_ = unstructured.SetNestedStringMap(obj.Object, data, "data")
 			}
 		}
 

--- a/pkg/cluster/serving.go
+++ b/pkg/cluster/serving.go
@@ -82,6 +82,15 @@ func installNetworking(ctx context.Context, cfg ClusterConfig, out io.Writer) er
 	status(out, "Installing Ingress Controller (Contour)")
 	fmt.Fprintf(out, "Version: %s\n", contourVersion)
 
+	fmt.Fprintln(out, "Installing Gateway API CRDs.")
+	gatewayAPICRDsURL := fmt.Sprintf("https://github.com/kubernetes-sigs/gateway-api/releases/download/%s/standard-install.yaml", gatewayAPIVersion)
+	if err := run(ctx, out, "", cfg.kubectl(), "apply", "-f", gatewayAPICRDsURL); err != nil {
+		return fmt.Errorf("applying Gateway API CRDs: %w", err)
+	}
+	if err := run(ctx, out, "", cfg.kubectl(), "wait", "--for=condition=Established", "--all", "crd", "--timeout=5m"); err != nil {
+		return fmt.Errorf("waiting for Gateway API CRDs: %w", err)
+	}
+
 	fmt.Fprintln(out, "Installing a configured Contour.")
 	contourURL := fmt.Sprintf("https://github.com/knative/net-contour/releases/download/knative-%s/contour.yaml", contourVersion)
 	contourYAML, err := httpGet(ctx, contourURL)
@@ -104,6 +113,26 @@ func installNetworking(ctx context.Context, cfg ClusterConfig, out io.Writer) er
 		"-n", "contour-external", "--timeout=10m")
 	if err != nil {
 		return fmt.Errorf("waiting for contour pods: %w", err)
+	}
+
+	fmt.Fprintln(out, "Creating shared Gateway.")
+	gateway := fmt.Sprintf(`apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  gatewayClassName: contour
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+`, gatewayName, gatewayNamespace)
+	if err := applyManifest(ctx, out, cfg, gateway); err != nil {
+		return fmt.Errorf("applying Gateway: %w", err)
 	}
 
 	fmt.Fprintln(out, "Installing the Knative Contour controller.")
@@ -190,6 +219,7 @@ func addContourIPv6Args(yamlContent string) (string, error) {
 				args := append(argsRaw,
 					"--envoy-service-http-address=::",
 					"--envoy-service-https-address=::",
+					fmt.Sprintf("--gateway-ref=%s/%s", gatewayNamespace, gatewayName),
 				)
 				container["args"] = toAnySlice(args)
 				containers[0] = container

--- a/pkg/cluster/serving.go
+++ b/pkg/cluster/serving.go
@@ -74,15 +74,14 @@ func configureDNS(ctx context.Context, cfg ClusterConfig, out io.Writer) error {
 	return fmt.Errorf("unable to set Knative domain after 10 attempts: %w", lastErr)
 }
 
-// installNetworking installs Contour ingress controller and configures Knative
-// to use it. The Contour YAML is modified in Go (replacing yq) to add IPv6
-// dual-stack support args.
-func installNetworking(ctx context.Context, cfg ClusterConfig, out io.Writer) error {
+// installGatewayAPICRDs installs the Gateway API CRDs. This must run before
+// the parallel phase because multiple components (registry, eventing, tekton)
+// create HTTPRoute resources that require these CRDs to exist.
+func installGatewayAPICRDs(ctx context.Context, cfg ClusterConfig, out io.Writer) error {
 	start := time.Now()
-	status(out, "Installing Ingress Controller (Contour)")
-	fmt.Fprintf(out, "Version: %s\n", contourVersion)
+	status(out, "Installing Gateway API CRDs")
+	fmt.Fprintf(out, "Version: %s\n", gatewayAPIVersion)
 
-	fmt.Fprintln(out, "Installing Gateway API CRDs.")
 	gatewayAPICRDsURL := fmt.Sprintf("https://github.com/kubernetes-sigs/gateway-api/releases/download/%s/experimental-install.yaml", gatewayAPIVersion)
 	if err := run(ctx, out, "", cfg.kubectl(), "apply", "--server-side", "-f", gatewayAPICRDsURL); err != nil {
 		return fmt.Errorf("applying Gateway API CRDs: %w", err)
@@ -90,6 +89,18 @@ func installNetworking(ctx context.Context, cfg ClusterConfig, out io.Writer) er
 	if err := run(ctx, out, "", cfg.kubectl(), "wait", "--for=condition=Established", "--all", "crd", "--timeout=5m"); err != nil {
 		return fmt.Errorf("waiting for Gateway API CRDs: %w", err)
 	}
+
+	success(out, "Gateway API CRDs", time.Since(start))
+	return nil
+}
+
+// installNetworking installs Contour ingress controller and configures Knative
+// to use it. The Contour YAML is modified in Go (replacing yq) to add IPv6
+// dual-stack support args.
+func installNetworking(ctx context.Context, cfg ClusterConfig, out io.Writer) error {
+	start := time.Now()
+	status(out, "Installing Ingress Controller (Contour)")
+	fmt.Fprintf(out, "Version: %s\n", contourVersion)
 
 	fmt.Fprintln(out, "Installing a configured Contour.")
 	contourURL := fmt.Sprintf("https://github.com/knative/net-contour/releases/download/knative-%s/contour.yaml", contourVersion)

--- a/pkg/cluster/tekton.go
+++ b/pkg/cluster/tekton.go
@@ -82,28 +82,24 @@ func installPAC(ctx context.Context, cfg ClusterConfig, out io.Writer) error {
 		return fmt.Errorf("waiting for PAC: %w", err)
 	}
 
-	pacIngress := fmt.Sprintf(`apiVersion: networking.k8s.io/v1
-kind: Ingress
+	pacRoute := fmt.Sprintf(`apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
 metadata:
   name: pipelines-as-code
   namespace: pipelines-as-code
 spec:
-  ingressClassName: contour-external
+  parentRefs:
+    - name: %s
+      namespace: %s
+  hostnames: ["%s"]
   rules:
-  - host: %s
-    http:
-      paths:
-      - backend:
-          service:
-            name: pipelines-as-code-controller
-            port:
-              number: 8080
-        pathType: Prefix
-        path: /
-`, cfg.PacHost)
+    - backendRefs:
+        - name: pipelines-as-code-controller
+          port: 8080
+`, gatewayName, gatewayNamespace, cfg.PacHost)
 
-	if err := applyManifest(ctx, out, cfg, pacIngress); err != nil {
-		return fmt.Errorf("applying PAC ingress: %w", err)
+	if err := applyManifest(ctx, out, cfg, pacRoute); err != nil {
+		return fmt.Errorf("applying PAC HTTPRoute: %w", err)
 	}
 
 	fmt.Fprintf(out, "the Pipeline as Code controller is available at: http://%s\n", cfg.PacHost)

--- a/pkg/cluster/versions.go
+++ b/pkg/cluster/versions.go
@@ -5,6 +5,7 @@ package cluster
 // hack/component-versions.json and hardcoded values in hack/cluster.sh.
 const (
 	kindNodeVersion      = "v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a"
+	gatewayAPIVersion    = "v1.4.1"
 	servingVersion       = "v1.21.2"
 	eventingVersion      = "v1.21.2"
 	contourVersion       = "v1.21.1"
@@ -13,6 +14,9 @@ const (
 	kedaVersion          = "v2.17.0"
 	kedaHTTPAddOnVersion = "v0.12.0"
 	metalLBVersion       = "v0.13.7"
+
+	gatewayName      = "contour-gateway"
+	gatewayNamespace = "contour-external"
 )
 
 // Tool versions — only tools we download and manage.


### PR DESCRIPTION
# Changes

Replace all networking.k8s.io/v1 Ingress resources used by non-Knative services (broker, registry, PAC controller, GitLab, git-server) with gateway.networking.k8s.io/v1 HTTPRoute resources pointing at a shared Gateway in the contour-external namespace.

Knative Serving's own networking remains on the existing Contour-based KIngress mechanism (contour.ingress.networking.knative.dev) and is unaffected by this change.

Shell scripts (hack/):
- Install Gateway API CRDs (v1.4.1) before Contour in networking()
- Pass --gateway-ref=contour-external/contour-gateway to Contour
- Create a shared Gateway with an HTTP listener allowing routes from all namespaces
- Replace Ingress with HTTPRoute in eventing(), registry(), pac(), gitlab.sh, and git-server.sh

Go cluster package (pkg/cluster/):
- Add gatewayAPIVersion, gatewayName, gatewayNamespace constants
- Install Gateway API CRDs and create Gateway in installNetworking()
- Append --gateway-ref arg in addContourIPv6Args()
- Replace Ingress templates with HTTPRoute in eventing.go and tekton.go

Integration test (pkg/builders/builders_int_test.go):
- Replace Ingress with TLS termination by dynamically patching the shared Gateway to add an HTTPS listener with the test certificate
- Create HTTPRoute via typed Gateway API clientset
- Cleanup removes the HTTPS listener and TLS secret from the Gateway namespace

Dependencies:
- Promote sigs.k8s.io/gateway-api v1.4.1 from indirect to direct
