### PR TITLE
Wait for the CoreDNS rollout in func cluster create

### DIFF
--- a/pkg/cluster/dns.go
+++ b/pkg/cluster/dns.go
@@ -27,17 +27,14 @@ func configureMagicDNS(ctx context.Context, cfg ClusterConfig, out io.Writer) er
 		return err
 	}
 
-	// Deployment patch triggers a rolling restart. Sleep so the new pods
-	// enter NotReady before we wait for Ready — otherwise the old pods
-	// still satisfy the condition and we return before the restart lands.
-	if err := wait(ctx, 5*time.Second); err != nil {
-		return err
-	}
+	// The deployment patch triggers a rolling restart. Wait for the rollout
+	// itself: the new pods are available and the old ones are gone. Waiting
+	// for every kube-system pod to be Ready instead raced with the old
+	// coredns pods, which are terminating and never become Ready again.
 	if err := run(ctx, out, "",
-		cfg.kubectl(), "wait", "pod",
-		"--for=condition=Ready", "-l", "!job-name",
-		"-n", "kube-system", "--timeout=60s"); err != nil {
-		return fmt.Errorf("waiting for coredns: %w", err)
+		cfg.kubectl(), "rollout", "status", "deployment/coredns",
+		"-n", "kube-system", "--timeout=120s"); err != nil {
+		return fmt.Errorf("waiting for coredns rollout: %w", err)
 	}
 
 	success(out, "Magic DNS", time.Since(start))


### PR DESCRIPTION
<!-- PR Title: Wait for the CoreDNS rollout in func cluster create -->
# Changes

- :bug: `func cluster create` waited for every kube-system pod to be Ready after patching the CoreDNS deployment for Magic DNS. The old CoreDNS pods are terminating after the patch and never become Ready again, so on hosts where they took more than 60s to go the wait timed out and the whole cluster was torn down at its last step. The step now waits for the CoreDNS deployment rollout (`kubectl rollout status`), which ends when the new pods are available and the old ones are gone.

`hack/cluster.sh`, from which this was ported, has the same sleep-and-wait pattern with a 15s timeout. It is left as is here.

/kind bug

Seen on a docker host (kind 0.31.0, kindest/node v1.34.0): the first attempt failed with `timed out waiting for the condition on pods/coredns-...` for the old ReplicaSet's pods while the new ones had already reported `condition met`. With the rollout wait the same host completes: `Waiting for deployment "coredns" rollout to finish: 1 old replicas are pending termination...` then `successfully rolled out`.

**Release Note**

```release-note
`func cluster create` no longer fails at the Magic DNS step when the previous CoreDNS pods take a while to terminate.
```

**Docs**

```docs

```
