### PR TITLE
fix(git): avoid misclassifying GitLab repository URLs

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	giturls "github.com/chainguard-dev/git-urls"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 
 	"knative.dev/func/pkg/git/github"
@@ -37,16 +38,24 @@ func (sp SupportedProviders) PrettyString() string {
 	return b.String()
 }
 
-func GitProviderName(url string) (string, error) {
-	switch {
-	case strings.Contains(url, "github"):
-		return GitHubProvider, nil
-	case strings.Contains(url, "gitlab"):
-		return GitLabProvider, nil
-	case strings.Contains(url, "bitbucket-cloud"):
-		//return BitBucketProvider, nil
+func GitProviderName(rawURL string) (string, error) {
+	parsedURL, err := giturls.ParseTransport(rawURL)
+	if err != nil {
+		parsedURL, err = giturls.ParseScp(rawURL)
 	}
-	return "", fmt.Errorf("runtime for url %q is not supported, please use one of supported runtimes: %s", url, SupportedProvidersList.PrettyString())
+	if err == nil {
+		for _, label := range strings.Split(strings.ToLower(parsedURL.Hostname()), ".") {
+			switch label {
+			case GitHubProvider:
+				return GitHubProvider, nil
+			case GitLabProvider:
+				return GitLabProvider, nil
+			case BitBucketProvider:
+				//return BitBucketProvider, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("runtime for url %q is not supported, please use one of supported runtimes: %s", rawURL, SupportedProvidersList.PrettyString())
 }
 
 // RepoOwnerAndNameFromUrl for input url returns repo owner and repo name

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -74,6 +74,51 @@ func TestGitProviderName(t *testing.T) {
 			wantErr:      false,
 		},
 		{
+			name:         "GitLab repository path contains GitHub",
+			url:          "https://gitlab.com/foo/github-actions",
+			wantProvider: GitLabProvider,
+			wantErr:      false,
+		},
+		{
+			name:         "GitHub repository path contains GitLab",
+			url:          "https://github.com/foo/gitlab-runner",
+			wantProvider: GitHubProvider,
+			wantErr:      false,
+		},
+		{
+			name:         "GitHub SSH",
+			url:          "git@github.com:foo/bar.git",
+			wantProvider: GitHubProvider,
+			wantErr:      false,
+		},
+		{
+			name:         "GitLab SCP repository path contains GitHub",
+			url:          "git@gitlab.com:foo/github-actions.git",
+			wantProvider: GitLabProvider,
+			wantErr:      false,
+		},
+		{
+			name:    "Provider name only in path - not supported",
+			url:     "https://example.com/foo/github-actions",
+			wantErr: true,
+		},
+		{
+			name:    "Provider name only in username - not supported",
+			url:     "https://github@example.com/foo/bar",
+			wantErr: true,
+		},
+		{
+			name:    "Provider name is not a complete host label - not supported",
+			url:     "https://notgithub.example.com/foo/bar",
+			wantErr: true,
+		},
+		{
+			name:         "Uppercase GitLab host",
+			url:          "https://GITLAB.COM/foo/bar",
+			wantProvider: GitLabProvider,
+			wantErr:      false,
+		},
+		{
 			name: "Bitbucket Cloud - not supported",
 			url:  "https://bitbucket.com/foo/bar",
 			//wantProvider: BitBucketProvider,


### PR DESCRIPTION
## Changes

Fix automatic Git provider detection so repository path text cannot be mistaken for the provider hostname.

Previously, `GitProviderName` searched the complete repository URL with `strings.Contains`. Because GitHub was checked first, a valid GitLab URL such as `https://gitlab.com/foo/github-actions` could incorrectly be classified as GitHub.

Provider detection now parses normal transport and SCP-style Git URLs using the repository's existing `github.com/chainguard-dev/git-urls` dependency, considers only the parsed hostname, and compares provider names as complete, case-insensitive hostname labels.

This preserves GitHub and GitLab detection while preventing repository paths, user information, and partial hostname labels from influencing the result. For example:

    https://gitlab.com/foo/github-actions
      -> GitLab

    https://github.com/foo/gitlab-runner
      -> GitHub

    git@gitlab.com:foo/github-actions.git
      -> GitLab

    https://example.com/foo/github-actions
      -> unsupported

    https://notgithub.example.com/foo/bar
      -> unsupported

Validation completed with Go 1.26.5 in the official `golang:1.26` Linux/ARM64 container:

- `go test ./pkg/git`
- `go vet ./pkg/git`
- `go test ./cmd/... ./pkg/git/...`
- `gofmt -d`
- `git diff --check`
- `make check-whitespace check-eof`

No dependency was added; `github.com/chainguard-dev/git-urls` was already used by the repository.

/kind bug

**Release Note**

```release-note
Fixed automatic Git provider detection so repository path text cannot cause GitLab URLs to be mistaken for GitHub.
```

**Docs**

```docs
NONE
```
