### PR TITLE
[release-1.22] fix: write func.yaml before remote upload

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -316,6 +316,12 @@ func runDeploy(cmd *cobra.Command, newClient ClientFactory) (err error) {
 
 	// Deploy
 	if cfg.Remote {
+		// Write func.yaml before the pipeline uploads sources to the PVC,
+		// so that the on-cluster deploy step sees the latest config
+		// (e.g. --service-account, --deployer).
+		if err = f.Write(); err != nil {
+			return
+		}
 		var url string
 		// Invoke a remote build/push/deploy pipeline
 		// Returned is the function with fields like Registry, f.Deploy.Image &

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -1831,6 +1831,50 @@ func TestDeploy_UnsetFlag(t *testing.T) {
 	}
 }
 
+// TestDeploy_DeployerRemote ensures that when deploying remotely,
+// func.yaml is written to disk before the pipeline starts, so the on-cluster
+// deploy step picks up the --deployer value.
+func TestDeploy_DeployerRemote(t *testing.T) {
+	root := FromTempDirectory(t)
+
+	f := fn.Function{Runtime: "go", Root: root, Registry: TestRegistry}
+	_, err := fn.New().Init(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pipelinesProvider := mock.NewPipelinesProvider()
+	pipelinesProvider.RunFn = func(f fn.Function) (string, fn.Function, error) {
+		// Inside the pipeline Run, func.yaml on disk should already
+		// have the deployer written.
+		diskFn, err := fn.NewFunction(root)
+		if err != nil {
+			t.Fatalf("failed to load func.yaml during pipeline Run: %v", err)
+		}
+		if diskFn.Deploy.Deployer != "keda" {
+			t.Fatalf("expected func.yaml on disk to have deployer 'keda', got '%v'", diskFn.Deploy.Deployer)
+		}
+		f.Deploy.Namespace = "default"
+		if f.Deploy.Image, err = f.ImageName(); err != nil {
+			return "", f, err
+		}
+		return "", f, nil
+	}
+
+	cmd := NewDeployCmd(NewTestClient(
+		fn.WithPipelinesProvider(pipelinesProvider),
+		fn.WithRegistry(TestRegistry),
+	))
+	cmd.SetArgs([]string{"--remote", "--deployer=keda", "--namespace=default"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !pipelinesProvider.RunInvoked {
+		t.Fatal("expected pipeline Run to be invoked")
+	}
+}
+
 // Test_ValidateBuilder tests that the builder validation accepts the
 // set of known builders, and spot-checks an error is thrown for unknown.
 func Test_ValidateBuilder(t *testing.T) {


### PR DESCRIPTION
persist the func.yaml before pipeline write because its the remote deployment works with the disk-version of func.yaml not the in-memory version. -- this is a workaround.
backporting this because of functions-operator which, because of this bug, cannot properly run e2e middleware update tests (deployer persistance does not work off-of knative)

Backport of #3663.

# Changes

- :bug: Workaround: write `func.yaml` before remote pipeline upload so deployer, service account, and other config persist on-cluster

/kind bug

Relates to #3663

**Release Note**

```release-note
Bugfix / workaround: remote deployment persists the deployer, service account, and other configs.
```