### PR TITLE
fix(cluster): run Delete when no clusters are tracked

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -249,17 +249,24 @@ func runClusterDelete(cmd *cobra.Command, args []string) error {
 		cfg.Name = args[0]
 	}
 
+	// If clusters are tracked and a non-matching name was given, refuse with
+	// a clear message — otherwise hand off to Delete, which handles both
+	// "delete the matched cluster" and "nothing tracked" (idempotent cleanup
+	// of shared resources Delete already owns when List() is empty).
 	clusters := cluster.List()
-	for _, c := range clusters {
-		if c == cfg.Name {
-			return cluster.Delete(cmd.Context(), cfg, cmd.OutOrStderr())
+	if len(clusters) > 0 {
+		matched := false
+		for _, c := range clusters {
+			if c == cfg.Name {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return fmt.Errorf("cluster %q not found; existing clusters: %v\nUse 'func cluster create' to create one", cfg.Name, clusters)
 		}
 	}
-
-	if len(clusters) == 0 {
-		return fmt.Errorf("no clusters exist; use 'func cluster create' to create one")
-	}
-	return fmt.Errorf("cluster %q not found; existing clusters: %v\nUse 'func cluster create' to create one", cfg.Name, clusters)
+	return cluster.Delete(cmd.Context(), cfg, cmd.OutOrStderr())
 }
 
 // NewClusterListCmd creates the 'func cluster list' command.

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -12,17 +12,28 @@ import (
 // container and the host's insecure-registries entry are removed only when
 // the *last* func-managed cluster is being torn down — other surviving
 // clusters keep using the shared registry.
+//
+// Delete is safe when nothing is tracked (empty List / no kubeconfig): it
+// still runs the empty-list shared-resource teardown and returns nil
+// (idempotent, rm -f style). kind-delete failures are only warned when a
+// kubeconfig was present — otherwise every empty-system delete would print
+// a scary "failed to delete cluster" for a cluster that never existed.
 func Delete(ctx context.Context, cfg ClusterConfig, out io.Writer) error {
 	// Set KUBECONFIG for child processes; restore the caller's value on return.
 	defer setKubeconfig(cfg.Kubeconfig())()
 
 	status(out, "Deleting Cluster")
 
+	_, kubeconfigErr := os.Stat(cfg.Kubeconfig())
+	kubeconfigPresent := kubeconfigErr == nil
+
 	if err := run(ctx, out, "",
 		cfg.kind(), "delete", "cluster",
 		"--name="+cfg.Name,
 		"--kubeconfig="+cfg.Kubeconfig()); err != nil {
-		warnf(out, "failed to delete cluster %q: %v", cfg.Name, err)
+		if kubeconfigPresent {
+			warnf(out, "failed to delete cluster %q: %v", cfg.Name, err)
+		}
 	}
 
 	// Remove this cluster's kubeconfig dir so the "last cluster?" check


### PR DESCRIPTION
<!-- PR Title: fix(cluster): run Delete when no clusters are tracked -->

# Changes

- :bug: `func cluster delete` no longer hard-errors with `no clusters exist` when nothing is tracked. It hands off to `cluster.Delete`, which already performs empty-list shared-resource cleanup and returns nil (**idempotent / `rm -f` semantics** — exit 0 where it previously exited non-zero).
- :broom: Quiet `kind delete` warnings when no kubeconfig is present, so empty-system delete does not print a scary "failed to delete cluster" for a cluster that never existed.

Wrong name with existing clusters still errors as before.

/kind bug

# Release Note

```release-note
func cluster delete is idempotent when no clusters are tracked (exit 0, shared cleanup)
```

# Docs

- [ ] Docs PR required (link below)
- [x] Docs not required

Functions#63