### PR TITLE
ci: skip Codecov upload when CODECOV_TOKEN is unset (fork PRs)

### DIFF
--- a/.github/actions/codecov/action.yml
+++ b/.github/actions/codecov/action.yml
@@ -1,0 +1,42 @@
+name: codecov
+description: >
+  Upload coverage to Codecov when a token is available. No-ops when the token
+  is empty so fork PRs (no CODECOV_TOKEN secret) stay green after tests pass.
+
+# Callers pass secrets.CODECOV_TOKEN as inputs.token — secrets cannot be used
+# in step-level if: expressions, so the empty-token check lives here once.
+
+inputs:
+  token:
+    description: Codecov upload token; empty skips the upload
+    required: false
+    default: ""
+  files:
+    description: Coverage file path(s) for codecov-action
+    required: false
+    default: ./coverage.txt
+  flags:
+    description: Codecov flags (e.g. unit, integration, e2e)
+    required: false
+    default: ""
+  fail_ci_if_error:
+    description: Fail the job if Codecov upload errors (only when uploading)
+    required: false
+    default: "true"
+  verbose:
+    description: Verbose codecov-action logging
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Upload coverage to Codecov
+      if: ${{ inputs.token != '' }}
+      uses: codecov/codecov-action@v7
+      with:
+        files: ${{ inputs.files }}
+        flags: ${{ inputs.flags }}
+        fail_ci_if_error: ${{ inputs.fail_ci_if_error }}
+        verbose: ${{ inputs.verbose }}
+        token: ${{ inputs.token }}

--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -2,10 +2,9 @@ name: Functions
 
 # To run this workflow's tests locally, see ./hack/test-full.sh
 #
-# Fork CI note (#395 external-dev / Functions#57): Codecov upload steps run only
-# when CODECOV_TOKEN is set (workflow env from the secret). On forks without that secret they are skipped
-# so unit/integration/e2e signal is not painted red by tokenless Codecov 400s.
-# knative/func (upstream) continues to upload when the org secret is present.
+# Fork CI note (Hamr#395 external-dev / Functions#57): coverage upload goes through
+# ./.github/actions/codecov — no-ops when CODECOV_TOKEN is empty so forks without
+# the secret stay green after tests. Upstream knative/func still uploads when set.
 
 
 permissions:
@@ -33,9 +32,6 @@ env:
   NODE_VERSION: "20"
   JAVA_VERSION: "21"
   JAVA_DISTRIBUTION: "temurin"
-  # Mapped so step-level if: can gate Codecov (secrets context is not allowed in if).
-  # Empty on forks without the secret → Codecov steps skip (actionlint-clean).
-  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:
   # --------
@@ -86,16 +82,10 @@ jobs:
       - name: Run Unit Tests
         run: make test
 
-      # Skip when CODECOV_TOKEN is empty (forks without the secret). Gated via env
-      # (secrets cannot appear in step if: — actionlint). Upstream keeps the secret.
-      - uses: codecov/codecov-action@v7
-        if: ${{ env.CODECOV_TOKEN != '' }}
+      - uses: ./.github/actions/codecov
         with:
-          files: ./coverage.txt
-          flags: unit ${{ matrix.os }}
-          fail_ci_if_error: true
-          verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit ${{ matrix.os }}
 
   # --------------
   # TEMPLATE TESTS
@@ -187,16 +177,10 @@ jobs:
       - name: Run Integration Tests
         run: make test-integration
 
-      # Skip when CODECOV_TOKEN is empty (forks without the secret). Gated via env
-      # (secrets cannot appear in step if: — actionlint). Upstream keeps the secret.
-      - uses: codecov/codecov-action@v7
-        if: ${{ env.CODECOV_TOKEN != '' }}
+      - uses: ./.github/actions/codecov
         with:
-          files: ./coverage.txt
-          flags: integration
-          fail_ci_if_error: true
-          verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: integration
 
       # Preserve Cluster Logs
       - name: Dump Cluster Logs
@@ -247,16 +231,10 @@ jobs:
       - name: Run Basic E2E Tests (core, metadata, remote)
         run: make test-e2e
 
-      # Skip when CODECOV_TOKEN is empty (forks without the secret). Gated via env
-      # (secrets cannot appear in step if: — actionlint). Upstream keeps the secret.
-      - uses: codecov/codecov-action@v7
-        if: ${{ env.CODECOV_TOKEN != '' }}
+      - uses: ./.github/actions/codecov
         with:
