### PR TITLE
fix(list): populate RUNTIME column in func list

### DIFF
--- a/pkg/k8s/lister.go
+++ b/pkg/k8s/lister.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	fn "knative.dev/func/pkg/functions"
+	"knative.dev/func/pkg/k8s/labels"
 )
 
 type Lister struct {
@@ -82,11 +83,10 @@ func (l *Lister) get(ctx context.Context, clientset *kubernetes.Clientset, name,
 		return fn.ListItem{}, fmt.Errorf("could not get service: %w", err)
 	}
 
-	runtimeLabel := ""
 	listItem := fn.ListItem{
 		Name:      service.Name,
 		Namespace: service.Namespace,
-		Runtime:   runtimeLabel,
+		Runtime:   deployment.Labels[labels.FunctionRuntimeKey],
 		URL:       fmt.Sprintf("http://%s.%s.svc", service.Name, service.Namespace), // TODO: use correct scheme
 		Ready:     string(ready),
 		Deployer:  KubernetesDeployerName,

--- a/pkg/keda/lister.go
+++ b/pkg/keda/lister.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fn "knative.dev/func/pkg/functions"
 	"knative.dev/func/pkg/k8s"
+	"knative.dev/func/pkg/k8s/labels"
 )
 
 type Lister struct {
@@ -59,7 +60,8 @@ func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, err
 			continue
 		}
 
-		item, err := l.get(ctx, httpScaledObjectClientset, service.Name, service.Namespace)
+		runtime := service.Labels[labels.FunctionRuntimeKey]
+		item, err := l.get(ctx, httpScaledObjectClientset, service.Name, service.Namespace, runtime)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get details about function: %v", err)
 		}
@@ -71,7 +73,7 @@ func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, err
 }
 
 // Get a function, optionally specifying a namespace.
-func (l *Lister) get(ctx context.Context, httpScaledObjectClientset *versioned.Clientset, name, namespace string) (fn.ListItem, error) {
+func (l *Lister) get(ctx context.Context, httpScaledObjectClientset *versioned.Clientset, name, namespace, runtime string) (fn.ListItem, error) {
 	httpScaledObject, err := httpScaledObjectClientset.HttpV1alpha1().HTTPScaledObjects(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return fn.ListItem{}, fmt.Errorf("unable to get HTTPScaledObject: %v", err)
@@ -89,11 +91,10 @@ func (l *Lister) get(ctx context.Context, httpScaledObjectClientset *versioned.C
 		url = fmt.Sprintf("http://%s:8080", httpScaledObject.Spec.Hosts[0])
 	}
 
-	runtimeLabel := ""
 	listItem := fn.ListItem{
 		Name:      name,
 		Namespace: namespace,
-		Runtime:   runtimeLabel,
+		Runtime:   runtime,
 		URL:       url,
 		Ready:     string(ready),
 		Deployer:  KedaDeployerName,

--- a/pkg/knative/lister.go
+++ b/pkg/knative/lister.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	clientservingv1 "knative.dev/client/pkg/serving/v1"
 	"knative.dev/func/pkg/k8s"
+	"knative.dev/func/pkg/k8s/labels"
 	servingv1 "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1"
 
 	fn "knative.dev/func/pkg/functions"
@@ -79,7 +80,7 @@ func (l *Lister) List(ctx context.Context, namespace string) ([]fn.ListItem, err
 			}
 		}
 
-		runtimeLabel := ""
+		runtimeLabel := service.Labels[labels.FunctionRuntimeKey]
 
 		listItem := fn.ListItem{
 			Name:      service.Name,


### PR DESCRIPTION
<!-- PR Title: fix: populate RUNTIME column in func list -->

# Changes

- Fix `func list` always showing an empty `RUNTIME` column for all deployers (Knative, k8s, KEDA)

/kind bug

Fixes #4009

**Release Note**

```release-note
`func list` now correctly displays the runtime (e.g. `go`, `node`, `python`) in the RUNTIME column for functions deployed via the Knative, k8s, and KEDA deployers.
```

**Docs**

```docs

```