### PR TITLE
fix(functions): clean up all orphaned local-run directories

### DIFF
--- a/pkg/functions/job.go
+++ b/pkg/functions/job.go
@@ -101,7 +101,9 @@ func cleanupJobDirs(j *Job) error {
 			fmt.Printf("No process listening on port %v.  Removing its job directory\n", d.Name())
 			fmt.Printf("rm %v\n", orphanedJobDir)
 		}
-		return os.RemoveAll(orphanedJobDir)
+		if err := os.RemoveAll(orphanedJobDir); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/functions/job_test.go
+++ b/pkg/functions/job_test.go
@@ -2,6 +2,9 @@ package functions_test
 
 import (
 	"errors"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
 
 	fn "knative.dev/func/pkg/functions"
@@ -56,6 +59,74 @@ func TestJob_New(t *testing.T) {
 		}
 	}
 
+}
+
+func TestJob_NewCleansAllOrphanedDirectories(t *testing.T) {
+	root, rm := Mktemp(t)
+	t.Cleanup(rm)
+	client := fn.New()
+
+	f, err := client.Init(fn.Function{Runtime: "go", Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listeners := make([]net.Listener, 4)
+	ports := make([]string, len(listeners))
+	seen := make(map[string]struct{}, len(listeners))
+	for i := range listeners {
+		listener, err := net.Listen("tcp", ":0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		listeners[i] = listener
+		t.Cleanup(func() { _ = listener.Close() })
+
+		_, port, err := net.SplitHostPort(listener.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := seen[port]; ok {
+			t.Fatalf("listener reused port %s", port)
+		}
+		seen[port] = struct{}{}
+		ports[i] = port
+	}
+
+	runsDir := filepath.Join(root, fn.RunDataDir, "runs")
+	for _, port := range ports[:3] {
+		if err := os.MkdirAll(filepath.Join(runsDir, port), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, listener := range listeners[1:] {
+		if err := listener.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	j, err := fn.NewJob(f, "127.0.0.1", ports[3], nil, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := j.Stop(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	for _, port := range ports[1:3] {
+		dir := filepath.Join(runsDir, port)
+		if _, err := os.Stat(dir); !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("stale job directory %s was not removed: %v", dir, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(runsDir, ports[0])); err != nil {
+		t.Errorf("active job directory was removed: %v", err)
+	}
+	if _, err := os.Stat(j.Dir()); err != nil {
+		t.Errorf("new job directory was not created: %v", err)
+	}
 }
 
 // TestJob_Stop ensures that stopping a local job results in the API no longer


### PR DESCRIPTION
# Changes

`cleanupJobDirs()` now keeps scanning `.func/runs/` after removing an orphaned run directory, so a new Job cleans up every stale entry instead of only the first one. The regression test covers one active run directory, two stale directories, and the newly created Job.

## Problem

`cleanupJobDirs()` returned directly from the directory loop after its first successful `os.RemoveAll(...)` call. If more than one stale `.func/runs/<port>` directory existed, the remaining entries were left behind and could still be reported as local function instances. Local invocation could then select a stale port even when a new function was available on another port.

## Fix

The cleanup loop now continues after each successful removal and returns only when a removal fails. Active port directories are still preserved, files and non-integer directories are still ignored, and there are no public API or metadata changes.

## Testing

The regression test creates one active run directory, two stale run directories, and one new Job. It verifies that both stale directories are removed, the active directory remains, and the new Job directory is created.

The exact submitted commit (`beccbf4e8ba4fad6fc6b83b3d0742774a870e30b`) passed the full workflow in the fork: https://github.com/Elvand-Lie/func/actions/runs/30923394939. All 23 applicable unit, integration, template, Podman, and runtime E2E jobs passed; the three release/publish jobs were skipped as expected.

Local static checks (`gofmt`, `git diff --check`, and `make check-whitespace check-eof`) also passed. Full Go tests could not run locally because the ARM64 environment could not retrieve the Go 1.26 toolchain, so the fork workflow supplied that validation.

**Release Note**

```release-note
Fixed local run cleanup so all stale `.func/runs/<port>` directories are removed before registering a new Job.
```

**Docs**

```docs
NONE
```
