### PR TITLE
fix: skip knative backends on forbidden so list/describe/delete work for non-knative specific use-case

### DIFF
--- a/pkg/knative/describer.go
+++ b/pkg/knative/describer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -68,7 +69,14 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (fn.In
 			// Service doesn't exist as a Knative service - we don't handle this
 			return fn.Instance{}, fn.ErrNotHandled
 		}
-		// Some other error (permissions, network, etc.) - this is a real error
+		if errors.IsForbidden(err) {
+			fmt.Fprintf(os.Stderr, "Warning: cannot access Knative services (permission denied) - skipping; "+
+				"describing function %q will fail if it is Knative-managed; "+
+				"grant access to services.serving.knative.dev in namespace %q to allow it; "+
+				"if you do not use the Knative deployer you can safely ignore this message\n", name, namespace)
+			return fn.Instance{}, fn.ErrNotHandled
+		}
+		// Some other error (network, API server, etc.) - this is a real error
 		// We can't determine if we should handle it, so propagate it
 		return fn.Instance{}, fmt.Errorf("failed to check if service uses Knative: %w", err)
 	}
@@ -153,6 +161,12 @@ func (d *Describer) Describe(ctx context.Context, name, namespace string) (fn.In
 	if err != nil {
 		if errors.IsNotFound(err) || IsCRDNotFoundError(err) {
 			// No trigger found or Eventing is probably not installed on the cluster --> we're done here
+			return description, nil
+		}
+		if errors.IsForbidden(err) {
+			fmt.Fprintf(os.Stderr, "Warning: cannot list eventing triggers (permission denied) - skipping; "+
+				"grant access to triggers.eventing.knative.dev in namespace %q to show function subscriptions; "+
+				"if you are not using func subscriptions, you can safely ignore this message\n", namespace)
 			return description, nil
 		}
 

--- a/pkg/knative/lister.go
+++ b/pkg/knative/lister.go
@@ -2,8 +2,11 @@ package knative
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"knative.dev/pkg/apis"
 
 	fn "knative.dev/func/pkg/functions"
@@ -30,6 +33,17 @@ func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, err
 	if err != nil {
 		if IsCRDNotFoundError(err) {
 			// no services found --> nothing to return
+			return nil, nil
+		}
+		if errors.IsForbidden(err) {
+			// namespace is empty when listing across all namespaces (--all-namespaces)
+			grant := fmt.Sprintf("access to services.serving.knative.dev in namespace %q", namespace)
+			if namespace == "" {
+				grant = "cluster-wide access to services.serving.knative.dev"
+			}
+			fmt.Fprintf(os.Stderr, "Warning: cannot access Knative services (permission denied) - skipping; "+
+				"grant %s to include functions deployed by the Knative deployer; "+
+				"if you do not use the Knative deployer you can safely ignore this message\n", grant)
 			return nil, nil
 		}
 		return nil, err

--- a/pkg/knative/remover.go
+++ b/pkg/knative/remover.go
@@ -44,7 +44,14 @@ func (remover *Remover) Remove(ctx context.Context, name, ns string) error {
 			// Service doesn't exist as a Knative service - we don't handle this
 			return fn.ErrNotHandled
 		}
-		// Some other error (permissions, network, etc.) - this is a real error
+		if apiErrors.IsForbidden(err) {
+			fmt.Fprintf(os.Stderr, "Warning: cannot access Knative services (permission denied) - skipping; "+
+				"deleting function %q will fail if it is Knative-managed; "+
+				"grant access to services.serving.knative.dev in namespace %q to allow it; "+
+				"if you do not use the Knative deployer you can safely ignore this message\n", name, ns)
+			return fn.ErrNotHandled
+		}
+		// Some other error (network, API server, etc.) - this is a real error
 		// We can't determine if we should handle it, so propagate it
 		return fmt.Errorf("failed to get knative service: %w", err)
 	}


### PR DESCRIPTION
dont error on `forbidden` error. If user wants to use bare `k8s` deployment and has 0 knative installed - standard user will most likely not have grants for non-existing groups/resources.