### PR TITLE
test: skip gpg signing in test gitInit

### DIFF
--- a/e2e/e2e_config_ci_test.go
+++ b/e2e/e2e_config_ci_test.go
@@ -60,6 +60,10 @@ func gitInit(t *testing.T, dir string) {
 		{"init", "-b", "main"},
 		{"config", "user.email", "test@test.com"},
 		{"config", "user.name", "test"},
+		// Host global commit.gpgsign=true would otherwise fail the commit:
+		// the test identity has no signing key. Local-scope only (cmd.Dir=dir).
+		{"config", "commit.gpgsign", "false"},
+		{"config", "tag.gpgsign", "false"},
 		{"add", "."},
 		{"commit", "-m", "init"},
 	}


### PR DESCRIPTION
- :bug: Local-disable `commit.gpgsign` and `tag.gpgsign` in the config-ci e2e helper's temp git repo so a host global GPG signing config cannot fail `git commit` with `No secret key` for the synthetic test identity.

/kind bug

Functions#61