-          files: ./coverage.txt
-          flags: e2e
-          fail_ci_if_error: true
-          verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: e2e
 
       # Preserve Cluster Logs
       - name: Dump Cluster Logs
@@ -313,16 +291,10 @@ jobs:
       - name: Run E2E Podman Tests
         run: make test-e2e-podman
 
-      # Skip when CODECOV_TOKEN is empty (forks without the secret). Gated via env
-      # (secrets cannot appear in step if: — actionlint). Upstream keeps the secret.
-      - uses: codecov/codecov-action@v7
-        if: ${{ env.CODECOV_TOKEN != '' }}
+      - uses: ./.github/actions/codecov
         with:
-          files: ./coverage.txt
-          flags: e2e
-          fail_ci_if_error: true
-          verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: e2e
 
       # Preserve Cluster Logs
       - name: Dump Cluster Logs
@@ -406,16 +378,10 @@ jobs:
         run: make test-e2e-matrix
 
       # Coverage and Logs
-      # Skip when CODECOV_TOKEN is empty (forks without the secret). Gated via env
-      # (secrets cannot appear in step if: — actionlint). Upstream keeps the secret.
-      - uses: codecov/codecov-action@v7
-        if: ${{ env.CODECOV_TOKEN != '' }}
+      - uses: ./.github/actions/codecov
         with:
-          files: ./coverage.txt
-          flags: e2e ${{ matrix.runtime }}
-          fail_ci_if_error: true
-          verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: e2e ${{ matrix.runtime }}
 
       # Preserve Cluster Logs
       - name: Dump Cluster Logs
@@ -464,16 +430,10 @@ jobs:
       - name: Run Config CI E2E Tests
         run: make test-e2e-config-ci
 
-      # Skip when CODECOV_TOKEN is empty (forks without the secret). Gated via env
-      # (secrets cannot appear in step if: — actionlint). Upstream keeps the secret.
-      - uses: codecov/codecov-action@v7
-        if: ${{ env.CODECOV_TOKEN != '' }}
+      - uses: ./.github/actions/codecov
         with:
-          files: ./coverage.txt
-          flags: e2e-config-ci
-          fail_ci_if_error: true
-          verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: e2e-config-ci
 
       # Preserve Cluster Logs
       - name: Dump Cluster Logs

--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -3,7 +3,7 @@ name: Functions
 # To run this workflow's tests locally, see ./hack/test-full.sh
 #
 # Fork CI note (#395 external-dev / Functions#57): Codecov upload steps run only
-# when secrets.CODECOV_TOKEN is set. On forks without that secret they are skipped
+# when CODECOV_TOKEN is set (workflow env from the secret). On forks without that secret they are skipped
 # so unit/integration/e2e signal is not painted red by tokenless Codecov 400s.
 # knative/func (upstream) continues to upload when the org secret is present.
 
@@ -33,6 +33,9 @@ env:
   NODE_VERSION: "20"
   JAVA_VERSION: "21"
   JAVA_DISTRIBUTION: "temurin"
+  # Mapped so step-level if: can gate Codecov (secrets context is not allowed in if).
+  # Empty on forks without the secret → Codecov steps skip (actionlint-clean).
+  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:
   # --------
@@ -83,10 +86,10 @@ jobs:
       - name: Run Unit Tests
         run: make test
 
-      # Skip on forks without CODECOV_TOKEN (tokenless upload fails the job).
-      # Upstream knative/func keeps the secret; provisional fork PRs stay green.
+      # Skip when CODECOV_TOKEN is empty (forks without the secret). Gated via env
+      # (secrets cannot appear in step if: — actionlint). Upstream keeps the secret.
       - uses: codecov/codecov-action@v7
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        if: ${{ env.CODECOV_TOKEN != '' }}
         with:
           files: ./coverage.txt
           flags: unit ${{ matrix.os }}
@@ -184,10 +187,10 @@ jobs:
       - name: Run Integration Tests
         run: make test-integration
 
-      # Skip on forks without CODECOV_TOKEN (tokenless upload fails the job).
-      # Upstream knative/func keeps the secret; provisional fork PRs stay green.
+      # Skip when CODECOV_TOKEN is empty (forks without the secret). Gated via env
+      # (secrets cannot appear in step if: — actionlint). Upstream keeps the secret.
       - uses: codecov/codecov-action@v7
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        if: ${{ env.CODECOV_TOKEN != '' }}
         with:
           files: ./coverage.txt
           flags: integration
