### PR TITLE
feat(mcp): add config_ci tool for CI/CD workflow generation

### DIFF
--- a/pkg/mcp/instructions.md
+++ b/pkg/mcp/instructions.md
@@ -166,3 +166,12 @@ A first-time deploy can be detected by checking the func.yaml for a value in the
 - `config_volumes_add` — adds a volume; accepts `type` (configmap, secret, pvc, emptydir), `mountPath`, `source`, `medium`, `size`, `readOnly`
 - `config_volumes_remove` — removes a volume by `mountPath`
 - add/remove modify local func.yaml only (changes take effect on next deploy)
+
+### config_ci
+
+- **BEFORE calling:** Consider reading `func://help/config/ci` for authoritative usage
+- Requires the `path` parameter (absolute path to the Function directory)
+- Generates a GitHub Actions workflow (`.github/workflows/func-deploy.yaml` by default) that builds, tests, and deploys the Function on every push to `branch`
+- This is the last step of the production lifecycle: create → build/deploy → **config_ci** to wire up continuous deployment
+- Fails if a workflow file already exists at that path unless `force` is set to `true`
+- **IMPORTANT:** This command is gated behind an experimental feature flag. If it fails with an error like `unknown command "ci" for "config"`, the `func` binary backing this MCP server does not have `FUNC_ENABLE_CI_CONFIG=true` set in its environment — inform the user they need to set that environment variable when starting the MCP server (e.g. in their MCP client's server config) and restart it

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -118,6 +118,7 @@ func New(options ...Option) *Server {
 	mcp.AddTool(i, configEnvsListTool, s.configEnvsListHandler)
 	mcp.AddTool(i, configEnvsAddTool, s.configEnvsAddHandler)
 	mcp.AddTool(i, configEnvsRemoveTool, s.configEnvsRemoveHandler)
+	mcp.AddTool(i, configCITool, s.configCIHandler)
 
 	// Resources
 	// ---------
@@ -151,6 +152,8 @@ func New(options ...Option) *Server {
 	i.AddResource(newHelpResource(s, "Envs Help", "general help for environment variables", "config", "envs"))
 	i.AddResource(newHelpResource(s, "Envs Add Help", "help for 'config envs add'", "config", "envs", "add"))
 	i.AddResource(newHelpResource(s, "Envs Remove Help", "help for 'config envs remove'", "config", "envs", "remove"))
+
+	i.AddResource(newHelpResource(s, "CI Help", "help for 'config ci'", "config", "ci"))
 
 	s.impl = i
 

--- a/pkg/mcp/tools_config_ci.go
+++ b/pkg/mcp/tools_config_ci.go
@@ -1,0 +1,77 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// config_ci
+
+var configCITool = &mcp.Tool{
+	Name:  "config_ci",
+	Title: "Config CI",
+	Description: `Generates a GitHub Actions workflow to build, test, and deploy a function on push.
+
+Requires the 'func' binary to be running with the FUNC_ENABLE_CI_CONFIG=true
+environment variable set (experimental feature flag). If this is not set, the
+underlying command will fail with an "unknown command" error.
+
+Refuses to overwrite an existing workflow file unless 'force' is set.`,
+	Annotations: &mcp.ToolAnnotations{
+		Title:           "Config CI",
+		ReadOnlyHint:    false,
+		DestructiveHint: ptr(false), // refuses to overwrite an existing workflow unless force is set
+		IdempotentHint:  false,      // re-running without force will fail once the workflow file exists
+	},
+}
+
+type ConfigCIInput struct {
+	Path                         string  `json:"path" jsonschema:"required,Path to the function project directory"`
+	Branch                       *string `json:"branch,omitempty" jsonschema:"Git branch to trigger the workflow on push (defaults to the current branch)"`
+	WorkflowName                 *string `json:"workflowName,omitempty" jsonschema:"Custom name for the generated workflow"`
+	KubeconfigSecretName         *string `json:"kubeconfigSecretName,omitempty" jsonschema:"Name of the GitHub Actions secret containing the kubeconfig, e.g. secret.YOUR_CUSTOM_KUBECONFIG"`
+	RegistryLoginUrlVariableName *string `json:"registryLoginUrlVariableName,omitempty" jsonschema:"Name of the GitHub Actions variable containing the registry login URL, e.g. vars.YOUR_REGISTRY_LOGIN_URL"`
+	RegistryUserVariableName     *string `json:"registryUserVariableName,omitempty" jsonschema:"Name of the GitHub Actions variable containing the registry username, e.g. vars.YOUR_REGISTRY_USER"`
+	RegistryPassSecretName       *string `json:"registryPassSecretName,omitempty" jsonschema:"Name of the GitHub Actions secret containing the registry password, e.g. secret.YOUR_REGISTRY_PASSWORD"`
+	RegistryUrlVariableName      *string `json:"registryUrlVariableName,omitempty" jsonschema:"Name of the GitHub Actions variable containing the full registry URL, e.g. vars.YOUR_REGISTRY_URL"`
+	RegistryLogin                *bool   `json:"registryLogin,omitempty" jsonschema:"Add a registry login step to the generated workflow"`
+	Remote                       *bool   `json:"remote,omitempty" jsonschema:"Build the function on a Tekton-enabled cluster instead of in the workflow runner"`
+	SelfHostedRunner             *bool   `json:"selfHostedRunner,omitempty" jsonschema:"Use a 'self-hosted' runner instead of the default 'ubuntu-latest'"`
+	TestStep                     *bool   `json:"testStep,omitempty" jsonschema:"Add a language-specific test step (supported: go, node, typescript, python, quarkus)"`
+	Force                        *bool   `json:"force,omitempty" jsonschema:"Overwrite an existing GitHub workflow file"`
+	Verbose                      *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
+}
+
+func (i ConfigCIInput) Args() []string {
+	args := []string{"ci", "--path", i.Path}
+	args = appendStringFlag(args, "--branch", i.Branch)
+	args = appendStringFlag(args, "--workflow-name", i.WorkflowName)
+	args = appendStringFlag(args, "--kubeconfig-secret-name", i.KubeconfigSecretName)
+	args = appendStringFlag(args, "--registry-login-url-variable-name", i.RegistryLoginUrlVariableName)
+	args = appendStringFlag(args, "--registry-user-variable-name", i.RegistryUserVariableName)
+	args = appendStringFlag(args, "--registry-pass-secret-name", i.RegistryPassSecretName)
+	args = appendStringFlag(args, "--registry-url-variable-name", i.RegistryUrlVariableName)
+	args = appendBoolFlag(args, "--registry-login", i.RegistryLogin)
+	args = appendBoolFlag(args, "--remote", i.Remote)
+	args = appendBoolFlag(args, "--self-hosted-runner", i.SelfHostedRunner)
+	args = appendBoolFlag(args, "--test-step", i.TestStep)
+	args = appendBoolFlag(args, "--force", i.Force)
+	args = appendBoolFlag(args, "--verbose", i.Verbose)
+	return args
+}
+
+type ConfigCIOutput struct {
+	Message string `json:"message" jsonschema:"Output message"`
+}
+
+func (s *Server) configCIHandler(ctx context.Context, r *mcp.CallToolRequest, input ConfigCIInput) (result *mcp.CallToolResult, output ConfigCIOutput, err error) {
+	out, err := s.executor.Execute(ctx, "config", input.Args()...)
+	if err != nil {
+		err = fmt.Errorf("%w\n%s", err, string(out))
+		return
+	}
+	output = ConfigCIOutput{Message: string(out)}
+	return
+}

--- a/pkg/mcp/tools_config_ci_test.go
+++ b/pkg/mcp/tools_config_ci_test.go
@@ -1,0 +1,150 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"knative.dev/func/pkg/mcp/mock"
+)
+
+// TestTool_ConfigCI ensures the config_ci tool executes with all arguments forwarded.
+func TestTool_ConfigCI(t *testing.T) {
+	stringFlags := map[string]struct {
+		jsonKey string
+		flag    string
+		value   string
+	}{
+		"path":                         {"path", "--path", "."},
+		"branch":                       {"branch", "--branch", "main"},
+		"workflowName":                 {"workflowName", "--workflow-name", "Func Deploy"},
+		"kubeconfigSecretName":         {"kubeconfigSecretName", "--kubeconfig-secret-name", "KUBECONFIG"},
+		"registryLoginUrlVariableName": {"registryLoginUrlVariableName", "--registry-login-url-variable-name", "REGISTRY_LOGIN_URL"},
+		"registryUserVariableName":     {"registryUserVariableName", "--registry-user-variable-name", "REGISTRY_USERNAME"},
+		"registryPassSecretName":       {"registryPassSecretName", "--registry-pass-secret-name", "REGISTRY_PASSWORD"},
+		"registryUrlVariableName":      {"registryUrlVariableName", "--registry-url-variable-name", "REGISTRY_URL"},
+	}
+
+	boolFlags := map[string]string{
+		"registryLogin":    "--registry-login",
+		"remote":           "--remote",
+		"selfHostedRunner": "--self-hosted-runner",
+		"testStep":         "--test-step",
+		"force":            "--force",
+		"verbose":          "--verbose",
+	}
+
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		if subcommand != "config" {
+			t.Fatalf("expected subcommand 'config', got %q", subcommand)
+		}
+
+		if len(args) < 1 {
+			t.Fatalf("expected at least 1 arg, got %d: %v", len(args), args)
+		}
+
+		if args[0] != "ci" {
+			t.Fatalf("expected args[0]='ci', got %q", args[0])
+		}
+
+		// args[1:] are the flags
+		validateArgLength(t, args[1:], len(stringFlags), len(boolFlags))
+		validateStringFlags(t, args[1:], stringFlags)
+		validateBoolFlags(t, args[1:], boolFlags)
+
+		return []byte("GitHub workflow generated successfully\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inputArgs := buildInputArgs(stringFlags, boolFlags)
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_ci",
+		Arguments: inputArgs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_ConfigCI_MinimalArgs ensures the config_ci tool executes with only the
+// required 'path' parameter, omitting all optional flags.
+func TestTool_ConfigCI_MinimalArgs(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		if subcommand != "config" {
+			t.Fatalf("expected subcommand 'config', got %q", subcommand)
+		}
+
+		// "ci" + "--path" + "." = 3 args
+		if len(args) != 3 {
+			t.Fatalf("expected 3 args, got %d: %v", len(args), args)
+		}
+		if args[0] != "ci" {
+			t.Fatalf("expected args[0]='ci', got %q", args[0])
+		}
+
+		argsMap := argsToMap(args[1:])
+		if val, ok := argsMap["--path"]; !ok || val != "." {
+			t.Fatalf("expected --path='.', got %q", val)
+		}
+
+		return []byte("GitHub workflow generated successfully\n"), nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_ci",
+		Arguments: map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+	if !executor.ExecuteInvoked {
+		t.Fatal("executor was not invoked")
+	}
+}
+
+// TestTool_ConfigCI_Error ensures the config_ci tool propagates executor errors,
+// such as the "unknown command" error returned when FUNC_ENABLE_CI_CONFIG is not set.
+func TestTool_ConfigCI_Error(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+		return []byte(`unknown command "ci" for "config"`), errors.New("executor error")
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "config_ci",
+		Arguments: map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result, got success")
+	}
+}


### PR DESCRIPTION
## Summary
- Agents using the func MCP server had no way to complete the production lifecycle's CI/CD-wiring step, since `func config ci` had no corresponding MCP tool.
- Adds a `config_ci` tool that wraps `func config ci`, letting an agent generate a GitHub Actions deploy workflow (`.github/workflows/func-deploy.yaml`) for a Function, following the same pattern as the existing `config_envs_*`/`config_labels_*`/`config_volumes_*` tools.
- Registers a `func://help/config/ci` help resource and documents usage (including the `FUNC_ENABLE_CI_CONFIG` feature-flag requirement) in the MCP agent instructions.

## Changes
- `pkg/mcp/tools_config_ci.go`: new `config_ci` tool, input/output types, and handler
- `pkg/mcp/mcp.go`: register the tool and its help resource
- `pkg/mcp/instructions.md`: document `config_ci` usage and the `FUNC_ENABLE_CI_CONFIG` caveat
- `pkg/mcp/tools_config_ci_test.go`: tests for flag forwarding, minimal-args invocation, and error passthrough

## Test plan
- [x] `go test ./pkg/mcp/...` passes (93.6% coverage)
- [x] `make test` — new tests pass; unrelated pre-existing failures confirmed present on `main` too (sandboxed git/network restrictions)
- [x] `make check` — 0 lint issues, clean imports/spelling/whitespace/EOF