### PR TITLE
refactor(listers): inject k8s.Client via DI

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -60,6 +60,7 @@ func NewTestClient(options ...fn.Option) ClientFactory {
 // 'Verbose' indicates the system should write out a higher amount of logging.
 func NewClient(cfg ClientConfig, options ...fn.Option) (*fn.Client, func()) {
 	var (
+		kc = k8s.NewClient(k8s.GetClientConfig())
 		t  = newTransport(cfg.InsecureSkipVerify)                                // may provide a custom impl which proxies
 		c  = newCredentialsProvider(config.Dir(), t, "", cfg.InsecureSkipVerify) // for accessing registries
 		d  = newKnativeDeployer(cfg.Verbose)                                     // default deployer (can be overridden via options)
@@ -76,7 +77,7 @@ func NewClient(cfg ClientConfig, options ...fn.Option) (*fn.Client, func()) {
 				k8s.NewDescriber(cfg.Verbose, k8s.WithDescriberTransport(t)),
 				keda.NewDescriber(cfg.Verbose, keda.WithDescriberTransport(t)),
 			),
-			fn.WithListers(knative.NewLister(cfg.Verbose), k8s.NewLister(cfg.Verbose), keda.NewLister(cfg.Verbose)),
+			fn.WithListers(knative.NewLister(kc, cfg.Verbose), k8s.NewLister(kc, cfg.Verbose), keda.NewLister(kc, cfg.Verbose)),
 			fn.WithDeployer(d),
 			fn.WithPipelinesProvider(pp),
 			fn.WithPusher(docker.NewPusher(

--- a/cmd/completion_util.go
+++ b/cmd/completion_util.go
@@ -16,9 +16,10 @@ import (
 )
 
 func CompleteFunctionList(cmd *cobra.Command, args []string, toComplete string) (strings []string, directive cobra.ShellCompDirective) {
+	kc := k8s.NewClient(k8s.GetClientConfig())
 	listers := []fn.Lister{
-		knative.NewLister(false),
-		k8s.NewLister(false),
+		knative.NewLister(kc, false),
+		k8s.NewLister(kc, false),
 	}
 
 	items := []fn.ListItem{}

--- a/e2e/e2e_core_test.go
+++ b/e2e/e2e_core_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	fn "knative.dev/func/pkg/functions"
+	"knative.dev/func/pkg/k8s"
 	"knative.dev/func/pkg/knative"
 )
 
@@ -398,7 +399,8 @@ func TestCore_Delete(t *testing.T) {
 	}
 
 	// Check it appears in the list
-	client := fn.New(fn.WithListers(knative.NewLister(false)))
+	kc := k8s.NewClient(k8s.GetClientConfig())
+	client := fn.New(fn.WithListers(knative.NewLister(kc, false)))
 	list, err := client.List(t.Context(), Namespace)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/functions/client_int_test.go
+++ b/pkg/functions/client_int_test.go
@@ -666,6 +666,7 @@ func resetEnv() {
 // newClient creates an instance of the func client with concrete impls
 // sufficient for running integration tests.
 func newClient(verbose bool) *fn.Client {
+	kc := k8s.NewClient(k8s.GetClientConfig())
 	return fn.New(
 		fn.WithRegistry(DefaultIntTestRegistry),
 		fn.WithRegistryInsecure(true),
@@ -675,13 +676,14 @@ func newClient(verbose bool) *fn.Client {
 		fn.WithDeployer(knative.NewDeployer(knative.WithDeployerVerbose(verbose))),
 		fn.WithDescribers(knative.NewDescriber(verbose), k8s.NewDescriber(verbose)),
 		fn.WithRemovers(knative.NewRemover(verbose), k8s.NewRemover(verbose)),
-		fn.WithListers(knative.NewLister(verbose), k8s.NewLister(verbose)),
+		fn.WithListers(knative.NewLister(kc, verbose), k8s.NewLister(kc, verbose)),
 		fn.WithVerbose(verbose),
 	)
 }
 
 // copy of newClient just with s2i methods instead
 func newClientWithS2i(verbose bool) *fn.Client {
+	kc := k8s.NewClient(k8s.GetClientConfig())
 	return fn.New(
 		fn.WithRegistry(DefaultIntTestRegistry),
 		fn.WithRegistryInsecure(true),
@@ -692,7 +694,7 @@ func newClientWithS2i(verbose bool) *fn.Client {
 		fn.WithDeployer(knative.NewDeployer(knative.WithDeployerVerbose(verbose))),
 		fn.WithDescribers(knative.NewDescriber(verbose), k8s.NewDescriber(verbose)),
 		fn.WithRemovers(knative.NewRemover(verbose), k8s.NewRemover(verbose)),
-		fn.WithListers(knative.NewLister(verbose), k8s.NewLister(verbose)),
+		fn.WithListers(knative.NewLister(kc, verbose), k8s.NewLister(kc, verbose)),
 	)
 }
 

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -14,6 +15,42 @@ const (
 	DefaultWaitingTimeout     = 120 * time.Second
 	DefaultErrorWindowTimeout = 2 * time.Second
 )
+
+type Client struct {
+	cc  clientcmd.ClientConfig
+	cfg *rest.Config
+}
+
+func NewClient(cc clientcmd.ClientConfig) *Client {
+	return &Client{cc: cc}
+}
+
+func NewClientFromConfig(cfg *rest.Config) *Client {
+	return &Client{cfg: cfg}
+}
+
+func (c *Client) ClientConfig() (*rest.Config, error) {
+	if c.cfg != nil {
+		return c.cfg, nil
+	}
+	if c.cc == nil {
+		return nil, fmt.Errorf("no kubernetes client configuration available")
+	}
+	cfg, err := c.cc.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client config: %w", err)
+	}
+	c.cfg = cfg
+	return c.cfg, nil
+}
+
+func (c *Client) Clientset() (*kubernetes.Clientset, error) {
+	cfg, err := c.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(cfg)
+}
 
 func NewClientAndResolvedNamespace(ns string) (*kubernetes.Clientset, string, error) {
 	var err error

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"k8s.io/client-go/dynamic"
@@ -17,8 +18,10 @@ const (
 )
 
 type Client struct {
-	cc  clientcmd.ClientConfig
-	cfg *rest.Config
+	cc     clientcmd.ClientConfig
+	cfg    *rest.Config
+	cfgErr error
+	o      sync.Once
 }
 
 func NewClient(cc clientcmd.ClientConfig) *Client {
@@ -30,18 +33,20 @@ func NewClientFromConfig(cfg *rest.Config) *Client {
 }
 
 func (c *Client) ClientConfig() (*rest.Config, error) {
-	if c.cfg != nil {
-		return c.cfg, nil
-	}
-	if c.cc == nil {
-		return nil, fmt.Errorf("no kubernetes client configuration available")
-	}
-	cfg, err := c.cc.ClientConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes client config: %w", err)
-	}
-	c.cfg = cfg
-	return c.cfg, nil
+	c.o.Do(func() {
+		if c.cfg != nil {
+			return
+		}
+		if c.cc == nil {
+			c.cfgErr = fmt.Errorf("no kubernetes client configuration available")
+			return
+		}
+		c.cfg, c.cfgErr = c.cc.ClientConfig()
+		if c.cfgErr != nil {
+			c.cfgErr = fmt.Errorf("failed to create kubernetes client config: %w", c.cfgErr)
+		}
+	})
+	return c.cfg, c.cfgErr
 }
 
 func (c *Client) Clientset() (*kubernetes.Clientset, error) {

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -1,0 +1,81 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestNewClientFromConfig(t *testing.T) {
+	cfg := &rest.Config{Host: "https://example.com:6443"}
+	c := NewClientFromConfig(cfg)
+
+	got, err := c.ClientConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != cfg {
+		t.Error("ClientConfig() should return the same config that was passed in")
+	}
+}
+
+func TestClientClientset(t *testing.T) {
+	cfg := &rest.Config{Host: "https://example.com:6443"}
+	c := NewClientFromConfig(cfg)
+
+	cs, err := c.Clientset()
+	if err != nil {
+		t.Fatalf("unexpected error creating clientset: %v", err)
+	}
+	if cs == nil {
+		t.Fatal("expected non-nil clientset")
+	}
+}
+
+func TestNewClientWithInvalidConfig(t *testing.T) {
+	cc := &fakeClientConfig{err: fmt.Errorf("no kubeconfig")}
+	c := NewClient(cc)
+
+	_, err := c.ClientConfig()
+	if err == nil {
+		t.Fatal("expected error when ClientConfig fails")
+	}
+}
+
+func TestNewClientWithValidConfig(t *testing.T) {
+	cfg := &rest.Config{Host: "https://example.com:6443"}
+	cc := &fakeClientConfig{cfg: cfg}
+	c := NewClient(cc)
+
+	got, err := c.ClientConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Host != "https://example.com:6443" {
+		t.Errorf("expected host https://example.com:6443, got %s", got.Host)
+	}
+}
+
+type fakeClientConfig struct {
+	cfg *rest.Config
+	err error
+}
+
+func (f *fakeClientConfig) RawConfig() (clientcmdapi.Config, error) {
+	return clientcmdapi.Config{}, nil
+}
+
+func (f *fakeClientConfig) ClientConfig() (*rest.Config, error) {
+	return f.cfg, f.err
+}
+
+func (f *fakeClientConfig) Namespace() (string, bool, error) {
+	return "default", false, nil
+}
+
+func (f *fakeClientConfig) ConfigAccess() clientcmd.ConfigAccess {
+	return nil
+}

--- a/pkg/k8s/deployer_int_test.go
+++ b/pkg/k8s/deployer_int_test.go
@@ -10,10 +10,11 @@ import (
 )
 
 func TestInt_FullPath(t *testing.T) {
+	kc := k8s.NewClient(k8s.GetClientConfig())
 	deployertesting.TestInt_FullPath(t,
 		k8s.NewDeployer(k8s.WithDeployerVerbose(false)),
 		k8s.NewRemover(false),
-		k8s.NewLister(false),
+		k8s.NewLister(kc, false),
 		k8s.NewDescriber(false),
 		k8s.KubernetesDeployerName)
 }

--- a/pkg/k8s/lister.go
+++ b/pkg/k8s/lister.go
@@ -24,6 +24,9 @@ func NewLister(kc *Client, verbose bool) fn.Lister {
 }
 
 func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, error) {
+	if l.kc == nil {
+		return nil, fmt.Errorf("kubernetes client is not initialized")
+	}
 	clientset, err := l.kc.Clientset()
 	if err != nil {
 		return nil, fmt.Errorf("unable to create k8s client: %v", err)

--- a/pkg/k8s/lister.go
+++ b/pkg/k8s/lister.go
@@ -12,17 +12,19 @@ import (
 )
 
 type Lister struct {
+	kc      *Client
 	verbose bool
 }
 
-func NewLister(verbose bool) fn.Lister {
+func NewLister(kc *Client, verbose bool) fn.Lister {
 	return &Lister{
+		kc:      kc,
 		verbose: verbose,
 	}
 }
 
 func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, error) {
-	clientset, err := NewKubernetesClientset()
+	clientset, err := l.kc.Clientset()
 	if err != nil {
 		return nil, fmt.Errorf("unable to create k8s client: %v", err)
 	}

--- a/pkg/k8s/lister_int_test.go
+++ b/pkg/k8s/lister_int_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 func TestInt_List(t *testing.T) {
+	kc := k8s.NewClient(k8s.GetClientConfig())
 	listertesting.TestInt_List(t,
-		k8s.NewLister(true),
+		k8s.NewLister(kc, true),
 		k8s.NewDeployer(k8s.WithDeployerVerbose(true)),
 		k8s.NewDescriber(true),
 		k8s.NewRemover(true),

--- a/pkg/k8s/remover_int_test.go
+++ b/pkg/k8s/remover_int_test.go
@@ -10,10 +10,11 @@ import (
 )
 
 func TestInt_Remove(t *testing.T) {
+	kc := k8s.NewClient(k8s.GetClientConfig())
 	removertesting.TestInt_Remove(t,
 		k8s.NewRemover(true),
 		k8s.NewDeployer(k8s.WithDeployerVerbose(true)),
 		k8s.NewDescriber(true),
-		k8s.NewLister(true),
+		k8s.NewLister(kc, true),
 		k8s.KubernetesDeployerName)
 }

--- a/pkg/keda/deployer_int_test.go
+++ b/pkg/keda/deployer_int_test.go
@@ -6,14 +6,16 @@ import (
 	"testing"
 
 	deployertesting "knative.dev/func/pkg/deployer/testing"
+	"knative.dev/func/pkg/k8s"
 	"knative.dev/func/pkg/keda"
 )
 
 func TestInt_FullPath(t *testing.T) {
+	kc := k8s.NewClient(k8s.GetClientConfig())
 	deployertesting.TestInt_FullPath(t,
 		keda.NewDeployer(keda.WithDeployerVerbose(false)),
 		keda.NewRemover(false),
-		keda.NewLister(false),
+		keda.NewLister(kc, false),
 		keda.NewDescriber(false),
 		keda.KedaDeployerName)
 }

--- a/pkg/keda/lister.go
+++ b/pkg/keda/lister.go
@@ -14,22 +14,29 @@ import (
 )
 
 type Lister struct {
+	kc      *k8s.Client
 	verbose bool
 }
 
-func NewLister(verbose bool) fn.Lister {
+func NewLister(kc *k8s.Client, verbose bool) fn.Lister {
 	return &Lister{
+		kc:      kc,
 		verbose: verbose,
 	}
 }
 
 func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, error) {
-	clientset, err := k8s.NewKubernetesClientset()
+	clientset, err := l.kc.Clientset()
 	if err != nil {
 		return nil, fmt.Errorf("unable to create k8s client: %v", err)
 	}
 
-	httpScaledObjectClientset, err := NewHTTPScaledObjectClientset()
+	restConfig, err := l.kc.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get kubernetes client config: %v", err)
+	}
+
+	httpScaledObjectClientset, err := versioned.NewForConfig(restConfig)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create HTTPScaledObject client: %v", err)
 	}

--- a/pkg/keda/lister.go
+++ b/pkg/keda/lister.go
@@ -26,6 +26,9 @@ func NewLister(kc *k8s.Client, verbose bool) fn.Lister {
 }
 
 func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, error) {
+	if l.kc == nil {
+		return nil, fmt.Errorf("kubernetes client is not initialized")
+	}
 	clientset, err := l.kc.Clientset()
 	if err != nil {
 		return nil, fmt.Errorf("unable to create k8s client: %v", err)

--- a/pkg/keda/lister_int_test.go
+++ b/pkg/keda/lister_int_test.go
@@ -5,13 +5,15 @@ package keda_test
 import (
 	"testing"
 
+	"knative.dev/func/pkg/k8s"
 	"knative.dev/func/pkg/keda"
 	listertesting "knative.dev/func/pkg/lister/testing"
 )
 
 func TestInt_List(t *testing.T) {
+	kc := k8s.NewClient(k8s.GetClientConfig())
 	listertesting.TestInt_List(t,
-		keda.NewLister(true),
+		keda.NewLister(kc, true),
 		keda.NewDeployer(keda.WithDeployerVerbose(true)),
 		keda.NewDescriber(true),
 		keda.NewRemover(true),

--- a/pkg/keda/remover_int_test.go
+++ b/pkg/keda/remover_int_test.go
@@ -5,15 +5,17 @@ package keda_test
 import (
 	"testing"
 
+	"knative.dev/func/pkg/k8s"
 	"knative.dev/func/pkg/keda"
 	removertesting "knative.dev/func/pkg/remover/testing"
 )
 
 func TestInt_Remove(t *testing.T) {
+	kc := k8s.NewClient(k8s.GetClientConfig())
 	removertesting.TestInt_Remove(t,
 		keda.NewRemover(true),
 		keda.NewDeployer(keda.WithDeployerVerbose(true)),
 		keda.NewDescriber(true),
-		keda.NewLister(true),
+		keda.NewLister(kc, true),
 		keda.KedaDeployerName)
 }

--- a/pkg/knative/client.go
+++ b/pkg/knative/client.go
@@ -41,7 +41,7 @@ func NewEventingClient(namespace string) (clienteventingv1.KnEventingClient, err
 
 	restConfig, err := k8s.GetClientConfig().ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new serving client: %v", err)
+		return nil, fmt.Errorf("failed to create new eventing client: %v", err)
 	}
 
 	eventingClient, err := eventingv1.NewForConfig(restConfig)

--- a/pkg/knative/deployer_int_test.go
+++ b/pkg/knative/deployer_int_test.go
@@ -6,14 +6,16 @@ import (
 	"testing"
 
 	deployertesting "knative.dev/func/pkg/deployer/testing"
+	"knative.dev/func/pkg/k8s"
 	"knative.dev/func/pkg/knative"
 )
 
 func TestInt_FullPath(t *testing.T) {
+	kc := k8s.NewClient(k8s.GetClientConfig())
 	deployertesting.TestInt_FullPath(t,
 		knative.NewDeployer(knative.WithDeployerVerbose(true)),
 		knative.NewRemover(true),
-		knative.NewLister(true),
+		knative.NewLister(kc, true),
 		knative.NewDescriber(true),
 		knative.KnativeDeployerName)
 }

--- a/pkg/knative/lister.go
+++ b/pkg/knative/lister.go
@@ -26,13 +26,13 @@ func NewLister(kc *k8s.Client, verbose bool) *Lister {
 
 // List functions, optionally specifying a namespace.
 func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, error) {
-	if err := validateKubeconfigFile(); err != nil {
-		return nil, err
+	if l.kc == nil {
+		return nil, fmt.Errorf("kubernetes client is not initialized")
 	}
 
 	restConfig, err := l.kc.ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create serving client: %v", err)
+		return nil, fmt.Errorf("failed to get kubernetes client config: %v", err)
 	}
 
 	servingClient, err := servingv1.NewForConfig(restConfig)

--- a/pkg/knative/lister.go
+++ b/pkg/knative/lister.go
@@ -7,25 +7,40 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"knative.dev/pkg/apis"
+	clientservingv1 "knative.dev/client/pkg/serving/v1"
+	"knative.dev/func/pkg/k8s"
+	servingv1 "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1"
 
 	fn "knative.dev/func/pkg/functions"
+	"knative.dev/pkg/apis"
 )
 
 type Lister struct {
+	kc      *k8s.Client
 	verbose bool
 }
 
-func NewLister(verbose bool) *Lister {
-	return &Lister{verbose: verbose}
+func NewLister(kc *k8s.Client, verbose bool) *Lister {
+	return &Lister{kc: kc, verbose: verbose}
 }
 
 // List functions, optionally specifying a namespace.
 func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, error) {
-	client, err := NewServingClient(namespace)
-	if err != nil {
+	if err := validateKubeconfigFile(); err != nil {
 		return nil, err
 	}
+
+	restConfig, err := l.kc.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create serving client: %v", err)
+	}
+
+	servingClient, err := servingv1.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create serving client: %v", err)
+	}
+
+	client := clientservingv1.NewKnServingClient(servingClient, namespace)
 
 	// TODO: shouldn't this list only services for functions (-> having the function.knative.dev/name label)?!?
 

--- a/pkg/knative/lister_int_test.go
+++ b/pkg/knative/lister_int_test.go
@@ -5,13 +5,15 @@ package knative_test
 import (
 	"testing"
 
+	"knative.dev/func/pkg/k8s"
 	"knative.dev/func/pkg/knative"
 	listertesting "knative.dev/func/pkg/lister/testing"
 )
 
 func TestInt_List(t *testing.T) {
+	kc := k8s.NewClient(k8s.GetClientConfig())
 	listertesting.TestInt_List(t,
-		knative.NewLister(true),
+		knative.NewLister(kc, true),
 		knative.NewDeployer(knative.WithDeployerVerbose(true)),
 		knative.NewDescriber(true),
 		knative.NewRemover(true),

--- a/pkg/knative/remover_int_test.go
+++ b/pkg/knative/remover_int_test.go
@@ -5,15 +5,17 @@ package knative_test
 import (
 	"testing"
 
+	"knative.dev/func/pkg/k8s"
 	"knative.dev/func/pkg/knative"
 	removertesting "knative.dev/func/pkg/remover/testing"
 )
 
 func TestInt_Remove(t *testing.T) {
+	kc := k8s.NewClient(k8s.GetClientConfig())
 	removertesting.TestInt_Remove(t,
 		knative.NewRemover(true),
 		knative.NewDeployer(knative.WithDeployerVerbose(true)),
 		knative.NewDescriber(true),
-		knative.NewLister(true),
+		knative.NewLister(kc, true),
 		knative.KnativeDeployerName)
 }

--- a/pkg/pipelines/tekton/pipelines_int_test.go
+++ b/pkg/pipelines/tekton/pipelines_int_test.go
@@ -45,11 +45,12 @@ const (
 )
 
 func newRemoteTestClient(verbose bool, deployer string, opts ...fn.Option) *fn.Client {
+	kc := k8s.NewClient(k8s.GetClientConfig())
 	baseOpts := []fn.Option{
 		fn.WithBuilder(buildpacks.NewBuilder(buildpacks.WithVerbose(verbose))),
 		fn.WithPusher(docker.NewPusher(docker.WithCredentialsProvider(testCP))),
 		fn.WithDescribers(knative.NewDescriber(verbose), k8s.NewDescriber(verbose), keda.NewDescriber(verbose)),
-		fn.WithListers(knative.NewLister(verbose), k8s.NewLister(verbose), keda.NewLister(verbose)),
+		fn.WithListers(knative.NewLister(kc, verbose), k8s.NewLister(kc, verbose), keda.NewLister(kc, verbose)),
 		fn.WithRemovers(knative.NewRemover(verbose), k8s.NewRemover(verbose), keda.NewRemover(verbose)),
 		fn.WithPipelinesProvider(tekton.NewPipelinesProvider(tekton.WithCredentialsProvider(testCP), tekton.WithVerbose(verbose))),
 	}


### PR DESCRIPTION
# Changes

- Introduce `k8s.Client` wrapper with lazy config resolution, supporting both CLI path (`clientcmd.ClientConfig`) and SDK path (direct `*rest.Config`)
- Inject `*k8s.Client` into k8s, knative, and keda listers via constructors instead of creating clientsets internally
- Make `NewClient` infallible - errors are deferred to when the config is actually needed
- Add unit tests for `k8s.Client`
- The `knative` and `keda` listers inline the serving/HTTP client creation from the injected `*k8s.Client` config instead of calling `NewServingClient`/`NewHTTPScaledObjectClientset`, since modifying those functions to accept `*k8s.Client` would cascade to deployer, describer, and remover callers which are outside the scope of this PR.

/kind enhancement

Fixes #4000

**Release Note**

```release-note

```

**Docs**

```docs

```