@@ -244,10 +247,10 @@ jobs:
       - name: Run Basic E2E Tests (core, metadata, remote)
         run: make test-e2e
 
-      # Skip on forks without CODECOV_TOKEN (tokenless upload fails the job).
-      # Upstream knative/func keeps the secret; provisional fork PRs stay green.
+      # Skip when CODECOV_TOKEN is empty (forks without the secret). Gated via env
+      # (secrets cannot appear in step if: — actionlint). Upstream keeps the secret.
       - uses: codecov/codecov-action@v7
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        if: ${{ env.CODECOV_TOKEN != '' }}
         with:
           files: ./coverage.txt
           flags: e2e
@@ -310,10 +313,10 @@ jobs:
       - name: Run E2E Podman Tests
         run: make test-e2e-podman
 
-      # Skip on forks without CODECOV_TOKEN (tokenless upload fails the job).
-      # Upstream knative/func keeps the secret; provisional fork PRs stay green.
+      # Skip when CODECOV_TOKEN is empty (forks without the secret). Gated via env
+      # (secrets cannot appear in step if: — actionlint). Upstream keeps the secret.
       - uses: codecov/codecov-action@v7
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        if: ${{ env.CODECOV_TOKEN != '' }}
         with:
           files: ./coverage.txt
           flags: e2e
@@ -403,10 +406,10 @@ jobs:
         run: make test-e2e-matrix
 
       # Coverage and Logs
-      # Skip on forks without CODECOV_TOKEN (tokenless upload fails the job).
-      # Upstream knative/func keeps the secret; provisional fork PRs stay green.
+      # Skip when CODECOV_TOKEN is empty (forks without the secret). Gated via env
+      # (secrets cannot appear in step if: — actionlint). Upstream keeps the secret.
       - uses: codecov/codecov-action@v7
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        if: ${{ env.CODECOV_TOKEN != '' }}
         with:
           files: ./coverage.txt
           flags: e2e ${{ matrix.runtime }}
@@ -461,10 +464,10 @@ jobs:
       - name: Run Config CI E2E Tests
         run: make test-e2e-config-ci
 
-      # Skip on forks without CODECOV_TOKEN (tokenless upload fails the job).
-      # Upstream knative/func keeps the secret; provisional fork PRs stay green.
+      # Skip when CODECOV_TOKEN is empty (forks without the secret). Gated via env
+      # (secrets cannot appear in step if: — actionlint). Upstream keeps the secret.
       - uses: codecov/codecov-action@v7
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        if: ${{ env.CODECOV_TOKEN != '' }}
         with:
           files: ./coverage.txt
           flags: e2e-config-ci

--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -1,6 +1,12 @@
 name: Functions
 
 # To run this workflow's tests locally, see ./hack/test-full.sh
+#
+# Fork CI note (#395 external-dev / Functions#57): Codecov upload steps run only
+# when secrets.CODECOV_TOKEN is set. On forks without that secret they are skipped
+# so unit/integration/e2e signal is not painted red by tokenless Codecov 400s.
+# knative/func (upstream) continues to upload when the org secret is present.
+
 
 permissions:
   id-token: write # Required for signing
@@ -77,7 +83,10 @@ jobs:
       - name: Run Unit Tests
         run: make test
 
+      # Skip on forks without CODECOV_TOKEN (tokenless upload fails the job).
+      # Upstream knative/func keeps the secret; provisional fork PRs stay green.
       - uses: codecov/codecov-action@v7
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
         with:
           files: ./coverage.txt
           flags: unit ${{ matrix.os }}
@@ -175,7 +184,10 @@ jobs:
       - name: Run Integration Tests
         run: make test-integration
 
+      # Skip on forks without CODECOV_TOKEN (tokenless upload fails the job).
+      # Upstream knative/func keeps the secret; provisional fork PRs stay green.
       - uses: codecov/codecov-action@v7
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
         with:
           files: ./coverage.txt
           flags: integration
@@ -232,7 +244,10 @@ jobs:
       - name: Run Basic E2E Tests (core, metadata, remote)
         run: make test-e2e
 
+      # Skip on forks without CODECOV_TOKEN (tokenless upload fails the job).
+      # Upstream knative/func keeps the secret; provisional fork PRs stay green.
       - uses: codecov/codecov-action@v7
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
         with:
           files: ./coverage.txt
           flags: e2e
@@ -295,7 +310,10 @@ jobs:
       - name: Run E2E Podman Tests
         run: make test-e2e-podman
 
