### PR TITLE
feat(mcp): return structured JSON from the 'list' tool

### DIFF
--- a/pkg/mcp/instructions.md
+++ b/pkg/mcp/instructions.md
@@ -152,7 +152,7 @@ A first-time deploy can be detected by checking the func.yaml for a value in the
 - **FIRST:** Read `func://help/list` for authoritative usage information
 - Does NOT use path parameter (operates on cluster, not local files)
 - Optional `namespace` parameter to list Functions in specific namespace
-- Returns list of deployed Functions in current/specified namespace
+- Returns structured JSON: an `items` array (name, namespace, runtime, url, ready, deployer for each deployed Function; empty if none found) plus `warnings` for any non-fatal issues encountered while listing (e.g. a deployer backend that couldn't be reached)
 
 ### describe
 

--- a/pkg/mcp/tools_list.go
+++ b/pkg/mcp/tools_list.go
@@ -1,10 +1,14 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	fn "knative.dev/func/pkg/functions"
 )
 
 var listTool = &mcp.Tool{
@@ -18,14 +22,36 @@ var listTool = &mcp.Tool{
 	},
 }
 
+// noFunctionsFoundPrefix is the leading text of the human-readable message
+// `func list` prints on stdout (see cmd/list.go printNoFunctionsFound) when
+// there are zero results. This is printed even under `--output json`
+// instead of an empty JSON array, so it must be special-cased below rather
+// than treated as a JSON parse failure.
+const noFunctionsFoundPrefix = "no functions found"
+
 func (s *Server) listHandler(ctx context.Context, r *mcp.CallToolRequest, input ListInput) (result *mcp.CallToolResult, output ListOutput, err error) {
-	out, err := s.executor.Execute(ctx, "list", input.Args()...)
+	// ExecuteSplit (rather than Execute/CombinedOutput) is required here for
+	// the same reason as the describe tool: stdout must stay a clean,
+	// unmixed JSON payload so it can be parsed regardless of anything the
+	// CLI writes to stderr.
+	stdout, stderr, err := s.executor.ExecuteSplit(ctx, "list", input.Args()...)
 	if err != nil {
-		err = fmt.Errorf("%w\n%s", err, string(out))
+		err = fmt.Errorf("%w\nstdout: %s\nstderr: %s", err, string(stdout), string(stderr))
 		return
 	}
+
+	items := []fn.ListItem{}
+	trimmed := bytes.TrimSpace(stdout)
+	if len(trimmed) != 0 && !bytes.HasPrefix(trimmed, []byte(noFunctionsFoundPrefix)) {
+		if err = json.Unmarshal(trimmed, &items); err != nil {
+			err = fmt.Errorf("failed to parse list output: %w\n%s", err, string(stdout))
+			return
+		}
+	}
+
 	output = ListOutput{
-		Message: string(out),
+		Items:    items,
+		Warnings: strings.TrimSpace(string(stderr)),
 	}
 	return
 }
@@ -35,7 +61,6 @@ func (s *Server) listHandler(ctx context.Context, r *mcp.CallToolRequest, input 
 type ListInput struct {
 	AllNamespaces *bool   `json:"allNamespaces,omitempty" jsonschema:"List functions in all namespaces (overrides namespace parameter)"`
 	Namespace     *string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace to list functions in (default: current namespace)"`
-	Output        *string `json:"output,omitempty" jsonschema:"Output format: human, plain, json, xml, or yaml"`
 	Verbose       *bool   `json:"verbose,omitempty" jsonschema:"Enable verbose logging output"`
 }
 
@@ -44,12 +69,19 @@ func (i ListInput) Args() []string {
 
 	args = appendBoolFlag(args, "--all-namespaces", i.AllNamespaces)
 	args = appendStringFlag(args, "--namespace", i.Namespace)
-	args = appendStringFlag(args, "--output", i.Output)
 	args = appendBoolFlag(args, "--verbose", i.Verbose)
+
+	// The tool's contract is structured JSON, regardless of caller input.
+	args = append(args, "--output", "json")
 	return args
 }
 
 // ListOutput defines the structured output returned by the list tool.
 type ListOutput struct {
-	Message string `json:"message" jsonschema:"Output message"`
+	Items []fn.ListItem `json:"items" jsonschema:"Deployed Functions matching the query (empty if none found)"`
+	// A non-fatal warning on stderr (e.g. a cluster connectivity issue for
+	// one of several configured deployers) can accompany an otherwise
+	// successful, but partial, list. Surface it so the agent doesn't
+	// mistake a short list for the complete picture.
+	Warnings string `json:"warnings,omitempty" jsonschema:"Non-fatal warnings emitted while listing Functions"`
 }

--- a/pkg/mcp/tools_list_test.go
+++ b/pkg/mcp/tools_list_test.go
@@ -2,22 +2,23 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"knative.dev/func/pkg/mcp/mock"
 )
 
