### PR TITLE
feat: default func logs to a snapshot

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -13,36 +15,63 @@ import (
 
 	"knative.dev/func/pkg/config"
 	fn "knative.dev/func/pkg/functions"
+	"knative.dev/func/pkg/k8s"
 	"knative.dev/func/pkg/knative"
 )
 
+// logGatherer writes the logs of a deployed function.
+type logGatherer func(context.Context, knative.LogsOptions, io.Writer) error
+
 func NewLogsCmd(newClient ClientFactory) *cobra.Command {
+	return newLogsCmd(newClient, knative.GetKServiceLogs)
+}
+
+// newLogsCmd constructs the command with an explicit log gatherer, allowing
+// tests to exercise the command without a cluster.
+func newLogsCmd(newClient ClientFactory, gather logGatherer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logs",
-		Short: "Stream logs from a deployed function",
-		Long: `Stream logs from a deployed function
+		Short: "Print or stream logs from a deployed function",
+		Long: `Print or stream logs from a deployed function
 
-Streams logs for the function in the current directory or from the directory
-specified with --path. Abstracts away the underlying service name and pod details.
+Prints the logs of the function in the current directory or of the directory
+specified with --path and exits. Use --follow to stream logs until interrupted.
+Abstracts away the underlying service name and pod details.
+
+When more than one pod is serving the function, each line is prefixed with the
+pod it came from. A function which has scaled to zero has no pods, and thus no
+logs to print.
+
+Only functions deployed with the default Knative deployer are currently
+supported.
 `,
 		Example: `
-# Stream logs for the function in the current directory
+# Print the logs of the function in the current directory and exit
 {{rootCmdUse}} logs
 
-# Stream logs for a function by name
+# Stream logs until interrupted
+{{rootCmdUse}} logs -f
+
+# Print logs for a function by name
 {{rootCmdUse}} logs --name my-function
 
-# Stream logs from a specific namespace
+# Print logs from a specific namespace
 {{rootCmdUse}} logs --namespace my-namespace
 
-# Stream logs with a specific time window
+# Print logs of a specific time window
 {{rootCmdUse}} logs --since 5m
+
+# Print the last 20 log lines per pod
+{{rootCmdUse}} logs --tail 20
+
+# Stream logs, starting with those of the last 5 minutes
+{{rootCmdUse}} logs -f --since 5m
 `,
 		SuggestFor:        []string{"log", "tail"},
 		ValidArgsFunction: CompleteFunctionList,
-		PreRunE:           bindEnv("name", "namespace", "path", "since", "verbose"),
+		PreRunE:           bindEnv("name", "namespace", "path", "since", "tail", "follow", "verbose"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLogs(cmd, newClient)
+			return runLogs(cmd, newClient, gather)
 		},
 	}
 
@@ -55,14 +84,16 @@ specified with --path. Abstracts away the underlying service name and pod detail
 	// Flags
 	cmd.Flags().StringP("name", "", "", "Name of the function to get logs from ($FUNC_NAME)")
 	cmd.Flags().StringP("namespace", "n", defaultNamespace(fn.Function{}, false), "The namespace of the function ($FUNC_NAMESPACE)")
-	cmd.Flags().StringP("since", "", "1m", "Return logs newer than a relative duration like 5s, 2m, or 3h ($FUNC_LOGS_SINCE)")
+	cmd.Flags().StringP("since", "", "", "Return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all available logs, or to the last minute when following without --tail ($FUNC_SINCE)")
+	cmd.Flags().Int64P("tail", "", -1, "Number of most recent log lines to return per pod. Unlimited if negative ($FUNC_TAIL)")
+	cmd.Flags().BoolP("follow", "f", false, "Stream logs until interrupted rather than printing and exiting ($FUNC_FOLLOW)")
 	addPathFlag(cmd)
 	addVerboseFlag(cmd, cfg.Verbose)
 
 	return cmd
 }
 
-func runLogs(cmd *cobra.Command, newClient ClientFactory) error {
+func runLogs(cmd *cobra.Command, newClient ClientFactory, gather logGatherer) error {
 	cfg, err := newLogsConfig(cmd)
 	if err != nil {
 		return err
@@ -115,10 +146,24 @@ func runLogs(cmd *cobra.Command, newClient ClientFactory) error {
 			"You can use 'kubectl logs' directly to view logs for %s-deployed functions", deployer, deployer)
 	}
 
-	// Parse since duration
+	// Limit the lines returned per pod if requested
+	var tailLines *int64
+	if cfg.Tail >= 0 {
+		tailLines = &cfg.Tail
+	}
+
+	// Bound how far back logs are read.  A snapshot defaults to everything
+	// available, as does kubectl, because a default window would silently
+	// truncate --tail and hide the logs of a function which has been idle.
+	// Following, however, keeps its historical one minute of context, unless
+	// --tail already bounds the output.
+	since := cfg.Since
+	if since == "" && cfg.Follow && tailLines == nil {
+		since = "1m"
+	}
 	var sinceTime *time.Time
-	if cfg.Since != "" {
-		duration, err := time.ParseDuration(cfg.Since)
+	if since != "" {
+		duration, err := time.ParseDuration(since)
 		if err != nil {
 			return fmt.Errorf("invalid duration format for --since: %w", err)
 		}
@@ -126,31 +171,61 @@ func runLogs(cmd *cobra.Command, newClient ClientFactory) error {
 		sinceTime = &t
 	}
 
-	// Create context that can be cancelled with Ctrl+C
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
-	// Handle interrupt signal
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-sigChan
-		fmt.Fprintln(os.Stderr, "\nStopping log stream...")
-		cancel()
-	}()
+	// Following is interactive and unbounded: announce it on stderr, keeping
+	// stdout log content only, and stop on interrupt.
+	if cfg.Follow {
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+		defer signal.Stop(sigChan)
+		go func() {
+			select {
+			case <-sigChan:
+				fmt.Fprintln(cmd.ErrOrStderr(), "\nStopping log stream...")
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
 
-	fmt.Fprintf(os.Stderr, "Streaming logs for function '%s' in namespace '%s'...\n", f.Name, f.Namespace)
-	fmt.Fprintf(os.Stderr, "Press Ctrl+C to stop.\n\n")
+		fmt.Fprintf(cmd.ErrOrStderr(), "Streaming logs for function '%s' in namespace '%s'...\n", f.Name, f.Namespace)
+		fmt.Fprintf(cmd.ErrOrStderr(), "Press Ctrl+C to stop.\n\n")
+	}
 
-	err = knative.GetKServiceLogs(ctx, knative.LogsOptions{
+	// NOTE: the image of the described instance is deliberately not used to
+	// filter pods.  It is that of the latest revision, so filtering on it
+	// would drop the logs of the pods actually serving traffic during a
+	// rollout.  All pods of the function's service are of interest here.
+	err = gather(ctx, knative.LogsOptions{
 		Name:      f.Name,
 		Namespace: f.Namespace,
-		Image:     f.Image,
 		Since:     sinceTime,
-		Follow:    true,
-	}, os.Stdout)
-	if err != nil && err != context.Canceled {
-		return fmt.Errorf("failed to stream logs: %w", err)
+		TailLines: tailLines,
+		Follow:    cfg.Follow,
+	}, cmd.OutOrStdout())
+
+	// A function which has scaled to zero has no pods, and thus no logs.  This
+	// is not a failure, but it is reported such that an empty stdout is not
+	// mistaken for a function which is running silently.
+	if errors.Is(err, k8s.ErrNoMatchingPods) {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"No running or recently terminated pods found for function '%s' in namespace '%s'. "+
+				"It may have scaled to zero, in which case there are no logs to print.\n", f.Name, f.Namespace)
+		return nil
+	}
+
+	// Pods can disappear while their logs are being read, e.g. when a revision
+	// is scaled down.  Report it, but keep the logs which were gathered and
+	// the successful exit code.
+	var partial *k8s.PartialLogsError
+	if errors.As(err, &partial) {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %v\n", partial)
+		return nil
+	}
+
+	if err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("failed to get logs: %w", err)
 	}
 
 	return nil
@@ -164,6 +239,8 @@ type logsConfig struct {
 	Namespace string
 	Path      string
 	Since     string
+	Tail      int64
+	Follow    bool
 	Verbose   bool
 }
 
@@ -173,6 +250,8 @@ func newLogsConfig(cmd *cobra.Command) (cfg logsConfig, err error) {
 		Namespace: viper.GetString("namespace"),
 		Path:      viper.GetString("path"),
 		Since:     viper.GetString("since"),
+		Tail:      viper.GetInt64("tail"),
+		Follow:    viper.GetBool("follow"),
 		Verbose:   viper.GetBool("verbose"),
 	}
 

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -142,7 +142,13 @@ func runLogs(cmd *cobra.Command, newClient ClientFactory) error {
 	fmt.Fprintf(os.Stderr, "Streaming logs for function '%s' in namespace '%s'...\n", f.Name, f.Namespace)
 	fmt.Fprintf(os.Stderr, "Press Ctrl+C to stop.\n\n")
 
-	err = knative.GetKServiceLogs(ctx, f.Namespace, f.Name, f.Image, sinceTime, os.Stdout)
+	err = knative.GetKServiceLogs(ctx, knative.LogsOptions{
+		Name:      f.Name,
+		Namespace: f.Namespace,
+		Image:     f.Image,
+		Since:     sinceTime,
+		Follow:    true,
+	}, os.Stdout)
 	if err != nil && err != context.Canceled {
 		return fmt.Errorf("failed to stream logs: %w", err)
 	}

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -1,10 +1,21 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
 
 	fn "knative.dev/func/pkg/functions"
+	"knative.dev/func/pkg/k8s"
+	"knative.dev/func/pkg/knative"
 	"knative.dev/func/pkg/mock"
+	. "knative.dev/func/pkg/testing"
 )
 
 // TestLogs_CommandStructure ensures the logs command is properly structured
@@ -29,7 +40,7 @@ func TestLogs_CommandStructure(t *testing.T) {
 	}
 
 	// Check that required flags exist
-	flags := []string{"name", "namespace", "path", "since", "verbose"}
+	flags := []string{"name", "namespace", "path", "since", "tail", "follow", "verbose"}
 	for _, flag := range flags {
 		if logsCmd.Flags().Lookup(flag) == nil {
 			t.Errorf("expected flag '%s' to exist", flag)
@@ -111,5 +122,263 @@ func TestLogs_SuggestFor(t *testing.T) {
 		if !found {
 			t.Errorf("expected suggestion '%s' not found", suggestion)
 		}
+	}
+}
+
+// knativeDescriber returns a describer which reports a deployed function
+// deployed with the Knative deployer.
+func knativeDescriber() *mock.Describer {
+	describer := mock.NewDescriber()
+	describer.DescribeFn = func(_ context.Context, name, _ string) (fn.Instance, error) {
+		return fn.Instance{
+			Name:      name,
+			Namespace: "default",
+			// That of the latest revision, as the Knative describer reports it.
+			Image:    "example.com/myfunc@sha256:" + strings.Repeat("a", 64),
+			Deployer: "knative",
+		}, nil
+	}
+	return describer
+}
+
+// int64Ptr returns a pointer to the given value.
+func int64Ptr(i int64) *int64 { return &i }
+
+// newTestLogsCmd returns a logs command whose logs are gathered by the given
+// function rather than from a cluster.
+func newTestLogsCmd(gather logGatherer, out, errOut io.Writer) *cobra.Command {
+	cmd := newLogsCmd(NewTestClient(fn.WithDescribers(knativeDescriber())), gather)
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+	return cmd
+}
+
+// TestLogs_DefaultSnapshot ensures that, absent --follow, logs are written and
+// the command completes without gathering logs in follow mode and without
+// writing interactive chrome to stdout.
+func TestLogs_DefaultSnapshot(t *testing.T) {
+	_ = FromTempDirectory(t)
+
+	var opts knative.LogsOptions
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	cmd := newTestLogsCmd(func(ctx context.Context, o knative.LogsOptions, out io.Writer) error {
+		opts = o
+		if o.Follow { // would block indefinitely in the real implementation
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		_, err := out.Write([]byte("log line\n"))
+		return err
+	}, stdout, stderr)
+	cmd.SetArgs([]string{"--name", "myfunc"})
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- cmd.Execute() }()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("'logs' did not complete without --follow")
+	}
+
+	if opts.Follow {
+		t.Error("expected logs to be gathered in snapshot mode")
+	}
+	if stdout.String() != "log line\n" {
+		t.Errorf("expected stdout to contain log content only, got %q", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Errorf("expected no output on stderr, got %q", stderr.String())
+	}
+}
+
+// TestLogs_Follow ensures that --follow gathers logs in follow mode until the
+// context is cancelled, and that the interactive banner is written to stderr.
+func TestLogs_Follow(t *testing.T) {
+	_ = FromTempDirectory(t)
+
+	var opts knative.LogsOptions
+	started := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	cmd := newTestLogsCmd(func(ctx context.Context, o knative.LogsOptions, out io.Writer) error {
+		opts = o
+		close(started)
+		<-ctx.Done()
+		return ctx.Err()
+	}, stdout, stderr)
+	cmd.SetArgs([]string{"--name", "myfunc", "--follow"})
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- cmd.ExecuteContext(ctx) }()
+
+	select {
+	case <-started:
+	case err := <-errCh:
+		t.Fatalf("'logs --follow' returned before streaming: %v", err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("'logs --follow' did not begin streaming")
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil { // a cancelled stream is not an error
+			t.Fatal(err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("'logs --follow' did not stop when cancelled")
+	}
+
+	if !opts.Follow {
+		t.Error("expected logs to be gathered in follow mode")
+	}
+	if !strings.Contains(stderr.String(), "Press Ctrl+C to stop.") {
+		t.Errorf("expected the interactive banner on stderr, got %q", stderr.String())
+	}
+}
+
+// TestLogs_Window ensures --since and --tail are passed through, and that the
+// window defaults do not truncate a snapshot: a default window would hide the
+// logs of a function idle for longer than it, and would silently cut --tail
+// short.  Following keeps its historical minute of context instead.
+func TestLogs_Window(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantTail   *int64
+		wantWindow time.Duration // zero means all available logs
+	}{
+		{name: "snapshot defaults to all logs", args: []string{}},
+		{name: "snapshot honors since", args: []string{"--since", "5m"}, wantWindow: 5 * time.Minute},
+		{name: "snapshot tail is not truncated", args: []string{"--tail", "20"}, wantTail: int64Ptr(20)},
+		{name: "since and tail combine", args: []string{"--since", "5m", "--tail", "20"}, wantTail: int64Ptr(20), wantWindow: 5 * time.Minute},
+		{name: "follow defaults to the last minute", args: []string{"-f"}, wantWindow: time.Minute},
+		{name: "follow with tail is not truncated", args: []string{"-f", "--tail", "20"}, wantTail: int64Ptr(20)},
+		{name: "follow honors since", args: []string{"-f", "--since", "5m"}, wantWindow: 5 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = FromTempDirectory(t)
+
+			var opts knative.LogsOptions
+			cmd := newTestLogsCmd(func(_ context.Context, o knative.LogsOptions, _ io.Writer) error {
+				opts = o
+				return nil
+			}, &bytes.Buffer{}, &bytes.Buffer{})
+			cmd.SetArgs(append([]string{"--name", "myfunc"}, tt.args...))
+			if err := cmd.Execute(); err != nil {
+				t.Fatal(err)
+			}
+
+			if tt.wantTail == nil && opts.TailLines != nil {
+				t.Errorf("expected unlimited lines, got %v", *opts.TailLines)
+			}
+			if tt.wantTail != nil && (opts.TailLines == nil || *opts.TailLines != *tt.wantTail) {
+				t.Errorf("expected tail %v, got %v", *tt.wantTail, opts.TailLines)
+			}
+			if tt.wantWindow == 0 {
+				if opts.Since != nil {
+					t.Errorf("expected all available logs, got those since %v", *opts.Since)
+				}
+				return
+			}
+			if opts.Since == nil {
+				t.Fatalf("expected logs since ~%v ago, got all available logs", tt.wantWindow)
+			}
+			if window := time.Since(*opts.Since); window < tt.wantWindow || window > tt.wantWindow+time.Minute {
+				t.Errorf("expected logs since ~%v ago, got %v", tt.wantWindow, window)
+			}
+		})
+	}
+}
+
+// TestLogs_NoPods ensures that a function with no pods to read logs from - the
+// normal state of a Knative service which has scaled to zero - is reported on
+// stderr rather than being indistinguishable from a function logging nothing.
+func TestLogs_NoPods(t *testing.T) {
+	_ = FromTempDirectory(t)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	cmd := newTestLogsCmd(func(_ context.Context, _ knative.LogsOptions, _ io.Writer) error {
+		return k8s.ErrNoMatchingPods
+	}, stdout, stderr)
+	cmd.SetArgs([]string{"--name", "myfunc"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("an idle function is not a failure: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("expected no output on stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "scaled to zero") {
+		t.Errorf("expected the absence of pods to be explained, got %q", stderr.String())
+	}
+}
+
+// TestLogs_PartialLogs ensures that logs gathered from some pods are kept, and
+// the command still succeeds, when another pod's logs could not be read.
+func TestLogs_PartialLogs(t *testing.T) {
+	_ = FromTempDirectory(t)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	cmd := newTestLogsCmd(func(_ context.Context, _ knative.LogsOptions, out io.Writer) error {
+		_, _ = out.Write([]byte("log line\n"))
+		return &k8s.PartialLogsError{Err: errors.New("pod is terminating")}
+	}, stdout, stderr)
+	cmd.SetArgs([]string{"--name", "myfunc"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected partially gathered logs to succeed: %v", err)
+	}
+	if stdout.String() != "log line\n" {
+		t.Errorf("expected the gathered logs to be kept, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "pod is terminating") {
+		t.Errorf("expected a warning on stderr, got %q", stderr.String())
+	}
+}
+
+// TestLogs_Failure ensures a hard failure to gather logs is a non-zero exit.
+func TestLogs_Failure(t *testing.T) {
+	_ = FromTempDirectory(t)
+
+	cmd := newTestLogsCmd(func(_ context.Context, _ knative.LogsOptions, _ io.Writer) error {
+		return errors.New("forbidden")
+	}, &bytes.Buffer{}, &bytes.Buffer{})
+	cmd.SetArgs([]string{"--name", "myfunc"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected a failure to gather logs to be an error")
+	}
+}
+
+// TestLogs_ImageNotFiltered ensures the logs of all of a function's pods are
+// gathered.  The image of the described instance is that of the latest
+// revision, so filtering on it would drop the logs of the pods actually
+// serving traffic during a rollout.
+func TestLogs_ImageNotFiltered(t *testing.T) {
+	_ = FromTempDirectory(t)
+
+	var opts knative.LogsOptions
+	cmd := newTestLogsCmd(func(_ context.Context, o knative.LogsOptions, _ io.Writer) error {
+		opts = o
+		return nil
+	}, &bytes.Buffer{}, &bytes.Buffer{})
+	cmd.SetArgs([]string{"--name", "myfunc"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if opts.Image != "" {
+		t.Errorf("expected pods to not be filtered by image, got %q", opts.Image)
 	}
 }

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -382,3 +382,29 @@ func TestLogs_ImageNotFiltered(t *testing.T) {
 		t.Errorf("expected pods to not be filtered by image, got %q", opts.Image)
 	}
 }
+
+// TestLogs_FollowEnv ensures following can be enabled by environment, which is
+// how a user for whom the previous always-follow default was the right one can
+// restore it.
+func TestLogs_FollowEnv(t *testing.T) {
+	_ = FromTempDirectory(t)
+	t.Setenv("FUNC_FOLLOW", "true")
+
+	var opts knative.LogsOptions
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := newTestLogsCmd(func(ctx context.Context, o knative.LogsOptions, _ io.Writer) error {
+		opts = o
+		cancel()
+		return ctx.Err()
+	}, &bytes.Buffer{}, &bytes.Buffer{})
+	cmd.SetArgs([]string{"--name", "myfunc"})
+
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if !opts.Follow {
+		t.Error("expected FUNC_FOLLOW to enable following")
+	}
+}

--- a/docs/reference/func.md
+++ b/docs/reference/func.md
@@ -34,7 +34,7 @@ Learn more about Knative at: https://knative.dev
 * [func invoke](func_invoke.md)	 - Invoke a local or remote function
 * [func languages](func_languages.md)	 - List available function language runtimes
 * [func list](func_list.md)	 - List deployed functions
-* [func logs](func_logs.md)	 - Stream logs from a deployed function
+* [func logs](func_logs.md)	 - Print or stream logs from a deployed function
 * [func mcp](func_mcp.md)	 - Model Context Protocol (MCP) server
 * [func repository](func_repository.md)	 - Manage installed template repositories
 * [func run](func_run.md)	 - Run the function locally

--- a/docs/reference/func_logs.md
+++ b/docs/reference/func_logs.md
@@ -1,13 +1,21 @@
 ## func logs
 
-Stream logs from a deployed function
+Print or stream logs from a deployed function
 
 ### Synopsis
 
-Stream logs from a deployed function
+Print or stream logs from a deployed function
 
-Streams logs for the function in the current directory or from the directory
-specified with --path. Abstracts away the underlying service name and pod details.
+Prints the logs of the function in the current directory or of the directory
+specified with --path and exits. Use --follow to stream logs until interrupted.
+Abstracts away the underlying service name and pod details.
+
+When more than one pod is serving the function, each line is prefixed with the
+pod it came from. A function which has scaled to zero has no pods, and thus no
+logs to print.
+
+Only functions deployed with the default Knative deployer are currently
+supported.
 
 
 ```
@@ -18,28 +26,39 @@ func logs
 
 ```
 
-# Stream logs for the function in the current directory
+# Print the logs of the function in the current directory and exit
 func logs
 
-# Stream logs for a function by name
+# Stream logs until interrupted
+func logs -f
+
+# Print logs for a function by name
 func logs --name my-function
 
-# Stream logs from a specific namespace
+# Print logs from a specific namespace
 func logs --namespace my-namespace
 
-# Stream logs with a specific time window
+# Print logs of a specific time window
 func logs --since 5m
+
+# Print the last 20 log lines per pod
+func logs --tail 20
+
+# Stream logs, starting with those of the last 5 minutes
+func logs -f --since 5m
 
 ```
 
 ### Options
 
 ```
+  -f, --follow             Stream logs until interrupted rather than printing and exiting ($FUNC_FOLLOW)
   -h, --help               help for logs
       --name string        Name of the function to get logs from ($FUNC_NAME)
   -n, --namespace string   The namespace of the function ($FUNC_NAMESPACE) (default "default")
   -p, --path string        Path to the function.  Default is current directory ($FUNC_PATH)
-      --since string       Return logs newer than a relative duration like 5s, 2m, or 3h ($FUNC_LOGS_SINCE) (default "1m")
+      --since string       Return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all available logs, or to the last minute when following without --tail ($FUNC_SINCE)
+      --tail int           Number of most recent log lines to return per pod. Unlimited if negative ($FUNC_TAIL) (default -1)
   -v, --verbose            Print verbose logs ($FUNC_VERBOSE)
 ```
 

--- a/pkg/deployer/testing/integration_test_helper.go
+++ b/pkg/deployer/testing/integration_test_helper.go
@@ -759,7 +759,13 @@ func TestInt_FullPath(t *testing.T, deployer fn.Deployer, remover fn.Remover, li
 	buff := new(k8s.SynchronizedBuffer)
 	go func() {
 		selector := fmt.Sprintf("function.knative.dev/name=%s", functionName)
-		_ = k8s.GetPodLogsBySelector(ctx, namespace, selector, "user-container", "", &now, buff)
+		_ = k8s.GetPodLogsBySelector(ctx, k8s.PodLogsOptions{
+			Namespace:     namespace,
+			LabelSelector: selector,
+			Container:     "user-container",
+			Since:         &now,
+			Follow:        true,
+		}, buff)
 	}()
 
 	depRes, err := deployer.Deploy(ctx, function)
@@ -839,7 +845,13 @@ func TestInt_FullPath(t *testing.T, deployer fn.Deployer, remover fn.Remover, li
 	redeployLogBuff := new(k8s.SynchronizedBuffer)
 	go func() {
 		selector := fmt.Sprintf("function.knative.dev/name=%s", functionName)
-		_ = k8s.GetPodLogsBySelector(ctx, namespace, selector, "user-container", "", &now, redeployLogBuff)
+		_ = k8s.GetPodLogsBySelector(ctx, k8s.PodLogsOptions{
+			Namespace:     namespace,
+			LabelSelector: selector,
+			Container:     "user-container",
+			Since:         &now,
+			Follow:        true,
+		}, redeployLogBuff)
 	}()
 
 	_, err = deployer.Deploy(ctx, function)

--- a/pkg/k8s/logs.go
+++ b/pkg/k8s/logs.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
 )
 
 // GetPodLogs returns logs from a specified Container in a Pod, if container is empty string,
@@ -40,26 +41,55 @@ func GetPodLogs(ctx context.Context, namespace, podName, containerName string) (
 	return buffer.String(), nil
 }
 
+// PodLogsOptions are the parameters of GetPodLogsBySelector.
+type PodLogsOptions struct {
+	// Namespace in which the pods reside.  An empty value resolves to the
+	// currently active namespace.
+	Namespace string
+
+	// LabelSelector which matches the pods whose logs are gathered.
+	LabelSelector string
+
+	// Container whose logs are gathered.
+	Container string
+
+	// Image, when non-empty, restricts gathering to pods whose container runs
+	// this exact image.
+	Image string
+
+	// Since, when non-nil, is the time from which logs are returned.
+	Since *time.Time
+
+	// Follow keeps streaming the logs of matching pods, including pods which
+	// appear later, until the context is cancelled.
+	Follow bool
+}
+
 // GetPodLogsBySelector will get logs of a pod.
 //
 // It will do so by gathering logs of the given container of all affiliated pods.
 // In addition, filtering on image can be done so only logs for given image are logged.
 //
-// This function runs as long as the passed context is active (i.e. it is required cancel the context to stop log gathering).
-func GetPodLogsBySelector(ctx context.Context, namespace, labelSelector, containerName, image string, since *time.Time, out io.Writer) error {
-	client, namespace, err := NewClientAndResolvedNamespace(namespace)
+// This function runs as long as the passed context is active (i.e. it is
+// required to cancel the context to stop log gathering).
+func GetPodLogsBySelector(ctx context.Context, opts PodLogsOptions, out io.Writer) error {
+	client, namespace, err := NewClientAndResolvedNamespace(opts.Namespace)
 	if err != nil {
 		return fmt.Errorf("cannot create k8s client: %w", err)
 	}
 
-	pods := client.CoreV1().Pods(namespace)
+	return followPodLogs(ctx, client, namespace, opts, out)
+}
 
+// followPodLogs streams logs of the matching pods, including those which appear
+// later, until the context is cancelled.
+func followPodLogs(ctx context.Context, client kubernetes.Interface, namespace string, opts PodLogsOptions, out io.Writer) error {
 	podListOpts := metav1.ListOptions{
 		Watch:         true,
-		LabelSelector: labelSelector,
+		LabelSelector: opts.LabelSelector,
 	}
 
-	w, err := pods.Watch(ctx, podListOpts)
+	w, err := client.CoreV1().Pods(namespace).Watch(ctx, podListOpts)
 	if err != nil {
 		return fmt.Errorf("cannot create watch: %w", err)
 	}
@@ -67,52 +97,6 @@ func GetPodLogsBySelector(ctx context.Context, namespace, labelSelector, contain
 
 	beingProcessed := make(map[string]bool)
 	var beingProcessedMu sync.Mutex
-
-	copyLogs := func(pod corev1.Pod) error {
-		defer func() {
-			beingProcessedMu.Lock()
-			delete(beingProcessed, pod.Name)
-			beingProcessedMu.Unlock()
-		}()
-		podLogOpts := corev1.PodLogOptions{
-			Container: containerName,
-			Follow:    true,
-		}
-		if since != nil {
-			sinceTime := metav1.NewTime(*since)
-			podLogOpts.SinceTime = &sinceTime
-		}
-		req := client.CoreV1().Pods(namespace).GetLogs(pod.Name, &podLogOpts)
-
-		r, e := req.Stream(ctx)
-		if e != nil {
-			return fmt.Errorf("cannot get stream: %w", e)
-		}
-		defer r.Close()
-		_, e = io.Copy(out, r)
-		if e != nil {
-			return fmt.Errorf("error copying logs: %w", e)
-		}
-		return nil
-	}
-
-	mayReadLogs := func(pod corev1.Pod) bool {
-		for _, status := range pod.Status.ContainerStatuses {
-			if status.Name == containerName {
-				return status.State.Running != nil || status.State.Terminated != nil
-			}
-		}
-		return false
-	}
-
-	getImage := func(pod corev1.Pod) string {
-		for _, ctr := range pod.Spec.Containers {
-			if ctr.Name == containerName {
-				return ctr.Image
-			}
-		}
-		return ""
-	}
 
 	var eg errgroup.Group
 
@@ -124,7 +108,7 @@ func GetPodLogsBySelector(ctx context.Context, namespace, labelSelector, contain
 			_, loggingAlready := beingProcessed[pod.Name]
 			beingProcessedMu.Unlock()
 
-			if !loggingAlready && (image == "" || image == getImage(pod)) && mayReadLogs(pod) {
+			if !loggingAlready && (opts.Image == "" || opts.Image == containerImage(pod, opts.Container)) && mayReadLogs(pod, opts.Container) {
 
 				beingProcessedMu.Lock()
 				beingProcessed[pod.Name] = true
@@ -132,7 +116,14 @@ func GetPodLogsBySelector(ctx context.Context, namespace, labelSelector, contain
 
 				// Capture pod value for the goroutine to avoid closure over loop variable
 				pod := pod
-				eg.Go(func() error { return copyLogs(pod) })
+				eg.Go(func() error {
+					defer func() {
+						beingProcessedMu.Lock()
+						delete(beingProcessed, pod.Name)
+						beingProcessedMu.Unlock()
+					}()
+					return copyPodLogs(ctx, client, namespace, pod.Name, opts, out)
+				})
 			}
 		}
 	}
@@ -142,6 +133,49 @@ func GetPodLogsBySelector(ctx context.Context, namespace, labelSelector, contain
 		return fmt.Errorf("error while gathering logs: %w", err)
 	}
 	return nil
+}
+
+// copyPodLogs writes the logs of a single pod's container to out.
+func copyPodLogs(ctx context.Context, client kubernetes.Interface, namespace, podName string, opts PodLogsOptions, out io.Writer) error {
+	podLogOpts := corev1.PodLogOptions{
+		Container: opts.Container,
+		Follow:    opts.Follow,
+	}
+	if opts.Since != nil {
+		sinceTime := metav1.NewTime(*opts.Since)
+		podLogOpts.SinceTime = &sinceTime
+	}
+
+	r, err := client.CoreV1().Pods(namespace).GetLogs(podName, &podLogOpts).Stream(ctx)
+	if err != nil {
+		return fmt.Errorf("cannot get stream: %w", err)
+	}
+	defer r.Close()
+	if _, err = io.Copy(out, r); err != nil {
+		return fmt.Errorf("error copying logs: %w", err)
+	}
+	return nil
+}
+
+// mayReadLogs returns whether the given container of the pod has produced logs
+// which can be read.
+func mayReadLogs(pod corev1.Pod, containerName string) bool {
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == containerName {
+			return status.State.Running != nil || status.State.Terminated != nil
+		}
+	}
+	return false
+}
+
+// containerImage returns the image of the given container of the pod.
+func containerImage(pod corev1.Pod, containerName string) string {
+	for _, ctr := range pod.Spec.Containers {
+		if ctr.Name == containerName {
+			return ctr.Image
+		}
+	}
+	return ""
 }
 
 type SynchronizedBuffer struct {

--- a/pkg/k8s/logs.go
+++ b/pkg/k8s/logs.go
@@ -3,8 +3,10 @@ package k8s
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"sync"
 	"time"
 
@@ -41,6 +43,23 @@ func GetPodLogs(ctx context.Context, namespace, podName, containerName string) (
 	return buffer.String(), nil
 }
 
+// ErrNoMatchingPods is returned when no pod whose logs can be read matches the
+// given options.  This is an expected state rather than a failure: a Knative
+// service which has scaled to zero has no pods.
+var ErrNoMatchingPods = errors.New("no pods with readable logs matched")
+
+// PartialLogsError is returned when the logs of some, but not all, matching
+// pods could be gathered.  The logs which were gathered have been written.
+type PartialLogsError struct {
+	Err error
+}
+
+func (e *PartialLogsError) Error() string {
+	return fmt.Sprintf("logs of some pods could not be gathered: %v", e.Err)
+}
+
+func (e *PartialLogsError) Unwrap() error { return e.Err }
+
 // PodLogsOptions are the parameters of GetPodLogsBySelector.
 type PodLogsOptions struct {
 	// Namespace in which the pods reside.  An empty value resolves to the
@@ -60,8 +79,12 @@ type PodLogsOptions struct {
 	// Since, when non-nil, is the time from which logs are returned.
 	Since *time.Time
 
-	// Follow keeps streaming the logs of matching pods, including pods which
-	// appear later, until the context is cancelled.
+	// TailLines, when non-nil, limits the output to the last N lines per pod.
+	TailLines *int64
+
+	// Follow streams logs of matching pods, including pods which appear later,
+	// until the context is cancelled.  When false, the logs currently available
+	// from the currently matching pods are written and the call returns.
 	Follow bool
 }
 
@@ -70,15 +93,80 @@ type PodLogsOptions struct {
 // It will do so by gathering logs of the given container of all affiliated pods.
 // In addition, filtering on image can be done so only logs for given image are logged.
 //
-// This function runs as long as the passed context is active (i.e. it is
-// required to cancel the context to stop log gathering).
+// When Follow is set, this function runs as long as the passed context is active
+// (i.e. it is required to cancel the context to stop log gathering).  Otherwise a
+// snapshot of the currently available logs is written and the function returns.
 func GetPodLogsBySelector(ctx context.Context, opts PodLogsOptions, out io.Writer) error {
 	client, namespace, err := NewClientAndResolvedNamespace(opts.Namespace)
 	if err != nil {
 		return fmt.Errorf("cannot create k8s client: %w", err)
 	}
 
-	return followPodLogs(ctx, client, namespace, opts, out)
+	if opts.Follow {
+		return followPodLogs(ctx, client, namespace, opts, out)
+	}
+	return snapshotPodLogs(ctx, client, namespace, opts, out)
+}
+
+// snapshotPodLogs writes the logs currently available from the pods which
+// currently match the selector, then returns.
+//
+// Returns ErrNoMatchingPods if no pod with readable logs matches, and a
+// PartialLogsError if the logs of at least one, but not all, matching pods
+// could be gathered.
+func snapshotPodLogs(ctx context.Context, client kubernetes.Interface, namespace string, opts PodLogsOptions, out io.Writer) error {
+	list, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: opts.LabelSelector,
+	})
+	if err != nil {
+		return fmt.Errorf("cannot list pods: %w", err)
+	}
+
+	pods := make([]corev1.Pod, 0, len(list.Items))
+	for _, pod := range list.Items {
+		if (opts.Image == "" || opts.Image == containerImage(pod, opts.Container)) && mayReadLogs(pod, opts.Container) {
+			pods = append(pods, pod)
+		}
+	}
+	if len(pods) == 0 {
+		return ErrNoMatchingPods
+	}
+	// Sorted such that output is deterministic when multiple pods match.
+	sort.Slice(pods, func(i, j int) bool { return pods[i].Name < pods[j].Name })
+
+	// The logs of a single pod are written verbatim.  When several pods match,
+	// their lines are attributed, as they are otherwise indistinguishable.
+	prefix := ""
+
+	var errs []error
+	gathered := 0
+	for _, pod := range pods {
+		if len(pods) > 1 {
+			prefix = fmt.Sprintf("[pod/%s] ", pod.Name)
+		}
+		// Lines of a pod are always terminated, such that the logs of the next
+		// pod do not continue the last line of the previous.
+		w := &linePrefixer{out: out, prefix: []byte(prefix)}
+		if err = copyPodLogs(ctx, client, namespace, pod.Name, opts, w); err != nil {
+			// A pod can, for example, be evicted between listing and reading.
+			// Gather what remains rather than discarding it.
+			errs = append(errs, err)
+			continue
+		}
+		if err = w.terminate(); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		gathered++
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	if gathered == 0 {
+		return errors.Join(errs...)
+	}
+	return &PartialLogsError{Err: errors.Join(errs...)}
 }
 
 // followPodLogs streams logs of the matching pods, including those which appear
@@ -140,6 +228,7 @@ func copyPodLogs(ctx context.Context, client kubernetes.Interface, namespace, po
 	podLogOpts := corev1.PodLogOptions{
 		Container: opts.Container,
 		Follow:    opts.Follow,
+		TailLines: opts.TailLines,
 	}
 	if opts.Since != nil {
 		sinceTime := metav1.NewTime(*opts.Since)
@@ -152,6 +241,54 @@ func copyPodLogs(ctx context.Context, client kubernetes.Interface, namespace, po
 	}
 	defer r.Close()
 	if _, err = io.Copy(out, r); err != nil {
+		return fmt.Errorf("error copying logs: %w", err)
+	}
+	return nil
+}
+
+// linePrefixer writes each line it receives prefixed, and tracks whether the
+// last line written was terminated.  A pod's logs arrive in arbitrarily sized
+// chunks, and its last line need not be terminated at all.
+type linePrefixer struct {
+	out    io.Writer
+	prefix []byte
+	midway bool // a line has been started but not yet terminated
+}
+
+func (l *linePrefixer) Write(p []byte) (int, error) {
+	written := 0
+	for len(p) > 0 {
+		if !l.midway {
+			if len(l.prefix) > 0 {
+				if _, err := l.out.Write(l.prefix); err != nil {
+					return written, err
+				}
+			}
+			l.midway = true
+		}
+		i := bytes.IndexByte(p, '\n')
+		if i < 0 {
+			n, err := l.out.Write(p)
+			return written + n, err
+		}
+		n, err := l.out.Write(p[:i+1])
+		written += n
+		if err != nil {
+			return written, err
+		}
+		l.midway = false
+		p = p[i+1:]
+	}
+	return written, nil
+}
+
+// terminate ends the current line if it was left unterminated.
+func (l *linePrefixer) terminate() error {
+	if !l.midway {
+		return nil
+	}
+	l.midway = false
+	if _, err := l.out.Write([]byte{'\n'}); err != nil {
 		return fmt.Errorf("error copying logs: %w", err)
 	}
 	return nil

--- a/pkg/k8s/logs_int_test.go
+++ b/pkg/k8s/logs_int_test.go
@@ -4,6 +4,8 @@ package k8s_test
 
 import (
 	"context"
+	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -86,5 +88,103 @@ out:
 	}
 	if out != testMsg {
 		t.Errorf("unexpected logs: expected %q, but got %q", testMsg, out)
+	}
+}
+
+// TestInt_GetPodLogsBySelectorSnapshot ensures a snapshot of the logs of the
+// pods matching a selector is written and that the call returns, i.e. that it
+// does not wait for further logs as following does.
+func TestInt_GetPodLogsBySelectorSnapshot(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute*5)
+	t.Cleanup(cancel)
+	cliSet, err := k8s.NewKubernetesClientset()
+	if err != nil {
+		t.Fatal(err)
+	}
+	testingNS := "pod-logs-snapshot-test-ns-" + rand.String(5)
+	_, err = cliSet.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: testingNS},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = cliSet.CoreV1().Namespaces().Delete(context.Background(), testingNS, metav1.DeleteOptions{})
+	})
+	t.Log("created namespace: ", testingNS)
+
+	const (
+		testingPodName = "testing-pod"
+		containerName  = "testing-container"
+		testMsg        = "Hello World!"
+	)
+	opts := k8s.PodLogsOptions{
+		Namespace:     testingNS,
+		LabelSelector: "function.knative.dev/name=testing",
+		Container:     containerName,
+	}
+
+	// A snapshot of a selector which matches no pods is not an error, but is
+	// reported such that it is distinguishable from a pod logging nothing.
+	err = k8s.GetPodLogsBySelector(ctx, opts, io.Discard)
+	if !errors.Is(err, k8s.ErrNoMatchingPods) {
+		t.Errorf("expected ErrNoMatchingPods for a selector matching no pods, got %v", err)
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   testingPodName,
+			Labels: map[string]string{"function.knative.dev/name": "testing"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    containerName,
+					Image:   "alpine",
+					Command: []string{"echo", "-n", testMsg},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+	if _, err = cliSet.CoreV1().Pods(testingNS).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	t.Log("created pod: " + testingPodName)
+
+out:
+	for i := 0; i < 600; i++ {
+		pod, err = cliSet.CoreV1().Pods(testingNS).Get(ctx, testingPodName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, stat := range pod.Status.ContainerStatuses {
+			if stat.State.Terminated != nil {
+				break out
+			}
+		}
+		time.Sleep(time.Millisecond * 500)
+	}
+
+	// The snapshot is expected to complete on its own: a context which is
+	// cancelled would indicate it waited for logs which never came.
+	buff := &k8s.SynchronizedBuffer{}
+	done := make(chan error, 1)
+	go func() {
+		done <- k8s.GetPodLogsBySelector(ctx, opts, buff)
+	}()
+
+	select {
+	case err = <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Minute):
+		t.Fatal("snapshot did not complete")
+	}
+
+	// A single pod's logs are written verbatim, with a terminating newline.
+	if expected := testMsg + "\n"; buff.String() != expected {
+		t.Errorf("unexpected logs: expected %q, but got %q", expected, buff.String())
 	}
 }

--- a/pkg/k8s/logs_test.go
+++ b/pkg/k8s/logs_test.go
@@ -1,0 +1,350 @@
+package k8s
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// fake.Clientset always serves this as the content of a pod's logs.
+const fakeLogs = "fake logs"
+
+// runningPod returns a pod which matches the selector used by the tests and
+// whose container has readable logs.
+func runningPod(name, image string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "user-container", Image: image}},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "user-container",
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			}},
+		},
+	}
+}
+
+// pendingPod returns a pod whose container has not yet started, and whose logs
+// can therefore not be read.
+func pendingPod(name string) *corev1.Pod {
+	pod := runningPod(name, "example.com/img:latest")
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name:  "user-container",
+		State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{}},
+	}}
+	return pod
+}
+
+func snapshotOpts() PodLogsOptions {
+	return PodLogsOptions{
+		Namespace:     "default",
+		LabelSelector: "app=test",
+		Container:     "user-container",
+	}
+}
+
+// TestSnapshotPodLogs_NoMatchingPods ensures that the absence of pods whose
+// logs can be read is reported rather than presented as empty logs.  A Knative
+// service which has scaled to zero has no pods at all, which is the common
+// case, and a pod which has not yet started has no logs to read.
+func TestSnapshotPodLogs_NoMatchingPods(t *testing.T) {
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		opts    func(PodLogsOptions) PodLogsOptions
+	}{
+		{
+			name:    "no pods at all",
+			objects: nil,
+		},
+		{
+			name:    "container not yet running",
+			objects: []runtime.Object{pendingPod("pod-a")},
+		},
+		{
+			name:    "no pod runs the requested image",
+			objects: []runtime.Object{runningPod("pod-a", "example.com/img:v1")},
+			opts: func(o PodLogsOptions) PodLogsOptions {
+				o.Image = "example.com/img:v2"
+				return o
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewClientset(tt.objects...)
+			opts := snapshotOpts()
+			if tt.opts != nil {
+				opts = tt.opts(opts)
+			}
+
+			out := &bytes.Buffer{}
+			err := snapshotPodLogs(context.Background(), client, "default", opts, out)
+
+			if !errors.Is(err, ErrNoMatchingPods) {
+				t.Errorf("expected ErrNoMatchingPods, got %v", err)
+			}
+			if out.Len() != 0 {
+				t.Errorf("expected no output, got %q", out.String())
+			}
+		})
+	}
+}
+
+// TestSnapshotPodLogs_SinglePod ensures the logs of a matching pod are written
+// verbatim, terminated, and unprefixed.
+func TestSnapshotPodLogs_SinglePod(t *testing.T) {
+	client := fake.NewClientset(runningPod("pod-a", "example.com/img:v1"))
+
+	out := &bytes.Buffer{}
+	if err := snapshotPodLogs(context.Background(), client, "default", snapshotOpts(), out); err != nil {
+		t.Fatal(err)
+	}
+
+	// The fake logs are unterminated: a terminating newline is expected to be
+	// supplied, but nothing else.
+	if expected := fakeLogs + "\n"; out.String() != expected {
+		t.Errorf("expected %q, got %q", expected, out.String())
+	}
+}
+
+// TestSnapshotPodLogs_MultiplePods ensures the logs of several matching pods
+// are attributed, ordered deterministically, and not run together.
+func TestSnapshotPodLogs_MultiplePods(t *testing.T) {
+	client := fake.NewClientset(
+		runningPod("pod-b", "example.com/img:v1"),
+		runningPod("pod-a", "example.com/img:v1"),
+	)
+
+	out := &bytes.Buffer{}
+	if err := snapshotPodLogs(context.Background(), client, "default", snapshotOpts(), out); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "[pod/pod-a] " + fakeLogs + "\n[pod/pod-b] " + fakeLogs + "\n"
+	if out.String() != expected {
+		t.Errorf("expected %q, got %q", expected, out.String())
+	}
+}
+
+// TestSnapshotPodLogs_ImageFilter ensures that, when an image is given, only
+// the logs of pods running it are gathered.
+func TestSnapshotPodLogs_ImageFilter(t *testing.T) {
+	client := fake.NewClientset(
+		runningPod("pod-a", "example.com/img:v1"),
+		runningPod("pod-b", "example.com/img:v2"),
+	)
+
+	opts := snapshotOpts()
+	opts.Image = "example.com/img:v2"
+
+	out := &bytes.Buffer{}
+	if err := snapshotPodLogs(context.Background(), client, "default", opts, out); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only one pod matches, so its logs are written unprefixed.
+	if expected := fakeLogs + "\n"; out.String() != expected {
+		t.Errorf("expected only the logs of pod-b, got %q", out.String())
+	}
+}
+
+// TestSnapshotPodLogs_Options ensures the options which bound the logs
+// returned are passed to the API, and that a snapshot does not follow.
+func TestSnapshotPodLogs_Options(t *testing.T) {
+	client := fake.NewClientset(runningPod("pod-a", "example.com/img:v1"))
+
+	since := time.Now().Add(-5 * time.Minute)
+	tail := int64(20)
+	opts := snapshotOpts()
+	opts.Since = &since
+	opts.TailLines = &tail
+
+	if err := snapshotPodLogs(context.Background(), client, "default", opts, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+
+	podLogOpts := requestedPodLogOptions(t, client)
+	if podLogOpts.Follow {
+		t.Error("expected a snapshot to not follow")
+	}
+	if podLogOpts.Container != "user-container" {
+		t.Errorf("expected the user container, got %q", podLogOpts.Container)
+	}
+	if podLogOpts.TailLines == nil || *podLogOpts.TailLines != tail {
+		t.Errorf("expected tail lines %v, got %v", tail, podLogOpts.TailLines)
+	}
+	// metav1.Time carries second precision.
+	if podLogOpts.SinceTime == nil || podLogOpts.SinceTime.Time.Sub(since).Abs() >= time.Second {
+		t.Errorf("expected since time %v, got %v", since, podLogOpts.SinceTime)
+	}
+}
+
+// TestSnapshotPodLogs_PartialFailure ensures that a pod whose logs cannot be
+// written does not discard the logs already gathered from other pods, and that
+// the failure is reported as partial rather than as a plain error.
+func TestSnapshotPodLogs_PartialFailure(t *testing.T) {
+	client := fake.NewClientset(
+		runningPod("pod-a", "example.com/img:v1"),
+		runningPod("pod-b", "example.com/img:v1"),
+	)
+
+	// Fails once the first pod's logs have been written: a prefix, the logs
+	// themselves and the terminating newline.
+	out := &failingWriter{failAfter: 3}
+
+	err := snapshotPodLogs(context.Background(), client, "default", snapshotOpts(), out)
+
+	var partial *PartialLogsError
+	if !errors.As(err, &partial) {
+		t.Fatalf("expected a PartialLogsError, got %v", err)
+	}
+	if expected := "[pod/pod-a] " + fakeLogs + "\n"; out.written.String() != expected {
+		t.Errorf("expected the logs gathered before the failure to be kept, got %q", out.written.String())
+	}
+}
+
+// TestSnapshotPodLogs_TotalFailure ensures that a failure to gather the logs of
+// every matching pod is reported as an error, not as a partial success.
+func TestSnapshotPodLogs_TotalFailure(t *testing.T) {
+	client := fake.NewClientset(runningPod("pod-a", "example.com/img:v1"))
+
+	err := snapshotPodLogs(context.Background(), client, "default", snapshotOpts(), &failingWriter{})
+
+	var partial *PartialLogsError
+	if err == nil || errors.As(err, &partial) {
+		t.Fatalf("expected a plain error, got %v", err)
+	}
+}
+
+// TestSnapshotPodLogs_ListError ensures a failure to list pods is reported
+// rather than presented as an absence of pods.
+func TestSnapshotPodLogs_ListError(t *testing.T) {
+	client := fake.NewClientset()
+	client.PrependReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("forbidden")
+	})
+
+	err := snapshotPodLogs(context.Background(), client, "default", snapshotOpts(), &bytes.Buffer{})
+	if err == nil || errors.Is(err, ErrNoMatchingPods) {
+		t.Errorf("expected the listing error to be reported, got %v", err)
+	}
+}
+
+// TestLinePrefixer ensures lines are prefixed and terminated regardless of how
+// the logs are chunked, as a pod's logs arrive in arbitrarily sized parts and
+// its last line need not be terminated.
+func TestLinePrefixer(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		chunks   []string
+		expected string
+	}{
+		{
+			name:     "unterminated last line",
+			chunks:   []string{"a\nb"},
+			expected: "a\nb\n",
+		},
+		{
+			name:     "line split across chunks",
+			prefix:   "[p] ",
+			chunks:   []string{"hel", "lo\nwor", "ld\n"},
+			expected: "[p] hello\n[p] world\n",
+		},
+		{
+			name:     "empty lines are prefixed",
+			prefix:   "[p] ",
+			chunks:   []string{"\n\n"},
+			expected: "[p] \n[p] \n",
+		},
+		{
+			name:     "no output",
+			prefix:   "[p] ",
+			chunks:   nil,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			l := &linePrefixer{out: out, prefix: []byte(tt.prefix)}
+			for _, chunk := range tt.chunks {
+				n, err := l.Write([]byte(chunk))
+				if err != nil {
+					t.Fatal(err)
+				}
+				// io.Copy requires the count to be that of the bytes given,
+				// excluding any prefix written.
+				if n != len(chunk) {
+					t.Fatalf("expected %v bytes written, got %v", len(chunk), n)
+				}
+			}
+			if err := l.terminate(); err != nil {
+				t.Fatal(err)
+			}
+			if out.String() != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, out.String())
+			}
+		})
+	}
+}
+
+// requestedPodLogOptions returns the options of the single log request the
+// client received.
+func requestedPodLogOptions(t *testing.T, client kubernetes.Interface) corev1.PodLogOptions {
+	t.Helper()
+	f, ok := client.(*fake.Clientset)
+	if !ok {
+		t.Fatal("expected a fake clientset")
+	}
+	for _, action := range f.Actions() {
+		if action.GetVerb() != "get" || action.GetSubresource() != "log" {
+			continue
+		}
+		generic, ok := action.(k8stesting.GenericAction)
+		if !ok {
+			t.Fatalf("expected a generic action, got %T", action)
+		}
+		opts, ok := generic.GetValue().(*corev1.PodLogOptions)
+		if !ok {
+			t.Fatalf("expected pod log options, got %T", generic.GetValue())
+		}
+		return *opts
+	}
+	t.Fatal("no logs were requested")
+	return corev1.PodLogOptions{}
+}
+
+// failingWriter writes until the given number of writes have been made, and
+// fails from then on, as stdout does when its reader goes away.
+type failingWriter struct {
+	failAfter int
+	writes    int
+	written   bytes.Buffer
+}
+
+func (w *failingWriter) Write(p []byte) (int, error) {
+	if w.writes >= w.failAfter {
+		return 0, errors.New("broken pipe")
+	}
+	w.writes++
+	return w.written.Write(p)
+}

