### PR TITLE
test: pin func CLI version so config CI workflow test is deterministic

### DIFF
--- a/cmd/config_ci_int_test.go
+++ b/cmd/config_ci_int_test.go
@@ -18,6 +18,7 @@ import (
 	"knative.dev/func/pkg/ci/github"
 	fn "knative.dev/func/pkg/functions"
 	fnTest "knative.dev/func/pkg/testing"
+	"knative.dev/func/pkg/version"
 )
 
 // START: Integration Tests
@@ -77,6 +78,13 @@ func TestNewConfigCICmd_CreatesGitHubWorkflowDirectory(t *testing.T) {
 }
 
 func TestNewConfigCICmd_WritesWorkflowFileToFSWithCorrectYAMLStructure(t *testing.T) {
+	// Pin the CLI version so the generated workflow is deterministic,
+	// independent of the version injected via -ldflags at build time
+	// (which varies with the branch's most recent git tag).
+	prev := version.Kver
+	version.Kver = github.DefaultFuncCliVersion
+	t.Cleanup(func() { version.Kver = prev })
+
 	opts := defaultIntegrationOpts(t, nil)
 
 	err := runConfigCiCmdIntegration(t, opts)


### PR DESCRIPTION
# Changes

- Pin `version.Kver` in the config CI integration test so the generated workflow's func CLI version is independent of the build environment and branch tags

/kind cleanup

Relates to #4029

**Release Note**

```release-note

```

**Docs**

```docs

```