### PR TITLE
fix: source func CLI version from build ldflags

### DIFF
--- a/cmd/config_ci.go
+++ b/cmd/config_ci.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	"github.com/ory/viper"
@@ -11,7 +12,12 @@ import (
 	"knative.dev/func/cmd/common"
 	"knative.dev/func/pkg/ci/github"
 	fn "knative.dev/func/pkg/functions"
+	"knative.dev/func/pkg/version"
 )
+
+// gitDescribeSuffix matches the "-N-gHASH" suffix produced by git describe
+// on commits that are not exactly on a release tag.
+var gitDescribeSuffix = regexp.MustCompile(`-\d+-g[0-9a-f]+$`)
 
 // ciGeneratorFactory creates a CIGenerator from resolved CLI flag values.
 // Using a factory allows tests to capture the resolved config and inject
@@ -250,6 +256,7 @@ func newConfigAndLoadedFunc(
 		RegistryUserVar:        viper.GetString(registryUserVariableNameFlag),
 		RegistryPassSecret:     viper.GetString(registryPassSecretNameFlag),
 		RegistryUrlVar:         viper.GetString(registryUrlVariableNameFlag),
+		FuncCliVersion:         gitDescribeSuffix.ReplaceAllString(version.Kver, ""),
 		RegistryLogin:          viper.GetBool(registryLoginFlag),
 		SelfHostedRunner:       viper.GetBool(selfHostedRunnerFlag),
 		RemoteBuild:            viper.GetBool(remoteBuildFlag),

--- a/cmd/config_ci_int_test.go
+++ b/cmd/config_ci_int_test.go
@@ -231,7 +231,7 @@ func assertDefaultWorkflow(t *testing.T, actualGw string) {
 
 	assert.Assert(t, yamlContains(actualGw, "Install func cli"))
 	assert.Assert(t, yamlContains(actualGw, "functions-dev/action@main"))
-	assert.Assert(t, yamlContains(actualGw, "version: knative-v1.22.0"))
+	assert.Assert(t, yamlContains(actualGw, "version: "+github.DefaultFuncCliVersion))
 	assert.Assert(t, yamlContains(actualGw, "name: func"))
 
 	assert.Assert(t, yamlContains(actualGw, "Deploy function"))

--- a/pkg/ci/github/generator_test.go
+++ b/pkg/ci/github/generator_test.go
@@ -566,6 +566,7 @@ func defaultOpts() opts {
 		RegistryUserVar:        github.DefaultRegistryUserVariableName,
 		RegistryPassSecret:     github.DefaultRegistryPassSecretName,
 		RegistryUrlVar:         github.DefaultRegistryUrlVariableName,
+		FuncCliVersion:         github.DefaultFuncCliVersion,
 		RegistryLogin:          github.DefaultRegistryLogin,
 		SelfHostedRunner:       github.DefaultSelfHostedRunner,
 		RemoteBuild:            github.DefaultRemoteBuild,
@@ -643,7 +644,7 @@ func assertDefaultWorkflow(t *testing.T, actualGw string) {
 
 	assert.Assert(t, yamlContains(actualGw, "Install func cli"))
 	assert.Assert(t, yamlContains(actualGw, "functions-dev/action@main"))
-	assert.Assert(t, yamlContains(actualGw, "version: knative-v1.22.0"))
+	assert.Assert(t, yamlContains(actualGw, "version: "+github.DefaultFuncCliVersion))
 	assert.Assert(t, yamlContains(actualGw, "name: func"))
 
 	assert.Assert(t, yamlContains(actualGw, "Deploy function"))
@@ -676,7 +677,7 @@ func assertSemiDefaultWorkflow(t *testing.T, actualGw string) {
 
 	assert.Assert(t, yamlContains(actualGw, "Install func cli"))
 	assert.Assert(t, yamlContains(actualGw, "functions-dev/action@main"))
-	assert.Assert(t, yamlContains(actualGw, "version: knative-v1.22.0"))
+	assert.Assert(t, yamlContains(actualGw, "version: "+github.DefaultFuncCliVersion))
 	assert.Assert(t, yamlContains(actualGw, "name: func"))
 
 	assert.Assert(t, yamlContains(actualGw, "Deploy function"))

--- a/pkg/ci/github/workflow.go
+++ b/pkg/ci/github/workflow.go
@@ -14,7 +14,7 @@ import (
 var ErrWorkflowExists = errors.New("existing GitHub workflow detected, overwrite using the --force option")
 
 const (
-	defaultFuncCliVersion               = "knative-v1.22.0"
+	DefaultFuncCliVersion               = "knative-v1.23.0"
 	DefaultPlatform                     = "github"
 	DefaultGitHubWorkflowDir            = ".github/workflows"
 	DefaultGitHubWorkflowFilename       = "func-deploy.yaml"
@@ -45,7 +45,8 @@ type WorkflowConfig struct {
 	RegistryLoginUrlVar,
 	RegistryUserVar,
 	RegistryPassSecret,
-	RegistryUrlVar string
+	RegistryUrlVar,
+	FuncCliVersion string
 	RegistryLogin,
 	SelfHostedRunner,
 	RemoteBuild,
@@ -74,6 +75,7 @@ func defaultWorkflowConfig() WorkflowConfig {
 		RegistryUserVar:        DefaultRegistryUserVariableName,
 		RegistryPassSecret:     DefaultRegistryPassSecretName,
 		RegistryUrlVar:         DefaultRegistryUrlVariableName,
+		FuncCliVersion:         DefaultFuncCliVersion,
 		RegistryLogin:          DefaultRegistryLogin,
 		SelfHostedRunner:       DefaultSelfHostedRunner,
 		RemoteBuild:            DefaultRemoteBuild,
@@ -110,6 +112,9 @@ func setEmptyFieldsToDefaults(defaults WorkflowConfig) WorkflowConfig {
 	}
 	if defaults.RegistryUrlVar == "" {
 		defaults.RegistryUrlVar = DefaultRegistryUrlVariableName
+	}
+	if defaults.FuncCliVersion == "" {
+		defaults.FuncCliVersion = DefaultFuncCliVersion
 	}
 
 	return defaults
@@ -149,7 +154,7 @@ func newGitHubWorkflow(cfg WorkflowConfig, runtime string, messageWriter io.Writ
 	steps = createRuntimeTestStep(cfg, runtime, messageWriter, steps)
 	steps = createK8ContextStep(cfg, steps)
 	steps = createRegistryLoginStep(cfg, steps)
-	steps = createFuncCLIInstallStep(steps)
+	steps = createFuncCLIInstallStep(cfg, steps)
 
 	steps, err := createFuncDeployStep(cfg, runtime, steps)
 	if err != nil {
@@ -223,10 +228,10 @@ func createRegistryLoginStep(opts WorkflowConfig, steps []step) []step {
 	return append(steps, *loginToContainerRegistry)
 }
 
-func createFuncCLIInstallStep(steps []step) []step {
+func createFuncCLIInstallStep(cfg WorkflowConfig, steps []step) []step {
 	installFuncCli := newStep("Install func cli").
 		withUses("functions-dev/action@main").
-		withActionConfig("version", defaultFuncCliVersion).
+		withActionConfig("version", cfg.FuncCliVersion).
 		withActionConfig("name", "func")
 
 	return append(steps, *installFuncCli)


### PR DESCRIPTION
<!-- PR Title: config ci: source func CLI version from build ldflags -->

# Changes

- Source `FuncCliVersion` from `version.Kver` (set via ldflags at build time) instead of a hardcoded string
- Strip the `git describe` suffix (e.g. `-22-g2871d3bf`) so dev builds between releases emit the nearest real release tag
- Expose `FuncCliVersion` as a field on `WorkflowConfig` so library consumers can override it directly
  - this is important because library consumers with `no ldflags` have empty `version.Kver`, so it falls back to `DefaultFuncCliVersion` which may be out of date as it has to be manually updated 

/kind bug

Fixes #4028

**Release Note**

```release-note
`func config ci` now sources the func CLI version used in generated GitHub Actions workflows from the binary's build-time version (set via ldflags), instead of a hardcoded string. Dev builds between releases emit the nearest real release tag by stripping the git describe suffix.
```

**Docs**

```docs

```