### PR TITLE
fix: detect v2 registries.conf by top-level fields

### DIFF
--- a/hack/registry.sh
+++ b/hack/registry.sh
@@ -148,14 +148,19 @@ set_registry_insecure_podman() {
         fi
     fi
 
-    # Detect config format (v1 or v2)
+    # Detect config format (v1 or v2). A v2 file is not always marked by a
+    # [[registry]] table: podman 5's default config carries only top-level v2
+    # fields such as unqualified-search-registries, and appending v1 syntax to
+    # such a file makes containers/image refuse it entirely ("mixing
+    # sysregistry v1/v2 is not supported").
+    V2_MARKER="^\[\[registry\]\]|^unqualified-search-registries|^short-name-mode|^credential-helpers"
     IS_V2_FORMAT=false
     if [ "$NEED_SUDO" = true ]; then
-        if sudo grep -q "^\[\[registry\]\]" "$CONFIG_FILE" 2>/dev/null; then
+        if sudo grep -Eq "$V2_MARKER" "$CONFIG_FILE" 2>/dev/null; then
             IS_V2_FORMAT=true
         fi
     else
-        if grep -q "^\[\[registry\]\]" "$CONFIG_FILE" 2>/dev/null; then
+        if grep -Eq "$V2_MARKER" "$CONFIG_FILE" 2>/dev/null; then
             IS_V2_FORMAT=true
         fi
     fi


### PR DESCRIPTION
## Summary

`hack/registry.sh` treats Podman 5 `registries.conf` (v2 top-level keys only, no `[[registry]]`) as v1 and appends a v1 insecure stanza. That yields:

> "mixing sysregistry v1/v2 is not supported"

…and breaks e2e deploy/remote against `registry.localtest.me`.

## Fix

Detect v2 via `[[registry]]` **or** `unqualified-search-registries` / `short-name-mode` / `credential-helpers`, then append v2 `[[registry]]` config.

## Evidence

- [#3991 node e2e](https://github.com/knative/func/actions/runs/31105688428/job/92631158245)
- [#3992 springboot e2e](https://github.com/knative/func/actions/runs/31111676286/job/92651723833)
- [main after #3992, node e2e](https://github.com/knative/func/actions/runs/31114288068/job/92661245484)