### PR TITLE
fix: use %w instead of %v for error wrapping in fmt.Errorf

### DIFF
--- a/hack/cmd/components/main.go
+++ b/hack/cmd/components/main.go
@@ -118,7 +118,7 @@ func main() {
 		// regenerate .sh to keep up to date if changed
 		err = writeScript(componentList, fileScript)
 		if err != nil {
-			err = fmt.Errorf("failed to re-generate script: %v", err)
+			err = fmt.Errorf("failed to re-generate script: %w", err)
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
@@ -127,7 +127,7 @@ func main() {
 	}
 
 	if err := writeFiles(componentList, fileScript, fileJson); err != nil {
-		err = fmt.Errorf("failed to write files: %v", err)
+		err = fmt.Errorf("failed to write files: %w", err)
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
@@ -147,7 +147,7 @@ func update(ctx context.Context, client *github.Client, cl *ComponentList) (bool
 
 		newV, err := getLatestVersion(ctx, client, c.Owner, c.Repo)
 		if err != nil {
-			err = fmt.Errorf("error while getting latest v of %s/%s: %v", c.Owner, c.Repo, err)
+			err = fmt.Errorf("error while getting latest v of %s/%s: %w", c.Owner, c.Repo, err)
 			return false, err
 		}
 
@@ -183,12 +183,12 @@ func writeFiles(cl ComponentList, script, json string) error {
 	// write to json
 	err := writeSource(cl, json)
 	if err != nil {
-		return fmt.Errorf("failed to write to json: %v", err)
+		return fmt.Errorf("failed to write to json: %w", err)
 	}
 	// write to script file
 	err = writeScript(cl, script)
 	if err != nil {
-		return fmt.Errorf("failed to generate script: %v", err)
+		return fmt.Errorf("failed to generate script: %w", err)
 	}
 	return nil
 }
@@ -197,7 +197,7 @@ func writeFiles(cl ComponentList, script, json string) error {
 func writeSource(cl ComponentList, file string) error {
 	vB, err := json.MarshalIndent(cl, "", "	")
 	if err != nil {
-		return fmt.Errorf("can't Marshal versions: %v", err)
+		return fmt.Errorf("can't Marshal versions: %w", err)
 	}
 	f, err := os.Create(file)
 	if err != nil {
@@ -232,7 +232,7 @@ func writeScript(cl ComponentList, file string) error {
 func getLatestVersion(ctx context.Context, client *github.Client, owner string, repo string) (v string, err error) {
 	rr, res, err := client.Repositories.GetLatestRelease(ctx, owner, repo)
 	if err != nil {
-		err = fmt.Errorf("error: request for latest %s release: %v", owner+"/"+repo, err)
+		err = fmt.Errorf("error: request for latest %s release: %w", owner+"/"+repo, err)
 		return
 	}
 	if res.StatusCode < 200 && res.StatusCode > 299 {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -97,7 +97,7 @@ func NewDefault() (cfg Global, err error) {
 func Load(path string) (c Global, err error) {
 	bb, err := os.ReadFile(path)
 	if err != nil {
-		return c, fmt.Errorf("error reading global config: %v", err)
+		return c, fmt.Errorf("error reading global config: %w", err)
 	}
 	err = yaml.Unmarshal(bb, &c)
 	return
@@ -219,10 +219,10 @@ func RepositoriesPath() string {
 // ~/.config/func/repositories
 func CreatePaths() (err error) {
 	if err = os.MkdirAll(Dir(), 0755); err != nil { // rwxr-xr-x for directories
-		return fmt.Errorf("error creating global config path: %v", err)
+		return fmt.Errorf("error creating global config path: %w", err)
 	}
 	if err = os.MkdirAll(RepositoriesPath(), 0755); err != nil { // rwxr-xr-x for directories
-		return fmt.Errorf("error creating global config repositories path: %v", err)
+		return fmt.Errorf("error creating global config repositories path: %w", err)
 	}
 	return
 }

--- a/pkg/docker/runner.go
+++ b/pkg/docker/runner.go
@@ -160,16 +160,16 @@ func (n *Runner) Run(ctx context.Context, f fn.Function, address string, startTi
 			Timeout: &timeoutSecs,
 		}
 		if _, err = c.ContainerStop(ctx, id, ctrStopOpts); err != nil {
-			return fmt.Errorf("error stopping container %v: %v", id, err)
+			return fmt.Errorf("error stopping container %v: %w", id, err)
 		}
 		if _, err = c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{}); err != nil {
-			return fmt.Errorf("error removing container %v: %v", id, err)
+			return fmt.Errorf("error removing container %v: %w", id, err)
 		}
 		if err = conn.Close(); err != nil {
-			return fmt.Errorf("error closing connection to container: %v", err)
+			return fmt.Errorf("error closing connection to container: %w", err)
 		}
 		if err = c.Close(); err != nil {
-			return fmt.Errorf("error closing daemon client: %v", err)
+			return fmt.Errorf("error closing daemon client: %w", err)
 		}
 		return nil
 	}

--- a/pkg/functions/function.go
+++ b/pkg/functions/function.go
@@ -704,7 +704,7 @@ func (f Function) ImageName() (image string, err error) {
 
 	ref, err := name.ParseReference(refStr)
 	if err != nil {
-		return "", fmt.Errorf("%w: cannot determine function image: %v", ErrInvalidRegistry, err)
+		return "", fmt.Errorf("%w: cannot determine function image: %w", ErrInvalidRegistry, err)
 	}
 
 	return ref.Name(), nil

--- a/pkg/functions/repository.go
+++ b/pkg/functions/repository.go
@@ -305,7 +305,7 @@ func templates(fs filesystem.Filesystem, repoCfg repoConfig, runtimeCfg runtimeC
 	// Validate runtime path
 	runtimePath := path.Join(repoCfg.TemplatesPath, runtimeName)
 	if err = checkDir(fs, runtimePath); err != nil {
-		err = fmt.Errorf("runtime path '%v' not found. %v", runtimePath, err)
+		err = fmt.Errorf("runtime path '%v' not found. %w", runtimePath, err)
 		return
 	}
 

--- a/pkg/k8s/describer.go
+++ b/pkg/k8s/describer.go
@@ -42,7 +42,7 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (fn.In
 
 	clientset, err := NewKubernetesClientset()
 	if err != nil {
-		return fn.Instance{}, fmt.Errorf("unable to create k8s client: %v", err)
+		return fn.Instance{}, fmt.Errorf("unable to create k8s client: %w", err)
 	}
 
 	deploymentClient := clientset.AppsV1().Deployments(namespace)
@@ -67,7 +67,7 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (fn.In
 
 	deployment, err := deploymentClient.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return fn.Instance{}, fmt.Errorf("unable to get deployment %q: %v", name, err)
+		return fn.Instance{}, fmt.Errorf("unable to get deployment %q: %w", name, err)
 	}
 
 	ready := corev1.ConditionUnknown

--- a/pkg/k8s/lister.go
+++ b/pkg/k8s/lister.go
@@ -24,7 +24,7 @@ func NewLister(verbose bool) fn.Lister {
 func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, error) {
 	clientset, err := NewKubernetesClientset()
 	if err != nil {
-		return nil, fmt.Errorf("unable to create k8s client: %v", err)
+		return nil, fmt.Errorf("unable to create k8s client: %w", err)
 	}
 
 	serviceClient := clientset.CoreV1().Services(namespace)
@@ -33,7 +33,7 @@ func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, err
 		LabelSelector: "function.knative.dev/name",
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to list services: %v", err)
+		return nil, fmt.Errorf("unable to list services: %w", err)
 	}
 
 	listItems := make([]fn.ListItem, 0, len(services.Items))
@@ -44,7 +44,7 @@ func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, err
 
 		item, err := l.get(ctx, clientset, service.Name, service.Namespace)
 		if err != nil {
-			return nil, fmt.Errorf("unable to get details about function: %v", err)
+			return nil, fmt.Errorf("unable to get details about function: %w", err)
 		}
 
 		listItems = append(listItems, item)

--- a/pkg/k8s/remover.go
+++ b/pkg/k8s/remover.go
@@ -55,11 +55,11 @@ func (remover *Remover) Remove(ctx context.Context, name, ns string) error {
 		if apiErrors.IsNotFound(err) {
 			return fn.ErrFunctionNotFound
 		}
-		return fmt.Errorf("k8s remover failed to delete the deployment: %v", err)
+		return fmt.Errorf("k8s remover failed to delete the deployment: %w", err)
 	}
 
 	if err := WaitForServiceRemoved(ctx, clientset, ns, name, DefaultWaitingTimeout); err != nil {
-		return fmt.Errorf("k8s remover failed to propagate service deletion: %v", err)
+		return fmt.Errorf("k8s remover failed to propagate service deletion: %w", err)
 	}
 
 	return nil

--- a/pkg/keda/deployer.go
+++ b/pkg/keda/deployer.go
@@ -102,17 +102,17 @@ func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (fn.DeploymentResu
 
 	k8sClientset, err := k8s.NewKubernetesClientset()
 	if err != nil {
-		return fn.DeploymentResult{}, fmt.Errorf("failed to create K8sClientset: %v", err)
+		return fn.DeploymentResult{}, fmt.Errorf("failed to create K8sClientset: %w", err)
 	}
 
 	deployment, err := k8sClientset.AppsV1().Deployments(namespace).Get(ctx, f.Name, metav1.GetOptions{})
 	if err != nil {
-		return fn.DeploymentResult{}, fmt.Errorf("failed to get deployment %s/%s: %v", namespace, f.Name, err)
+		return fn.DeploymentResult{}, fmt.Errorf("failed to get deployment %s/%s: %w", namespace, f.Name, err)
 	}
 
 	appService, err := k8sClientset.CoreV1().Services(namespace).Get(ctx, f.Name, metav1.GetOptions{})
 	if err != nil {
-		return fn.DeploymentResult{}, fmt.Errorf("failed to get service %s/%s: %v", namespace, f.Name, err)
+		return fn.DeploymentResult{}, fmt.Errorf("failed to get service %s/%s: %w", namespace, f.Name, err)
 	}
 
 	if err := d.ensureInterceptorBridgeService(ctx, k8sClientset, f, namespace, deployment); err != nil {
@@ -271,7 +271,7 @@ func (d *Deployer) ensureHTTPScaledObject(ctx context.Context, f fn.Function, na
 
 	httpScaledObjectClientset, err := NewHTTPScaledObjectClientset()
 	if err != nil {
-		return fmt.Errorf("failed to create HTTPScaledObject clientset: %v", err)
+		return fmt.Errorf("failed to create HTTPScaledObject clientset: %w", err)
 	}
 
 	existing, err := httpScaledObjectClientset.HttpV1alpha1().HTTPScaledObjects(expected.Namespace).Get(ctx, expected.Name, metav1.GetOptions{})

--- a/pkg/keda/describer.go
+++ b/pkg/keda/describer.go
@@ -44,7 +44,7 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (fn.In
 
 	clientset, err := k8s.NewKubernetesClientset()
 	if err != nil {
-		return fn.Instance{}, fmt.Errorf("unable to create k8s client: %v", err)
+		return fn.Instance{}, fmt.Errorf("unable to create k8s client: %w", err)
 	}
 
 	serviceClient := clientset.CoreV1().Services(namespace)
@@ -68,7 +68,7 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (fn.In
 
 	httpScaledObjectClientset, err := NewHTTPScaledObjectClientset()
 	if err != nil {
-		return fn.Instance{}, fmt.Errorf("unable to create HTTPScaledObject client: %v", err)
+		return fn.Instance{}, fmt.Errorf("unable to create HTTPScaledObject client: %w", err)
 	}
 
 	httpScaledObject, err := httpScaledObjectClientset.HttpV1alpha1().HTTPScaledObjects(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -96,7 +96,7 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (fn.In
 	deploymentClient := clientset.AppsV1().Deployments(namespace)
 	deployment, err := deploymentClient.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return fn.Instance{}, fmt.Errorf("unable to get deployment %q: %v", name, err)
+		return fn.Instance{}, fmt.Errorf("unable to get deployment %q: %w", name, err)
 	}
 
 	// get image

--- a/pkg/keda/lister.go
+++ b/pkg/keda/lister.go
@@ -26,12 +26,12 @@ func NewLister(verbose bool) fn.Lister {
 func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, error) {
 	clientset, err := k8s.NewKubernetesClientset()
 	if err != nil {
-		return nil, fmt.Errorf("unable to create k8s client: %v", err)
+		return nil, fmt.Errorf("unable to create k8s client: %w", err)
 	}
 
 	httpScaledObjectClientset, err := NewHTTPScaledObjectClientset()
 	if err != nil {
-		return nil, fmt.Errorf("unable to create HTTPScaledObject client: %v", err)
+		return nil, fmt.Errorf("unable to create HTTPScaledObject client: %w", err)
 	}
 
 	serviceClient := clientset.CoreV1().Services(namespace)
@@ -40,7 +40,7 @@ func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, err
 		LabelSelector: "function.knative.dev/name",
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to list services: %v", err)
+		return nil, fmt.Errorf("unable to list services: %w", err)
 	}
 
 	listItems := make([]fn.ListItem, 0, len(services.Items))
@@ -51,7 +51,7 @@ func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, err
 
 		item, err := l.get(ctx, httpScaledObjectClientset, service.Name, service.Namespace)
 		if err != nil {
-			return nil, fmt.Errorf("unable to get details about function: %v", err)
+			return nil, fmt.Errorf("unable to get details about function: %w", err)
 		}
 
 		listItems = append(listItems, item)
@@ -64,7 +64,7 @@ func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, err
 func (l *Lister) get(ctx context.Context, httpScaledObjectClientset *versioned.Clientset, name, namespace string) (fn.ListItem, error) {
 	httpScaledObject, err := httpScaledObjectClientset.HttpV1alpha1().HTTPScaledObjects(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return fn.ListItem{}, fmt.Errorf("unable to get HTTPScaledObject: %v", err)
+		return fn.ListItem{}, fmt.Errorf("unable to get HTTPScaledObject: %w", err)
 	}
 
 	ready := v1.ConditionUnknown

--- a/pkg/keda/remover.go
+++ b/pkg/keda/remover.go
@@ -56,11 +56,11 @@ func (remover *Remover) Remove(ctx context.Context, name, ns string) error {
 		if apiErrors.IsNotFound(err) {
 			return fn.ErrFunctionNotFound
 		}
-		return fmt.Errorf("keda remover failed to delete the deployment: %v", err)
+		return fmt.Errorf("keda remover failed to delete the deployment: %w", err)
 	}
 
 	if err := k8s.WaitForServiceRemoved(ctx, clientset, ns, name, k8s.DefaultWaitingTimeout); err != nil {
-		return fmt.Errorf("k8s remover failed to propagate service deletion: %v", err)
+		return fmt.Errorf("k8s remover failed to propagate service deletion: %w", err)
 	}
 
 	return nil

--- a/pkg/knative/client.go
+++ b/pkg/knative/client.go
@@ -21,12 +21,12 @@ func NewServingClient(namespace string) (clientservingv1.KnServingClient, error)
 
 	restConfig, err := k8s.GetClientConfig().ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new serving client: %v", err)
+		return nil, fmt.Errorf("failed to create new serving client: %w", err)
 	}
 
 	servingClient, err := servingv1.NewForConfig(restConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new serving client: %v", err)
+		return nil, fmt.Errorf("failed to create new serving client: %w", err)
 	}
 
 	client := clientservingv1.NewKnServingClient(servingClient, namespace)
@@ -41,12 +41,12 @@ func NewEventingClient(namespace string) (clienteventingv1.KnEventingClient, err
 
 	restConfig, err := k8s.GetClientConfig().ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new serving client: %v", err)
+		return nil, fmt.Errorf("failed to create new serving client: %w", err)
 	}
 
 	eventingClient, err := eventingv1.NewForConfig(restConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new eventing client: %v", err)
+		return nil, fmt.Errorf("failed to create new eventing client: %w", err)
 	}
 
 	client := clienteventingv1.NewKnEventingClient(eventingClient, namespace)

--- a/pkg/knative/deployer.go
+++ b/pkg/knative/deployer.go
@@ -213,19 +213,19 @@ consider using the --image-pull-secret flag, or setting up pull secrets manually
 
 			service, err := generateNewService(f, d.decorator, daprInstalled, &referencedSecrets, &referencedConfigMaps, &referencedPVCs)
 			if err != nil {
-				err = fmt.Errorf("knative deployer failed to generate the Knative Service: %v", err)
+				err = fmt.Errorf("knative deployer failed to generate the Knative Service: %w", err)
 				return fn.DeploymentResult{}, err
 			}
 
 			err = k8s.CheckResourcesArePresent(ctx, namespace, &referencedSecrets, &referencedConfigMaps, &referencedPVCs, f.Deploy.ServiceAccountName, f.Deploy.ImagePullSecret)
 			if err != nil {
-				err = fmt.Errorf("knative deployer failed to generate the Knative Service: %v", err)
+				err = fmt.Errorf("knative deployer failed to generate the Knative Service: %w", err)
 				return fn.DeploymentResult{}, err
 			}
 
 			err = client.CreateService(ctx, service)
 			if err != nil {
-				err = fmt.Errorf("knative deployer failed to deploy the Knative Service: %v", err)
+				err = fmt.Errorf("knative deployer failed to deploy the Knative Service: %w", err)
 				return fn.DeploymentResult{}, err
 			}
 
@@ -270,7 +270,7 @@ consider using the --image-pull-secret flag, or setting up pull secrets manually
 				return fn.DeploymentResult{}, err
 			}
 			if err != nil {
-				err = fmt.Errorf("knative deployer failed to wait for the Knative Service to become ready: %v", err)
+				err = fmt.Errorf("knative deployer failed to wait for the Knative Service to become ready: %w", err)
 				if !d.verbose {
 					fmt.Fprintln(os.Stderr, "\nService output:")
 					_, _ = io.Copy(os.Stderr, &outBuff)
@@ -281,7 +281,7 @@ consider using the --image-pull-secret flag, or setting up pull secrets manually
 
 			route, err := client.GetRoute(ctx, f.Name)
 			if err != nil {
-				err = fmt.Errorf("knative deployer failed to get the Route: %v", err)
+				err = fmt.Errorf("knative deployer failed to get the Route: %w", err)
 				return fn.DeploymentResult{}, err
 			}
 
@@ -300,7 +300,7 @@ consider using the --image-pull-secret flag, or setting up pull secrets manually
 			}, nil
 
 		} else {
-			err = fmt.Errorf("knative deployer failed to get the Knative Service: %v", err)
+			err = fmt.Errorf("knative deployer failed to get the Knative Service: %w", err)
 			return fn.DeploymentResult{}, err
 		}
 	} else {
@@ -321,13 +321,13 @@ consider using the --image-pull-secret flag, or setting up pull secrets manually
 
 		err = k8s.CheckResourcesArePresent(ctx, namespace, &referencedSecrets, &referencedConfigMaps, &referencedPVCs, f.Deploy.ServiceAccountName, f.Deploy.ImagePullSecret)
 		if err != nil {
-			err = fmt.Errorf("knative deployer failed to update the Knative Service: %v", err)
+			err = fmt.Errorf("knative deployer failed to update the Knative Service: %w", err)
 			return fn.DeploymentResult{}, err
 		}
 
 		_, err = client.UpdateServiceWithRetry(ctx, f.Name, updateService(f, previousService, newEnv, newEnvFrom, newVolumes, newVolumeMounts, d.decorator, daprInstalled), 3)
 		if err != nil {
-			err = fmt.Errorf("knative deployer failed to update the Knative Service: %v", err)
+			err = fmt.Errorf("knative deployer failed to update the Knative Service: %w", err)
 			return fn.DeploymentResult{}, err
 		}
 
@@ -345,7 +345,7 @@ consider using the --image-pull-secret flag, or setting up pull secrets manually
 
 		route, err := client.GetRoute(ctx, f.Name)
 		if err != nil {
-			err = fmt.Errorf("knative deployer failed to get the Route: %v", err)
+			err = fmt.Errorf("knative deployer failed to get the Route: %w", err)
 			return fn.DeploymentResult{}, err
 		}
 
@@ -365,7 +365,7 @@ consider using the --image-pull-secret flag, or setting up pull secrets manually
 func createTriggers(ctx context.Context, f fn.Function, client clientservingv1.KnServingClient, eventingClient clienteventingv1.KnEventingClient) error {
 	ksvc, err := client.GetService(ctx, f.Name)
 	if err != nil {
-		err = fmt.Errorf("knative deployer failed to get the Service for Trigger: %v", err)
+		err = fmt.Errorf("knative deployer failed to get the Service for Trigger: %w", err)
 		return err
 	}
 
@@ -406,7 +406,7 @@ func createTriggers(ctx context.Context, f fn.Function, client clientservingv1.K
 			},
 		})
 		if err != nil && !errors.IsAlreadyExists(err) {
-			err = fmt.Errorf("knative deployer failed to create the Trigger: %v", err)
+			err = fmt.Errorf("knative deployer failed to create the Trigger: %w", err)
 			return err
 		}
 	}
@@ -827,13 +827,13 @@ func wrapDeployerClientError(err error) error {
 
 	// Missing kubeconfig file
 	if strings.Contains(errMsg, "kubeconfig file does not exist at path") {
-		return fmt.Errorf("%w: %v", fn.ErrInvalidKubeconfig, err)
+		return fmt.Errorf("%w: %w", fn.ErrInvalidKubeconfig, err)
 	}
 
 	// Empty config or cluster not accessible
 	if strings.Contains(errMsg, "no configuration has been provided") ||
 		strings.Contains(errMsg, "invalid configuration") {
-		return fmt.Errorf("%w: %v", fn.ErrClusterNotAccessible, err)
+		return fmt.Errorf("%w: %w", fn.ErrClusterNotAccessible, err)
 	}
 
 	return err
@@ -852,7 +852,7 @@ func wrapK8sConnectionError(err error) error {
 		strings.Contains(errMsg, "dial tcp") ||
 		strings.Contains(errMsg, "i/o timeout") ||
 		strings.Contains(errMsg, "x509:") {
-		return fmt.Errorf("%w: %v", fn.ErrClusterNotAccessible, err)
+		return fmt.Errorf("%w: %w", fn.ErrClusterNotAccessible, err)
 	}
 
 	return nil

--- a/pkg/knative/describer.go
+++ b/pkg/knative/describer.go
@@ -118,7 +118,7 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (fn.In
 	// get used image (including the sha)
 	clientset, err := k8s.NewKubernetesClientset()
 	if err != nil {
-		return fn.Instance{}, fmt.Errorf("unable to create k8s client: %v", err)
+		return fn.Instance{}, fmt.Errorf("unable to create k8s client: %w", err)
 	}
 
 	deploymentClient := clientset.AppsV1().Deployments(namespace)

--- a/pkg/knative/remover.go
+++ b/pkg/knative/remover.go
@@ -57,7 +57,7 @@ func (remover *Remover) Remove(ctx context.Context, name, ns string) error {
 
 	err = client.DeleteService(ctx, name, RemoveTimeout)
 	if err != nil {
-		return fmt.Errorf("knative remover failed to delete the service: %v", err)
+		return fmt.Errorf("knative remover failed to delete the service: %w", err)
 	}
 
 	return nil

--- a/pkg/pipelines/tekton/client.go
+++ b/pkg/pipelines/tekton/client.go
@@ -22,7 +22,7 @@ func NewTektonClient(namespace string) (*v1.TektonV1Client, error) {
 
 	client, err := v1.NewForConfig(restConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new tekton client: %v", err)
+		return nil, fmt.Errorf("failed to create new tekton client: %w", err)
 	}
 
 	return client, nil
@@ -31,14 +31,14 @@ func NewTektonClient(namespace string) (*v1.TektonV1Client, error) {
 func NewTektonClients() (*cli.Clients, error) {
 	restConfig, err := k8s.GetClientConfig().ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new tekton clientset: %v", err)
+		return nil, fmt.Errorf("failed to create new tekton clientset: %w", err)
 	}
 
 	params := cli.TektonParams{}
 	clients, err := params.Clients(restConfig)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new tekton clients: %v", err)
+		return nil, fmt.Errorf("failed to create new tekton clients: %w", err)
 	}
 
 	return clients, nil

--- a/pkg/pipelines/tekton/pac/client.go
+++ b/pkg/pipelines/tekton/pac/client.go
@@ -25,7 +25,7 @@ func NewTektonPacClientAndResolvedNamespace(namespace string) (*pacv1alpha1.Pipe
 
 	client, err := pacv1alpha1.NewForConfig(restConfig)
 	if err != nil {
-		return nil, namespace, fmt.Errorf("failed to create new tekton pac client: %v", err)
+		return nil, namespace, fmt.Errorf("failed to create new tekton pac client: %w", err)
 	}
 
 	return client, namespace, nil

--- a/pkg/pipelines/tekton/pipelines_provider.go
+++ b/pkg/pipelines/tekton/pipelines_provider.go
@@ -184,15 +184,15 @@ func (pp *PipelinesProvider) Run(ctx context.Context, f fn.Function) (string, fn
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			if k8serrors.IsNotFound(err) {
-				return "", f, fmt.Errorf("problem creating pipeline, missing tekton?: %v", err)
+				return "", f, fmt.Errorf("problem creating pipeline, missing tekton?: %w", err)
 			}
-			return "", f, fmt.Errorf("problem creating pipeline: %v", err)
+			return "", f, fmt.Errorf("problem creating pipeline: %w", err)
 		}
 	}
 
 	registry, err := docker.GetRegistry(image)
 	if err != nil {
-		return "", f, fmt.Errorf("problem in resolving image registry name: %v", err)
+		return "", f, fmt.Errorf("problem in resolving image registry name: %w", err)
 	}
 
 	creds, err := pp.credentialsProvider(ctx, image)
@@ -214,12 +214,12 @@ func (pp *PipelinesProvider) Run(ctx context.Context, f fn.Function) (string, fn
 
 	err = k8s.EnsureDockerRegistrySecretExist(ctx, getPipelineSecretName(f), namespace, labels, f.Deploy.Annotations, creds.Username, creds.Password, registry)
 	if err != nil {
-		return "", f, fmt.Errorf("problem in creating secret: %v", err)
+		return "", f, fmt.Errorf("problem in creating secret: %w", err)
 	}
 
 	err = createAndApplyPipelineRunTemplate(f, namespace, labels)
 	if err != nil {
-		return "", f, fmt.Errorf("problem in creating pipeline run: %v", err)
+		return "", f, fmt.Errorf("problem in creating pipeline run: %w", err)
 	}
 
 	// we need to give k8s time to actually create the Pipeline Run
@@ -227,13 +227,13 @@ func (pp *PipelinesProvider) Run(ctx context.Context, f fn.Function) (string, fn
 
 	newestPipelineRun, err := findNewestPipelineRunWithRetry(ctx, f, namespace, client)
 	if err != nil {
-		return "", f, fmt.Errorf("problem in listing pipeline runs: %v", err)
+		return "", f, fmt.Errorf("problem in listing pipeline runs: %w", err)
 	}
 
 	err = pp.watchPipelineRunProgress(ctx, newestPipelineRun, namespace)
 	if err != nil {
 		if !errors.Is(err, context.Canceled) {
-			return "", f, fmt.Errorf("problem in watching started pipeline run: %v", err)
+			return "", f, fmt.Errorf("problem in watching started pipeline run: %w", err)
 		}
 		// TODO replace deletion with pipeline-run cancellation
 		_ = client.PipelineRuns(namespace).Delete(context.TODO(), newestPipelineRun.Name, metav1.DeleteOptions{})
@@ -242,7 +242,7 @@ func (pp *PipelinesProvider) Run(ctx context.Context, f fn.Function) (string, fn
 
 	newestPipelineRun, err = client.PipelineRuns(namespace).Get(ctx, newestPipelineRun.Name, metav1.GetOptions{})
 	if err != nil {
-		return "", f, fmt.Errorf("problem in retrieving pipeline run status: %v", err)
+		return "", f, fmt.Errorf("problem in retrieving pipeline run status: %w", err)
 	}
 
 	if newestPipelineRun.Status.GetCondition(apis.ConditionSucceeded).Status == corev1.ConditionFalse {
@@ -263,7 +263,7 @@ func (pp *PipelinesProvider) Run(ctx context.Context, f fn.Function) (string, fn
 
 	obj, err := describer.Describe(ctx, f.Name, f.Namespace)
 	if err != nil {
-		return "", f, fmt.Errorf("problem in retrieving status of deployed function: %v", err)
+		return "", f, fmt.Errorf("problem in retrieving status of deployed function: %w", err)
 	}
 
 	if obj.Generation == 1 {
@@ -558,7 +558,7 @@ func findNewestPipelineRunWithRetry(ctx context.Context, f fn.Function, namespac
 	for attempt := 1; attempt <= 3; attempt++ {
 		prs, err := client.PipelineRuns(namespace).List(ctx, listOptions)
 		if err != nil {
-			return nil, fmt.Errorf("problem in listing pipeline runs: %v", err)
+			return nil, fmt.Errorf("problem in listing pipeline runs: %w", err)
 		}
 
 		for _, pr := range prs.Items {
@@ -595,7 +595,7 @@ func createPipelinePersistentVolumeClaim(ctx context.Context, f fn.Function, nam
 	}
 	err = createPersistentVolumeClaim(ctx, getPipelinePvcName(f), namespace, labels, f.Deploy.Annotations, corev1.ReadWriteOnce, pvcs, f.Build.RemoteStorageClass)
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
-		return fmt.Errorf("problem creating persistent volume claim: %v", err)
+		return fmt.Errorf("problem creating persistent volume claim: %w", err)
 	}
 	return nil
 }

--- a/pkg/pipelines/tekton/templates.go
+++ b/pkg/pipelines/tekton/templates.go
@@ -122,7 +122,7 @@ func createPipelineTemplatePAC(f fn.Function, labels map[string]string) error {
 	} {
 		ts, err := getTaskSpec(val.ref)
 		if err != nil {
-			return fmt.Errorf("failed to get task spec: %v", err)
+			return fmt.Errorf("failed to get task spec: %w", err)
 		}
 		*val.field = ts
 	}
@@ -225,11 +225,11 @@ func createPipelineRunTemplatePAC(f fn.Function, labels map[string]string) error
 func createResource(projectRoot, fileName, fileTemplate string, data interface{}) error {
 	tmpl, err := template.New(fileName).Parse(fileTemplate)
 	if err != nil {
-		return fmt.Errorf("error parsing pipeline template: %v", err)
+		return fmt.Errorf("error parsing pipeline template: %w", err)
 	}
 
 	if err = os.MkdirAll(path.Join(projectRoot, resourcesDirectory), os.ModePerm); err != nil {
-		return fmt.Errorf("error creating pipeline resources path: %v", err)
+		return fmt.Errorf("error creating pipeline resources path: %w", err)
 	}
 
 	filePath := path.Join(projectRoot, resourcesDirectory, fileName)
@@ -248,7 +248,7 @@ func createResource(projectRoot, fileName, fileTemplate string, data interface{}
 
 	file, err := os.Create(filePath)
 	if err != nil {
-		return fmt.Errorf("error creating pipeline resources: %v", err)
+		return fmt.Errorf("error creating pipeline resources: %w", err)
 	}
 	defer file.Close()
 
@@ -280,7 +280,7 @@ func getTaskSpec(taskYaml string) (string, error) {
 	dec := yaml.NewDecoder(strings.NewReader(taskYaml))
 	err = dec.Decode(&data)
 	if err != nil {
-		return "", fmt.Errorf("failed to decode task yaml: %v", err)
+		return "", fmt.Errorf("failed to decode task yaml: %w", err)
 	}
 	data = map[string]any{
 		"taskSpec": data["spec"],
@@ -290,11 +290,11 @@ func getTaskSpec(taskYaml string) (string, error) {
 	enc.SetIndent(2)
 	err = enc.Encode(data)
 	if err != nil {
-		return "", fmt.Errorf("failed to encode task yaml: %v", err)
+		return "", fmt.Errorf("failed to encode task yaml: %w", err)
 	}
 	err = enc.Close()
 	if err != nil {
-		return "", fmt.Errorf("failed to close task yaml encoder: %v", err)
+		return "", fmt.Errorf("failed to close task yaml encoder: %w", err)
 	}
 	return strings.ReplaceAll(buff.String(), "\n", "\n      "), nil
 }
@@ -329,7 +329,7 @@ func createAndApplyPipelineTemplate(f fn.Function, namespace string, labels map[
 	} {
 		ts, err := getTaskSpec(val.ref)
 		if err != nil {
-			return fmt.Errorf("failed to get task spec: %v", err)
+			return fmt.Errorf("failed to get task spec: %w", err)
 		}
 		*val.field = ts
 	}
@@ -441,25 +441,25 @@ func createAndApplyResource(projectRoot, fileName, fileTemplate, kind, resourceN
 	} else {
 		tmpl, err := template.New("template").Parse(fileTemplate)
 		if err != nil {
-			return fmt.Errorf("error parsing template: %v", err)
+			return fmt.Errorf("error parsing template: %w", err)
 		}
 
 		var buf bytes.Buffer
 		err = tmpl.Execute(&buf, data)
 		if err != nil {
-			return fmt.Errorf("error executing template: %v", err)
+			return fmt.Errorf("error executing template: %w", err)
 		}
 		source = manifestival.Reader(&buf)
 	}
 
 	client, err := manifestivalClient()
 	if err != nil {
-		return fmt.Errorf("error generating template: %v", err)
+		return fmt.Errorf("error generating template: %w", err)
 	}
 
 	m, err := manifestival.ManifestFrom(source, manifestival.UseClient(client))
 	if err != nil {
-		return fmt.Errorf("error generating template: %v", err)
+		return fmt.Errorf("error generating template: %w", err)
 	}
 
 	resources := m.Resources()

--- a/pkg/testing/testing.go
+++ b/pkg/testing/testing.go
@@ -151,7 +151,7 @@ func ServeRepo(name string, t *testing.T) string {
 
 		relp, err := filepath.Rel("./testdata", path)
 		if err != nil {
-			return fmt.Errorf("cannot get relpath: %v", err)
+			return fmt.Errorf("cannot get relpath: %w", err)
 		}
 
 		dest := filepath.Join(gitRoot, relp)
@@ -161,22 +161,22 @@ func ServeRepo(name string, t *testing.T) string {
 			var in, out *os.File
 			in, err = os.Open(path)
 			if err != nil {
-				return fmt.Errorf("cannot open source file: %v", err)
+				return fmt.Errorf("cannot open source file: %w", err)
 			}
 			defer in.Close()
 			out, err = os.OpenFile(dest, os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
-				return fmt.Errorf("cannot open destination file: %v", err)
+				return fmt.Errorf("cannot open destination file: %w", err)
 			}
 			defer out.Close()
 			_, err = io.Copy(out, in)
 			if err != nil {
-				return fmt.Errorf("cannot copy data: %v", err)
+				return fmt.Errorf("cannot copy data: %w", err)
 			}
 		case fi.IsDir():
 			err = os.MkdirAll(dest, 0755)
 			if err != nil {
-				return fmt.Errorf("cannot mkdir: %v", err)
+				return fmt.Errorf("cannot mkdir: %w", err)
 			}
 		default:
 			return fmt.Errorf("unsupported file type")


### PR DESCRIPTION
# Changes

Use `%w` verb instead of `%v` in `fmt.Errorf` calls to preserve error chains, enabling `errors.Is` and `errors.As` to match wrapped errors correctly.

Affected packages:
- `pkg/config`
- `pkg/docker`
- `pkg/functions`
- `pkg/k8s`
- `pkg/keda`
- `pkg/knative`
- `pkg/pipelines/tekton`
- `pkg/testing`
- `hack/cmd/components`

/kind cleanup

**Release Note**
```release-note
NONE
```

**Docs**
```docs
NONE
```