+      # Skip on forks without CODECOV_TOKEN (tokenless upload fails the job).
+      # Upstream knative/func keeps the secret; provisional fork PRs stay green.
       - uses: codecov/codecov-action@v7
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
         with:
           files: ./coverage.txt
           flags: e2e
@@ -385,7 +403,10 @@ jobs:
         run: make test-e2e-matrix
 
       # Coverage and Logs
+      # Skip on forks without CODECOV_TOKEN (tokenless upload fails the job).
+      # Upstream knative/func keeps the secret; provisional fork PRs stay green.
       - uses: codecov/codecov-action@v7
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
         with:
           files: ./coverage.txt
           flags: e2e ${{ matrix.runtime }}
@@ -440,7 +461,10 @@ jobs:
       - name: Run Config CI E2E Tests
         run: make test-e2e-config-ci
 
+      # Skip on forks without CODECOV_TOKEN (tokenless upload fails the job).
+      # Upstream knative/func keeps the secret; provisional fork PRs stay green.
       - uses: codecov/codecov-action@v7
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
         with:
           files: ./coverage.txt
           flags: e2e-config-ci

--- a/.github/workflows/knative-go-test.yaml
+++ b/.github/workflows/knative-go-test.yaml
@@ -13,6 +13,9 @@ on:
     branches: [ 'main', 'release-*' ]
 
 jobs:
+  # CODECOV_TOKEN may be empty on forks; reusable workflow should treat missing
+  # coverage upload as non-fatal. Primary fork CI honesty for this repo is in
+  # functions.yaml (Codecov steps gated on secrets.CODECOV_TOKEN).
   test:
     uses: knative/actions/.github/workflows/reusable-go-test.yaml@main
     secrets:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,8 @@ To run core unit tests, use `make test`.
 ### Fork CI (GitHub Actions)
 
 Pull requests **on a fork** (e.g. provisional PRs used in development) do not
-have Knative org secrets. Codecov upload steps in `.github/workflows/functions.yaml`
-run only when `CODECOV_TOKEN` is set; without it they are skipped so unit,
+have Knative org secrets. Coverage upload uses the local composite action
+`.github/actions/codecov`, which no-ops when `CODECOV_TOKEN` is empty so unit,
 integration, and e2e results stay the CI signal. Upstream `knative/func` still
 uploads coverage when the secret is present.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,14 @@ To remove built artifacts, use `make clean`.
 
 To run core unit tests, use `make test`.
 
+### Fork CI (GitHub Actions)
+
+Pull requests **on a fork** (e.g. provisional PRs used in development) do not
+have Knative org secrets. Codecov upload steps in `.github/workflows/functions.yaml`
+run only when `CODECOV_TOKEN` is set; without it they are skipped so unit,
+integration, and e2e results stay the CI signal. Upstream `knative/func` still
+uploads coverage when the secret is present.
+
 ## Linting
 
 Before submitting code in a Pull Request, please run `make check` and resolve any errors.  This creates and runs `bin/golangci-lint`.  For settings such as configured linters, see [.golangci.yaml](../.golangci.yaml).


### PR DESCRIPTION
A useful paradigm is to open a PR against your own fork of Functions to run CI before submitting upstream.  Reason-being that a PR opened upstream must be non-draft in order for CI to run, which is essentially signaling "I'm ready for review".  This is not always the case.  I like to run CI first _before_ asking for a review.

This PR makes that possible by removing the hard-fail on a missing CODECOV_TOKEN in
forks.

You can now open PRs against your own fork, ensure CI is clean, before opening an upstream PR and wasting anyone's time.

👍🏻 


# Changes

- :broom: Add `.github/actions/codecov` composite action that **no-ops when `token` is empty** (fork PRs without `CODECOV_TOKEN`) and uploads via `codecov-action@v7` when set.
- :broom: Point all six Codecov steps in `functions.yaml` at that action (token + flags only).
- :broom: Align `knative-go-test.yaml` Codecov step with the same empty-token skip pattern.
- :broom: Document fork CI expectations in the workflow header and CONTRIBUTING.

Fork PRs were failing Unit/Integration/E2E jobs on Codecov **tokenless 400** even when tests passed. Org repos with `CODECOV_TOKEN` keep uploading as before.

/kind cleanup

**Release Note**

```release-note
NONE
```

**Docs**

```docs
CONTRIBUTING.md — Fork CI subsection
```