--- a/pkg/knative/deployer.go
+++ b/pkg/knative/deployer.go
@@ -198,7 +198,13 @@ consider using the --image-pull-secret flag, or setting up pull secrets manually
 	}
 	since := time.Now()
 	go func() {
-		_ = GetKServiceLogs(ctx, namespace, f.Name, f.Deploy.Image, &since, out)
+		_ = GetKServiceLogs(ctx, LogsOptions{
+			Name:      f.Name,
+			Namespace: namespace,
+			Image:     f.Deploy.Image,
+			Since:     &since,
+			Follow:    true,
+		}, out)
 	}()
 
 	previousService, err := client.GetService(ctx, f.Name)

--- a/pkg/knative/logs.go
+++ b/pkg/knative/logs.go
@@ -26,7 +26,11 @@ type LogsOptions struct {
 	// Since, when non-nil, is the time from which logs are returned.
 	Since *time.Time
 
-	// Follow keeps streaming the logs until the context is cancelled.
+	// TailLines, when non-nil, limits the output to the last N lines per pod.
+	TailLines *int64
+
+	// Follow streams logs until the context is cancelled.  When false, the
+	// logs currently available are written and the call returns.
 	Follow bool
 }
 
@@ -34,8 +38,11 @@ type LogsOptions struct {
 //
 // It will do so by gathering logs of user-container of all affiliated pods.
 //
-// This function runs as long as the passed context is active (i.e. it is
-// required to cancel the context to stop log gathering).
+// When opts.Follow is set, this function runs as long as the passed context is
+// active (i.e. it is required to cancel the context to stop log gathering).
+// Otherwise a snapshot of the currently available logs is written and the
+// function returns, with k8s.ErrNoMatchingPods if the service currently has no
+// pods whose logs can be read.
 func GetKServiceLogs(ctx context.Context, opts LogsOptions, out io.Writer) error {
 	return k8s.GetPodLogsBySelector(ctx, k8s.PodLogsOptions{
 		Namespace:     opts.Namespace,
@@ -43,6 +50,7 @@ func GetKServiceLogs(ctx context.Context, opts LogsOptions, out io.Writer) error
 		Container:     "user-container",
 		Image:         opts.Image,
 		Since:         opts.Since,
+		TailLines:     opts.TailLines,
 		Follow:        opts.Follow,
 	}, out)
 }

--- a/pkg/knative/logs.go
+++ b/pkg/knative/logs.go
@@ -9,14 +9,40 @@ import (
 	"knative.dev/func/pkg/k8s"
 )
 
+// LogsOptions are the parameters of GetKServiceLogs.
+type LogsOptions struct {
+	// Name of the Knative service whose logs are gathered.
+	Name string
+
+	// Namespace of the Knative service.  An empty value resolves to the
+	// currently active namespace.
+	Namespace string
+
+	// Image, when non-empty, restricts gathering to pods running this exact
+	// image, which must be in digest format since pods of a Knative service
+	// use it.  Useful to isolate the logs of a single revision.
+	Image string
+
+	// Since, when non-nil, is the time from which logs are returned.
+	Since *time.Time
+
+	// Follow keeps streaming the logs until the context is cancelled.
+	Follow bool
+}
+
 // GetKServiceLogs will get logs of Knative service.
 //
 // It will do so by gathering logs of user-container of all affiliated pods.
-// In addition, filtering on image can be done so only logs for given image are logged.
-// The image must be the digest format since pods of Knative service use it.
 //
-// This function runs as long as the passed context is active (i.e. it is required cancel the context to stop log gathering).
-func GetKServiceLogs(ctx context.Context, namespace, kServiceName, image string, since *time.Time, out io.Writer) error {
-	selector := fmt.Sprintf("serving.knative.dev/service=%s", kServiceName)
-	return k8s.GetPodLogsBySelector(ctx, namespace, selector, "user-container", image, since, out)
+// This function runs as long as the passed context is active (i.e. it is
+// required to cancel the context to stop log gathering).
+func GetKServiceLogs(ctx context.Context, opts LogsOptions, out io.Writer) error {
+	return k8s.GetPodLogsBySelector(ctx, k8s.PodLogsOptions{
+		Namespace:     opts.Namespace,
+		LabelSelector: fmt.Sprintf("serving.knative.dev/service=%s", opts.Name),
+		Container:     "user-container",
+		Image:         opts.Image,
+		Since:         opts.Since,
+		Follow:        opts.Follow,
+	}, out)
 }


### PR DESCRIPTION
# Changes

- :broom: `func logs` prints the available logs and exits; `-f`/`--follow` streams as before
- :gift: Add `--tail` to limit the lines returned per pod
- :bug: Snapshots have no default `--since` window and are not filtered by the latest revision's image; having no pods, or losing one mid-read, is reported on stderr

/kind enhancement

Fixes #3999

**Release Note**

```release-note
action required: `func logs` now prints the available logs and exits instead of following. Use `func logs -f` to stream, or set FUNC_FOLLOW=true to restore the previous default. New `--tail` limits the lines returned per pod.
```

**Docs**

```docs
- [knative/docs]: follow-up needed; the func logs pages describe it as stream-only.
```
