### PR TITLE
fix: skip forbidden check on triggers to remove hard dep

### DIFF
--- a/pkg/k8s/deployer.go
+++ b/pkg/k8s/deployer.go
@@ -238,8 +238,8 @@ func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (fn.DeploymentResu
 	if err != nil {
 		return fn.DeploymentResult{}, fmt.Errorf("failed to create eventing client: %w", err)
 	}
-	if err := syncTriggers(ctx, f, namespace, eventingClient, clientset); err != nil {
-		return fn.DeploymentResult{}, fmt.Errorf("failed to sync triggers: %w", err)
+	if err := warnOrFailOnTriggerSync(syncTriggers(ctx, f, namespace, eventingClient, clientset), namespace, len(f.Deploy.Subscriptions) > 0); err != nil {
+		return fn.DeploymentResult{}, err
 	}
 
 	url := fmt.Sprintf("http://%s.%s.svc", f.Name, namespace)
@@ -269,6 +269,39 @@ func generateTriggerName(functionName, broker string, filters map[string]string)
 	hashStr := fmt.Sprintf("%x", hash[:4])
 
 	return fmt.Sprintf("%s-trigger-%s", functionName, hashStr)
+}
+
+// TODO: gauron: this is a quick fix, not every deployment should be dependent
+// on knative eventing. For a proper fix we should make sure we only touch
+// resources that are required for a specific deployer. It might be the case
+// that we will gate the incompatible deployer switch with a "delete current
+// function first to remove its resources before switching..."
+//
+// warnOrFailOnTriggerSync is the ONLY place trigger-sync errors are checked
+// for Forbidden - syncTriggers/deleteStaleTriggers just propagate whatever
+// they get. Trigger sync is unconditional (runs even with no subscriptions
+// or Eventing installed) and RBAC precedes existence, so a 403 can hit a
+// deploy that already succeeded and never touched eventing. Internal calls
+// already fail fast, so the first 403 aborts the whole sync immediately -
+// checking once here gives exactly one warning and no further doomed
+// calls. Any other error still fails the deploy. Forbidden is only
+// tolerated when hasSubscriptions is false - a function that declares
+// subscriptions is genuinely dependent on eventing, so a forbidden trigger
+// sync must fail its deploy rather than silently no-op.
+func warnOrFailOnTriggerSync(syncErr error, namespace string, hasSubscriptions bool) error {
+	if syncErr == nil {
+		return nil
+	}
+	if errors.IsForbidden(syncErr) {
+		if hasSubscriptions {
+			return fmt.Errorf("function declares eventing subscriptions but access to triggers.eventing.knative.dev is denied in namespace %q: %w", namespace, syncErr)
+		}
+		fmt.Fprintf(os.Stderr, "Warning: cannot sync eventing triggers (permission denied) - skipping; "+
+			"grant access to triggers.eventing.knative.dev in namespace %q to manage function subscriptions; "+
+			"if you are not using func subscriptions, you can safely ignore this message\n", namespace)
+		return nil
+	}
+	return fmt.Errorf("failed to sync triggers: %w", syncErr)
 }
 
 func syncTriggers(ctx context.Context, f fn.Function, namespace string, eventingClient clienteventingv1.KnEventingClient, clientset kubernetes.Interface) error {

--- a/pkg/k8s/triggers_test.go
+++ b/pkg/k8s/triggers_test.go
@@ -1,0 +1,154 @@
+//go:build !integration
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	clienteventingv1 "knative.dev/client/pkg/eventing/v1"
+	"knative.dev/client/pkg/util/mock"
+	fn "knative.dev/func/pkg/functions"
+)
+
+func forbiddenTriggersErr() error {
+	return apierrors.NewForbidden(schema.GroupResource{Group: "eventing.knative.dev", Resource: "triggers"}, "", nil)
+}
+
+// captureStderr runs fn with os.Stderr redirected, returning what it wrote.
+func captureStderr(t *testing.T, fn func()) (out string) {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+
+	outC := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(r)
+		outC <- string(data)
+	}()
+
+	defer func() {
+		os.Stderr = old
+		w.Close()
+		out = <-outC
+		r.Close()
+	}()
+
+	fn()
+	return
+}
+
+// Test_TriggerSync_ForbiddenWithoutSubscriptions_NoBlock: a function
+// that never touches eventing (zero Deploy.Subscriptions, so syncTriggers'
+// create block is skipped entirely) still runs the unconditional ListTriggers
+// cleanup call, which is the only call in this scenario.
+func Test_TriggerSync_ForbiddenWithoutSubscriptions_NoBlock(t *testing.T) {
+	namespace := "myns"
+
+	eventingClient := clienteventingv1.NewMockKnEventingClient(t, namespace)
+	eventingClient.Recorder().ListTriggers(nil, forbiddenTriggersErr())
+
+	f := fn.Function{Name: "myfn"}
+
+	syncErr := syncTriggers(context.Background(), f, namespace, eventingClient, nil)
+	eventingClient.Recorder().Validate()
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = warnOrFailOnTriggerSync(syncErr, namespace, len(f.Deploy.Subscriptions) > 0)
+	})
+
+	if err != nil {
+		t.Fatalf("expected a forbidden trigger sync not to block the deploy, got: %v", err)
+	}
+	if !strings.Contains(stderr, "cannot sync eventing triggers (permission denied)") {
+		t.Errorf("expected an actionable warning on stderr, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, `namespace "myns"`) {
+		t.Errorf("expected the warning to name the namespace, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "you can safely ignore this message") {
+		t.Errorf("expected the warning to reassure functions that don't use subscriptions, got: %q", stderr)
+	}
+}
+
+// Test_TriggerSync_OtherErrorStillFails covers a non-forbidden list
+// failure propagating all the way through the choke point to a hard
+// deploy failure, with no warning printed.
+func Test_TriggerSync_OtherErrorStillFails(t *testing.T) {
+	namespace := "myns"
+
+	eventingClient := clienteventingv1.NewMockKnEventingClient(t, namespace)
+	eventingClient.Recorder().ListTriggers(nil, apierrors.NewInternalError(fmt.Errorf("boom")))
+
+	f := fn.Function{Name: "myfn"}
+
+	syncErr := syncTriggers(context.Background(), f, namespace, eventingClient, nil)
+	eventingClient.Recorder().Validate()
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = warnOrFailOnTriggerSync(syncErr, namespace, len(f.Deploy.Subscriptions) > 0)
+	})
+
+	if err == nil {
+		t.Fatal("expected a non-forbidden trigger sync error to still fail the deploy")
+	}
+	if stderr != "" {
+		t.Errorf("expected no warning printed on a hard error, got: %q", stderr)
+	}
+}
+
+// Test_TriggerSync_ForbiddenWithSubscriptions_Fails: unlike the
+// no-subscriptions case, a function that declares subscriptions is
+// genuinely dependent on eventing - a forbidden trigger sync must fail
+// the deploy rather than silently no-op.
+func Test_TriggerSync_ForbiddenWithSubscriptions_Fails(t *testing.T) {
+	namespace := "myns"
+	f := fn.Function{
+		Name: "myfn",
+		Deploy: fn.DeploySpec{
+			Subscriptions: []fn.KnativeSubscription{{Source: "my-broker"}},
+		},
+	}
+
+	clientset := fake.NewClientset(
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: f.Name, Namespace: namespace}},
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: f.Name, Namespace: namespace}},
+	)
+
+	eventingClient := clienteventingv1.NewMockKnEventingClient(t, namespace)
+	eventingClient.Recorder().CreateTrigger(mock.Any(), forbiddenTriggersErr())
+
+	syncErr := syncTriggers(context.Background(), f, namespace, eventingClient, clientset)
+	eventingClient.Recorder().Validate()
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = warnOrFailOnTriggerSync(syncErr, namespace, len(f.Deploy.Subscriptions) > 0)
+	})
+
+	if err == nil {
+		t.Fatal("expected a forbidden trigger sync to block the deploy when subscriptions are declared")
+	}
+	if !strings.Contains(err.Error(), "subscriptions") || !strings.Contains(err.Error(), "denied") {
+		t.Errorf("expected the error to mention subscriptions and permission denial, got: %v", err)
+	}
+	if stderr != "" {
+		t.Errorf("expected no warning printed when the deploy is blocked, got: %q", stderr)
+	}
+}


### PR DESCRIPTION
Unconditionally we list triggers related to func subscriptions. a pleb user on cluster will not have RBAC on a non-existing resource when knative eventing is not even installed and throw a `Forbidden` error instead. This PR instead makes it so that a warning is printed instead so the "already successfully deployed" function can continue instead.

Without this, even basic `func deploy --deployer=raw` fails on normal user. Cluster-admin happily ignores this and continues