-// TestTool_List_Args ensures the list tool executes with all arguments passed correctly.
+// TestTool_List_Args ensures the list tool executes with all arguments passed
+// correctly, always forcing --output json regardless of caller input, and
+// that the structured JSON output from the CLI is parsed into ListOutput.
 func TestTool_List_Args(t *testing.T) {
-	// Test data - defined once and used for both input and validation
 	stringFlags := map[string]struct {
 		jsonKey string
 		flag    string
 		value   string
 	}{
 		"namespace": {"namespace", "--namespace", "prod"},
-		"output":    {"output", "--output", "json"},
 	}
 
 	boolFlags := map[string]string{
@@ -26,16 +27,24 @@ func TestTool_List_Args(t *testing.T) {
 	}
 
 	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, error) {
+	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
 		if subcommand != "list" {
 			t.Fatalf("expected subcommand 'list', got %q", subcommand)
 		}
 
-		validateArgLength(t, args, len(stringFlags), len(boolFlags))
+		// len(stringFlags) + 1 for the always-appended --output json
+		validateArgLength(t, args, len(stringFlags)+1, len(boolFlags))
 		validateStringFlags(t, args, stringFlags)
 		validateBoolFlags(t, args, boolFlags)
+		validateStringFlags(t, args, map[string]struct {
+			jsonKey string
+			flag    string
+			value   string
+		}{
+			"output": {"output", "--output", "json"},
+		})
 
-		return []byte("NAME\tNAMESPACE\tRUNTIME\nmy-func\tprod\tgo\n"), nil
+		return []byte(`[{"name":"my-func","namespace":"prod","runtime":"go","url":"https://my-func.prod.example.com","ready":"true","deployer":"knative"}]`), nil, nil
 	}
 
 	client, _, err := newTestPair(t, WithExecutor(executor))
@@ -43,10 +52,8 @@ func TestTool_List_Args(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Build input arguments from test data
 	inputArgs := buildInputArgs(stringFlags, boolFlags)
 
-	// Invoke tool with all optional arguments
 	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "list",
 		Arguments: inputArgs,
@@ -57,7 +64,198 @@ func TestTool_List_Args(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result)
 	}
-	if !executor.ExecuteInvoked {
+	if !executor.ExecuteSplitInvoked {
 		t.Fatal("executor was not invoked")
+	}
+
+	var output ListOutput
+	if err := unmarshalStructuredContent(result, &output); err != nil {
+		t.Fatal(err)
+	}
+	if len(output.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d: %v", len(output.Items), output.Items)
+	}
+	item := output.Items[0]
+	if item.Name != "my-func" {
+		t.Errorf("expected name %q, got %q", "my-func", item.Name)
+	}
+	if item.Namespace != "prod" {
+		t.Errorf("expected namespace %q, got %q", "prod", item.Namespace)
+	}
+	if item.Runtime != "go" {
+		t.Errorf("expected runtime %q, got %q", "go", item.Runtime)
+	}
+	if item.URL != "https://my-func.prod.example.com" {
+		t.Errorf("expected url %q, got %q", "https://my-func.prod.example.com", item.URL)
+	}
+	if item.Ready != "true" {
+		t.Errorf("expected ready %q, got %q", "true", item.Ready)
+	}
+	if item.Deployer != "knative" {
+		t.Errorf("expected deployer %q, got %q", "knative", item.Deployer)
+	}
+	if output.Warnings != "" {
+		t.Errorf("expected no warnings, got %q", output.Warnings)
+	}
+}
+
+// TestTool_List_NoFunctionsFound ensures the handler treats the CLI's
+// human-readable "no functions found" message (which `func list` prints on
+// stdout even under --output json, see cmd/list.go printNoFunctionsFound) as
+// a valid empty result rather than a JSON parse failure.
+func TestTool_List_NoFunctionsFound(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
+		return []byte(`no functions found in namespace 'prod'
+
+'func list' shows functions that have been deployed to your cluster.`), nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "list",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+
+	var output ListOutput
+	if err := unmarshalStructuredContent(result, &output); err != nil {
+		t.Fatal(err)
+	}
+	if len(output.Items) != 0 {
+		t.Errorf("expected no items, got %v", output.Items)
+	}
+}
+
+// TestTool_List_EmptyStdout ensures a handler that receives completely empty
+// stdout (no output at all) also resolves to an empty, non-erroring result.
+func TestTool_List_EmptyStdout(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
+		return []byte(""), nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "list",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+
+	var output ListOutput
+	if err := unmarshalStructuredContent(result, &output); err != nil {
+		t.Fatal(err)
+	}
+	if len(output.Items) != 0 {
+		t.Errorf("expected no items, got %v", output.Items)
+	}
+}
+
+// TestTool_List_MalformedJSON ensures the handler returns an error (rather
+// than panicking) when the CLI output cannot be parsed as JSON and doesn't
+// match the known "no functions found" message.
+func TestTool_List_MalformedJSON(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
+		return []byte("not json"), nil, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "list",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected list to return an error result for malformed JSON output")
+	}
+}
+
+// TestTool_List_StderrWarningDoesNotBreakParsing ensures the handler parses
+// the JSON payload correctly even when the CLI writes a warning to stderr on
+// an otherwise-successful call, and surfaces that warning in the output.
+func TestTool_List_StderrWarningDoesNotBreakParsing(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
+		stdout := []byte(`[{"name":"my-func","namespace":"prod","runtime":"go","url":"https://my-func.prod.example.com","ready":"true","deployer":"knative"}]`)
+		stderr := []byte("Warning: cannot connect to keda deployer - skipping\n")
+		return stdout, stderr, nil
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "list",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result)
+	}
+
+	var output ListOutput
+	if err := unmarshalStructuredContent(result, &output); err != nil {
+		t.Fatal(err)
+	}
+	if len(output.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d: %v", len(output.Items), output.Items)
+	}
+	wantWarning := "Warning: cannot connect to keda deployer - skipping"
+	if output.Warnings != wantWarning {
+		t.Errorf("expected warnings %q, got %q", wantWarning, output.Warnings)
+	}
+}
+
+// TestTool_List_CLIError ensures a CLI failure (non-zero exit) surfaces as
+// an error result including stdout/stderr context.
+func TestTool_List_CLIError(t *testing.T) {
+	executor := mock.NewExecutor()
+	executor.ExecuteSplitFn = func(ctx context.Context, subcommand string, args ...string) ([]byte, []byte, error) {
+		return nil, []byte("Error: cannot connect to cluster"), fmt.Errorf("exit status 1")
+	}
+
+	client, _, err := newTestPair(t, WithExecutor(executor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "list",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected list to return an error result when the CLI fails")
 	}
 }


### PR DESCRIPTION
# Changes

- 🎁 Update the `list` MCP tool to return structured JSON (`items`: name, namespace, runtime, url, ready, deployer; plus `warnings`) instead of an opaque `message` string, following the same "semantic" pattern introduced by the `describe` tool in #3995
- 🎁 Force `--output json` internally regardless of caller input, using `ExecuteSplit` so stderr content can never corrupt the parsed JSON (same rationale as `describe`)
- 🎁 Handle the CLI's "no functions found" text (printed on stdout even under `--output json`) as a valid empty result instead of a parse error
- 🎁 Add tests covering args, empty results, malformed output, stderr warnings, and CLI errors
- 🎁 Update `pkg/mcp/instructions.md` to document the new `items`/`warnings` output shape

This follows up on review feedback from #3995 (https://github.com/knative/func/pull/3995#discussion_r3746554765), which identified `list` as the highest-priority command to move from the "passthrough" (`Message: string`) pattern to the "semantic" (structured, parsed) pattern, since it already supports `--output json`.

/kind enhancement

Fixes #

**Release Note**
​```release-note
Changed the `list` MCP tool to return structured JSON (an `items` array with each Function's name, namespace, runtime, url, readiness, and deployer, plus a `warnings` field) instead of raw CLI text output.
​```

**Docs**
​```docs
​```